### PR TITLE
Implement CPU cycle timing and NMI interrupt handling

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/Opcodes.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/Opcodes.kt
@@ -201,7 +201,7 @@ class Opcodes {
                     registers.programCounter
                 }
 
-                //  TODO: Takes 6 cycles
+                workCyclesLeft = 6
             }
         }
 
@@ -216,7 +216,7 @@ class Opcodes {
 
         // NOP - No Operation
         map[0xea] = Opcode {
-            // TODO: Takes 2 cycles
+            it.workCyclesLeft = 2
         }
 
         //  RTS - Return from Subroutine
@@ -227,8 +227,9 @@ class Opcodes {
                 it.registers.programCounter = ((lowByte and 0xff) or (highByte shl 8)).toSignedShort()
                 it.registers.programCounter++
 //                println("Returning to Program Counter ${it.registers.programCounter.toHexString()}")
+
+                workCyclesLeft = 6
             }
-            //  TODO: Takes 6 cycles
         }
 
         //  PLA - Pull A from Stack
@@ -236,7 +237,8 @@ class Opcodes {
             it.apply {
                 registers.accumulator = pop()
                 processorStatus.resolveZeroAndNegativeFlags(registers.accumulator)
-                //  TODO: Takes 4 cycles
+
+                workCyclesLeft = 4
             }
         }
 
@@ -246,7 +248,8 @@ class Opcodes {
             it.apply {
                 registers.indexY = ((registers.indexY + 1) and 0xFF).toSignedByte()
                 processorStatus.resolveZeroAndNegativeFlags(registers.indexY)
-                //  TODO: Takes 2 cycles
+
+                workCyclesLeft = 2
             }
         }
 
@@ -255,7 +258,8 @@ class Opcodes {
             it.apply {
                 registers.indexY = ((registers.indexY - 1) and 0xFF).toSignedByte()
                 processorStatus.resolveZeroAndNegativeFlags(registers.indexY)
-                //  TODO: Takes 2 cycles
+
+                workCyclesLeft = 2
             }
         }
 
@@ -264,7 +268,8 @@ class Opcodes {
             it.apply {
                 registers.indexX = ((registers.indexX + 1) and 0xFF).toSignedByte()
                 processorStatus.resolveZeroAndNegativeFlags(registers.indexX)
-                //  TODO: Takes 2 cycles
+
+                workCyclesLeft = 2
             }
         }
 
@@ -273,16 +278,17 @@ class Opcodes {
             it.apply {
                 registers.indexX = ((registers.indexX - 1) and 0xFF).toSignedByte()
                 processorStatus.resolveZeroAndNegativeFlags(registers.indexX)
-                //  TODO: Takes 2 cycles
+
+                workCyclesLeft = 2
             }
         }
 
         //  PLP - Pull ProcessorStatus from Stack
         map[0x28] = Opcode {
             it.apply {
-                //  TODO: Handle some interrupt?
                 processorStatus.toFlags(pop())
-                //  TODO: Takes 4 cycles
+
+                workCyclesLeft = 4
             }
         }
 
@@ -291,7 +297,8 @@ class Opcodes {
             it.apply {
                 processorStatus.toFlags(pop())
                 registers.programCounter = (pop().toUnsignedInt() or (pop().toUnsignedInt() shl 8)).toSignedShort()
-                //  TODO: Takes 6 cycles
+
+                workCyclesLeft = 6
             }
         }
 
@@ -301,7 +308,8 @@ class Opcodes {
                 processorStatus.carry = registers.accumulator.isBitSet(0)
                 registers.accumulator = (registers.accumulator.toUnsignedInt() shr 1).toSignedByte()
                 processorStatus.resolveZeroAndNegativeFlags(registers.accumulator)
-                //  TODO: Takes 2 cycles
+
+                workCyclesLeft = 2
             }
         }
 
@@ -311,7 +319,8 @@ class Opcodes {
                 processorStatus.carry = registers.accumulator.isBitSet(7)
                 registers.accumulator = (registers.accumulator.toUnsignedInt() shl 1).toSignedByte()
                 processorStatus.resolveZeroAndNegativeFlags(registers.accumulator)
-                //  TODO: Takes 2 cycles
+
+                workCyclesLeft = 2
             }
         }
 
@@ -322,7 +331,8 @@ class Opcodes {
                 processorStatus.carry = registers.accumulator.isBitSet(0)
                 registers.accumulator = ((registers.accumulator.toUnsignedInt() shr 1) or (if (oldCarry) 0x80 else 0)).toSignedByte()
                 processorStatus.resolveZeroAndNegativeFlags(registers.accumulator)
-                //  TODO: Takes 2 cycles
+
+                workCyclesLeft = 2
             }
         }
 
@@ -333,7 +343,8 @@ class Opcodes {
                 processorStatus.carry = (newAccumulator and 0xFF00) > 0
                 registers.accumulator = (newAccumulator and 0xFF).toSignedByte()
                 processorStatus.resolveZeroAndNegativeFlags(registers.accumulator)
-                //  TODO: Takes 2 cycles
+
+                workCyclesLeft = 2
             }
         }
 


### PR DESCRIPTION
This commit completes Priority 2 of the NES emulator implementation plan.

CPU Timing Fixes:
- Fixed all 14 missing cycle counts in Opcodes.kt
- JSR (0x20): 6 cycles
- NOP (0xEA): 2 cycles
- RTS (0x60): 6 cycles
- PLA (0x68): 4 cycles
- INY (0xC8): 2 cycles
- DEY (0x88): 2 cycles
- INX (0xE8): 2 cycles
- DEX (0xCA): 2 cycles
- PLP (0x28): 4 cycles
- RTI (0x40): 6 cycles
- LSR A (0x4A): 2 cycles
- ASL A (0x0A): 2 cycles
- ROR A (0x6A): 2 cycles
- ROL A (0x2A): 2 cycles

NMI Interrupt Implementation:
- Added checkAndHandleNmi() method in Cpu.kt
- NMI is edge-triggered on nmiOccurred && controller.generateNmi()
- Properly pushes PC and processor status to stack
- Clears B flag in status byte (correct for interrupt context)
- Sets interrupt disable flag
- Loads PC from NMI vector at $FFFA-$FFFB
- Takes 7 cycles per 6502 specification
- Connects CPU to PPU VBlank signals via nmiOccurred flag

Implementation follows 6502 and NES architecture specifications. The CPU can now respond to VBlank interrupts from the PPU, enabling proper game loop timing and frame synchronization.