### PR TITLE
Fix Mapper4 R0/R1 2KB-bank multiplier (0x800 -> 0x400)

### DIFF
--- a/.claude/skills/mesen/SKILL.md
+++ b/.claude/skills/mesen/SKILL.md
@@ -75,6 +75,36 @@ Mesen.exe --doNotSaveSettings <script.lua> <rom>
 
 Requires display attached. Screenshot path: `emu.getScriptDataFolder() .. "screenshot.png"`
 
+### `emu.read(addr, memType)` in Mesen2 GUI mode
+
+Works reliably. Useful for byte-level Nestlin↔Mesen2 comparison without
+plumbing state diffs. Examples used in this codebase:
+
+```lua
+local y    = emu.read(i * 4,     emu.memType.nesSpriteRam)  -- OAM
+local tile = emu.read(addr,      emu.memType.nesPpuMemory)  -- pattern/nametable
+```
+
+Useful NES memTypes (full list emitted by `for k,_ in pairs(emu.memType)`):
+`nesMemory`, `nesInternalRam`, `nesWorkRam`, `nesSaveRam`, `nesSpriteRam`,
+`nesSecondarySpriteRam`, `nesPaletteRam`, `nesNametableRam`,
+`nesPpuMemory`, `nesChrRom`, `nesChrRam`, `nesPrgRom`, `nesMapperRam`,
+`nesDebug`, `nesPpuDebug`.
+
+### Embedding Lua in Kotlin triple-quoted strings — escape `$`
+
+Lua uses `$` only inside `string.format` format strings (e.g. `"$%02X"`).
+In a Kotlin `"""…"""` literal those `$` characters start interpolation.
+Use `${'$'}` for a literal dollar sign — **never** `\$`, which Lua rejects
+with `invalid escape sequence near '\$'` and which Kotlin doesn't unescape
+either:
+
+```kotlin
+val lua = """
+local s = string.format("tile=${'$'}%02X", t)
+"""
+```
+
 ## Key Differences: Mesen v1 vs v2
 
 | Feature | Mesen v1 (headless) | Mesen2 |
@@ -82,5 +112,5 @@ Requires display attached. Screenshot path: `emu.getScriptDataFolder() .. "scree
 | `emu.stop()` | ✅ Works | ❌ Hangs |
 | `os.exit()` | ✅ Works | ✅ Works |
 | `emu.getState()` | ✅ Works | ✅ Works |
-| `emu.read()` | ❌ Deadlocks | ❌ Hangs |
+| `emu.read()` | ❌ Deadlocks | ✅ Works in GUI mode (verified 2026-05-18) |
 | `emu.takeScreenshot()` | ✅ Works | ✅ Works |

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ hs_err_pid*
 # Claude local settings
 .claude/settings.local.json
 .claude/ralph-loop.local.md
+.claude/scheduled_tasks.lock
 CLAUDE.local.md
 
 # Debug output files

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,8 @@ val auxiliaryTests = listOf(
     "com.github.alondero.nestlin.Mapper1IntegrationTest",
     // Compare tests that depend on external ROMs (kirby.nes, etc.)
     "com.github.alondero.nestlin.compare.KirbyInstructionTraceTest",
+    "com.github.alondero.nestlin.compare.KirbyMesenVsNestlinOamTest",
+    "com.github.alondero.nestlin.compare.KirbyOamSnapshotTest",
     "com.github.alondero.nestlin.compare.KirbyPpuCtrlTrackingTest",
     "com.github.alondero.nestlin.compare.KirbyScreenshotTest",
     "com.github.alondero.nestlin.compare.KirbyVBlankTest",

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper4.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper4.kt
@@ -175,33 +175,25 @@ class Mapper4(private val gamePak: GamePak) : Mapper {
             return chrRam!![maskedAddress]
         }
 
-        // MMC3 CHR banking:
-        // Normal mode (chrPrgInvert=false): R0/R1 = 2KB, R2-R5 = 1KB
-        // Inverted mode (chrPrgInvert=true): R2-R5 = four 1KB at $0000, R0/R1 = 2KB at $1000
+        // MMC3 CHR banking (per NESdev MMC3 wiki):
+        //   R0/R1 select 2 KB CHR banks. The bank number is given in 1 KB
+        //   units with bit 0 ignored, so the multiplier is 0x400, NOT 0x800.
+        //   R2-R5 select 1 KB banks directly (multiplier 0x400).
+        //   Bit 7 of $8000 swaps the 2 KB and 1 KB windows between halves.
         return if (chrPrgInvert) {
-            // Inverted mode:
-            // $0000-$03FF = R2 (1KB), $0400-$07FF = R3 (1KB)
-            // $0800-$0BFF = R4 (1KB), $0C00-$0FFF = R5 (1KB)
-            // $1000-$17FF = R0 (2KB), $1800-$1FFF = R1 (2KB)
-            // CHR banks are 8KB units per NESdev MMC3 spec
             when (maskedAddress) {
                 in 0x0000..0x03FF -> chrRom[(chrBanks[2] * 0x0400 + maskedAddress) % chrRom.size]
                 in 0x0400..0x07FF -> chrRom[(chrBanks[3] * 0x0400 + (maskedAddress - 0x0400)) % chrRom.size]
                 in 0x0800..0x0BFF -> chrRom[(chrBanks[4] * 0x0400 + (maskedAddress - 0x0800)) % chrRom.size]
                 in 0x0C00..0x0FFF -> chrRom[(chrBanks[5] * 0x0400 + (maskedAddress - 0x0C00)) % chrRom.size]
-                in 0x1000..0x17FF -> chrRom[((chrBanks[0] and 0xFE) * 0x0800 + (maskedAddress - 0x1000)) % chrRom.size]
-                in 0x1800..0x1FFF -> chrRom[((chrBanks[1] and 0xFE) * 0x0800 + (maskedAddress - 0x1800)) % chrRom.size]
+                in 0x1000..0x17FF -> chrRom[((chrBanks[0] and 0xFE) * 0x0400 + (maskedAddress - 0x1000)) % chrRom.size]
+                in 0x1800..0x1FFF -> chrRom[((chrBanks[1] and 0xFE) * 0x0400 + (maskedAddress - 0x1800)) % chrRom.size]
                 else -> chrRom[maskedAddress % chrRom.size]
             }
         } else {
-            // Normal mode:
-            // $0000-$07FF = R0 (2KB), $0800-$0FFF = R1 (2KB)
-            // $1000-$13FF = R2 (1KB), $1400-$17FF = R3 (1KB)
-            // $1800-$1BFF = R4 (1KB), $1C00-$1FFF = R5 (1KB)
-            // CHR banks are 8KB units per NESdev MMC3 spec
             when {
-                maskedAddress < 0x0800 -> chrRom[((chrBanks[0] and 0xFE) * 0x0800 + maskedAddress) % chrRom.size]
-                maskedAddress < 0x1000 -> chrRom[((chrBanks[1] and 0xFE) * 0x0800 + (maskedAddress - 0x0800)) % chrRom.size]
+                maskedAddress < 0x0800 -> chrRom[((chrBanks[0] and 0xFE) * 0x0400 + maskedAddress) % chrRom.size]
+                maskedAddress < 0x1000 -> chrRom[((chrBanks[1] and 0xFE) * 0x0400 + (maskedAddress - 0x0800)) % chrRom.size]
                 maskedAddress < 0x1400 -> chrRom[(chrBanks[2] * 0x0400 + (maskedAddress - 0x1000)) % chrRom.size]
                 maskedAddress < 0x1800 -> chrRom[(chrBanks[3] * 0x0400 + (maskedAddress - 0x1400)) % chrRom.size]
                 maskedAddress < 0x1C00 -> chrRom[(chrBanks[4] * 0x0400 + (maskedAddress - 0x1800)) % chrRom.size]

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyMesenVsNestlinOamTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyMesenVsNestlinOamTest.kt
@@ -1,0 +1,42 @@
+package com.github.alondero.nestlin.compare
+
+import org.junit.Test
+import java.nio.file.Files
+import java.nio.file.Paths
+
+/**
+ * Driver: runs Mesen2 once to dump OAM at our target frames, then prints
+ * Mesen vs Nestlin OAM side-by-side. Nestlin OAM is produced by the
+ * sibling KirbyOamSnapshotTest, which writes build/kirby-oam-snapshots.txt.
+ *
+ * Requires Mesen2 + GUI + I/O permissions enabled.
+ */
+class KirbyMesenVsNestlinOamTest {
+
+    @Test
+    fun dumpMesenOam() {
+        val romPath = Paths.get("kirby.nes").toAbsolutePath()
+        if (!Files.exists(romPath)) {
+            System.err.println("Kirby ROM not at $romPath, skipping")
+            return
+        }
+        if (!Mesen2OamDumpRunner.isAvailable()) {
+            System.err.println("Mesen2 not at ${Mesen2OamDumpRunner.mesen2Path()}, skipping")
+            return
+        }
+
+        val targetFrames = listOf(500, 600, 619, 625, 700, 900)
+        val outDir = Paths.get("build/kirby-oam-mesen2")
+        Mesen2OamDumpRunner.dumpOam(romPath, targetFrames, outDir)
+
+        System.err.println("Mesen2 OAM dumps written to ${outDir.toAbsolutePath()}")
+        Files.list(outDir).use { stream ->
+            stream.sorted()
+                .filter { it.fileName.toString().endsWith(".txt") }
+                .forEach { p ->
+                    System.err.println("\n=== ${p.fileName} ===")
+                    Files.readAllLines(p).forEach { System.err.println(it) }
+                }
+        }
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyOamSnapshotTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyOamSnapshotTest.kt
@@ -1,0 +1,106 @@
+package com.github.alondero.nestlin.compare
+
+import com.github.alondero.nestlin.Nestlin
+import com.github.alondero.nestlin.toUnsignedInt
+import com.github.alondero.nestlin.ppu.Frame
+import com.github.alondero.nestlin.ui.FrameListener
+import org.junit.Test
+import java.awt.image.BufferedImage
+import java.nio.file.Files
+import java.nio.file.Paths
+import javax.imageio.ImageIO
+
+/**
+ * Snapshot Kirby OAM at a sequence of frames so we can pinpoint when the
+ * title-screen sprite overlay bug first appears, and what the OAM looks
+ * like across the transition.
+ *
+ * Output: build/kirby-oam-snapshots.txt
+ */
+class KirbyOamSnapshotTest {
+
+    @Test
+    fun snapshotOamAtKeyFrames() {
+        val romPath = Paths.get("kirby.nes")
+        if (!Files.exists(romPath)) {
+            System.err.println("Kirby ROM not at ${romPath.toAbsolutePath()}, skipping")
+            return
+        }
+
+        val framesToSnap = (500..1500 step 50).toSet() + setOf(615, 619, 625, 800, 900, 1200)
+        val snapshots = mutableMapOf<Int, String>()
+        val screenshotFrames = setOf(500, 619, 625, 700, 900, 1200)
+        val outDir = java.nio.file.Paths.get("build/kirby-oam-snapshots")
+        java.nio.file.Files.createDirectories(outDir)
+
+        val nestlin = Nestlin().apply {
+            config.speedThrottlingEnabled = false
+            load(romPath)
+        }
+
+        var frameCount = 0
+        nestlin.addFrameListener(object : FrameListener {
+            override fun frameUpdated(frame: Frame) {
+                frameCount++
+                if (frameCount in framesToSnap) {
+                    snapshots[frameCount] = dumpOam(nestlin) + "\n" + dumpPatternTableSlice(nestlin)
+                }
+                if (frameCount in screenshotFrames) {
+                    saveFrameAsPng(frame, outDir.resolve("nestlin-frame${frameCount}.png"))
+                }
+                if (frameCount > framesToSnap.max()) {
+                    nestlin.stop()
+                }
+            }
+        })
+
+        nestlin.powerReset()
+        nestlin.start()
+
+        val outPath = Paths.get("build/kirby-oam-snapshots.txt")
+        Files.createDirectories(outPath.parent)
+        val sb = StringBuilder()
+        for (f in snapshots.keys.sorted()) {
+            sb.append("=== frame $f ===\n")
+            sb.append(snapshots[f])
+            sb.append("\n")
+        }
+        Files.write(outPath, sb.toString().toByteArray())
+        System.err.println("Wrote ${snapshots.size} snapshots to ${outPath.toAbsolutePath()}")
+    }
+
+    private fun saveFrameAsPng(frame: Frame, path: java.nio.file.Path) {
+        val image = BufferedImage(256, 240, BufferedImage.TYPE_INT_RGB)
+        for (y in 0 until 240) {
+            for (x in 0 until 256) {
+                image.setRGB(x, y, frame.scanlines[y][x])
+            }
+        }
+        ImageIO.write(image, "PNG", path.toFile())
+    }
+
+    private fun dumpPatternTableSlice(nestlin: Nestlin): String {
+        val ppuMem = nestlin.memory.ppuAddressedMemory.ppuInternalMemory
+        val sb = StringBuilder()
+        sb.append("# pattern-table dump \$1800-\$1BFF (1KB)\n")
+        for (base in 0x1800 until 0x1C00 step 16) {
+            sb.append("%04X:".format(base))
+            for (i in 0 until 16) {
+                sb.append(" %02X".format(ppuMem[base + i].toUnsignedInt()))
+            }
+            sb.append('\n')
+        }
+        return sb.toString()
+    }
+
+    private fun dumpOam(nestlin: Nestlin): String {
+        val oam = nestlin.memory.ppuAddressedMemory.objectAttributeMemory
+        val sb = StringBuilder()
+        for (i in 0 until 16) {
+            val s = oam.getSprite(i)
+            sb.append("  S%02d  Y=%3d X=%3d tile=$%02X attr=$%02X\n"
+                .format(i, s.y, s.x, s.tileIndex.toUnsignedInt(), s.attributes.toUnsignedInt()))
+        }
+        return sb.toString()
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2OamDumpRunner.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2OamDumpRunner.kt
@@ -1,0 +1,141 @@
+package com.github.alondero.nestlin.compare
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Drives Mesen2 in GUI mode to dump OAM at a list of frames so we can
+ * compare against Nestlin OAM byte-for-byte.
+ *
+ * Defaults to MESEN2_PATH env var, falls back to tools/Mesen2/Mesen.exe.
+ * (NOT tools/Mesen — that is Mesen v1 and has no Lua support.)
+ */
+object Mesen2OamDumpRunner {
+    private val MESEN_ARGS = listOf("--doNotSaveSettings")
+
+    fun mesen2Path(): Path {
+        val env = System.getenv("MESEN2_PATH")
+        if (env != null) return Paths.get(env)
+        return Paths.get("tools/Mesen2/Mesen.exe")
+    }
+
+    fun isAvailable(): Boolean = mesen2Path().toFile().exists()
+
+    /**
+     * Run Kirby for `maxFrame` frames; on each frame in `targetFrames`
+     * write a `frameNNNN.txt` file with 16 sprites of OAM contents.
+     */
+    fun dumpOam(romPath: Path, targetFrames: List<Int>, outDir: Path) {
+        val mesen = mesen2Path()
+        val mesenDir = mesen.parent.toFile()
+        val runDir = Files.createTempDirectory("mesen_oam_")
+        val scriptPath = runDir.resolve("dump_oam.lua")
+        val targetsLua = targetFrames.joinToString(",")
+
+        val lua = """
+local targets = { $targetsLua }
+local maxFrame = ${targetFrames.max()}
+local targetSet = {}
+for _, f in ipairs(targets) do targetSet[f] = true end
+local frame = 0
+local base = emu.getScriptDataFolder()
+
+-- Find a working memType for OAM (varies by Mesen version)
+local oamType = nil
+local function pickOamType()
+    local candidates = { "nesSpriteRam", "spriteRam", "nesOam", "oam" }
+    for _, name in ipairs(candidates) do
+        if emu.memType[name] then return name, emu.memType[name] end
+    end
+    return nil, nil
+end
+
+local typeName, typeVal = pickOamType()
+
+function onEndFrame()
+    frame = frame + 1
+    if targetSet[frame] then
+        local path = base .. "/frame" .. string.format("%04d", frame) .. ".txt"
+        local f = io.open(path, "w")
+        if f then
+            f:write("# memType=" .. tostring(typeName) .. "\n")
+            if typeVal then
+                for i = 0, 15 do
+                    local base_addr = i * 4
+                    local y    = emu.read(base_addr,     typeVal)
+                    local tile = emu.read(base_addr + 1, typeVal)
+                    local attr = emu.read(base_addr + 2, typeVal)
+                    local x    = emu.read(base_addr + 3, typeVal)
+                    f:write(string.format("S%02d Y=%3d X=%3d tile=${'$'}%02X attr=${'$'}%02X\n", i, y, x, tile, attr))
+                end
+            else
+                f:write("# No OAM memType available\n")
+                for k, v in pairs(emu.memType) do
+                    f:write("# memType." .. tostring(k) .. " = " .. tostring(v) .. "\n")
+                end
+            end
+            -- Dump pattern table bytes for the sprite-fetch addresses Kirby would use
+            -- on the title screen (Kirby sprite tiles, both planes, every row)
+            local pmem = emu.memType.nesPpuMemory or emu.memType.nesPpu or
+                         emu.memType.ppuMemory or emu.memType.ppu or
+                         emu.memType.nesChrRom
+            f:write("# available memTypes:")
+            for k, v in pairs(emu.memType) do f:write(" " .. tostring(k)) end
+            f:write("\n# chosen pmem = " .. tostring(pmem) .. "\n")
+            if pmem then
+                f:write("# pattern-table dump ${'$'}1800-${'$'}1BFF (1KB)\n")
+                for addr = 0x1800, 0x1BFF, 16 do
+                    local line = string.format("%04X:", addr)
+                    for i = 0, 15 do
+                        line = line .. string.format(" %02X", emu.read(addr + i, pmem))
+                    end
+                    f:write(line .. "\n")
+                end
+            end
+            f:close()
+        end
+    end
+    if targetSet[frame] then
+        local data = emu.takeScreenshot()
+        local png = base .. "/frame" .. string.format("%04d", frame) .. ".png"
+        local pf = io.open(png, "wb")
+        if pf then pf:write(data); pf:close() end
+    end
+    if frame >= maxFrame then
+        os.exit()
+    end
+end
+
+emu.addEventCallback(onEndFrame, emu.eventType.endFrame)
+""".trimIndent()
+        Files.writeString(scriptPath, lua)
+
+        try {
+            val process = ProcessBuilder().apply {
+                command(mesen.toString(), *MESEN_ARGS.toTypedArray(),
+                        scriptPath.toString(), romPath.toString())
+                directory(mesenDir)
+                redirectError(ProcessBuilder.Redirect.INHERIT)
+                redirectOutput(ProcessBuilder.Redirect.INHERIT)
+            }.start()
+            val exitCode = process.waitFor()
+            if (exitCode != 0) {
+                System.err.println("Mesen2 exited with code $exitCode " +
+                    "(I/O access must be enabled in Script -> Settings -> Restrictions)")
+            }
+            val scriptDataDir = mesen.parent.resolve("LuaScriptData").resolve("dump_oam")
+            Files.createDirectories(outDir)
+            if (Files.exists(scriptDataDir)) {
+                Files.list(scriptDataDir).use { stream ->
+                    stream.filter { it.fileName.toString().startsWith("frame") }
+                          .forEach { Files.copy(it, outDir.resolve(it.fileName),
+                              java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
+                }
+            }
+        } finally {
+            scriptPath.toFile().delete()
+            runDir.toFile().deleteRecursively()
+        }
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper4ChrBankingTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper4ChrBankingTest.kt
@@ -1,0 +1,113 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.github.alondero.nestlin.toSignedByte
+import com.github.alondero.nestlin.toUnsignedInt
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.Test
+
+/**
+ * Per NESdev MMC3 spec:
+ *   R0, R1 select 2 KB CHR banks; the bank number is expressed in 1 KB units
+ *   and the least significant bit is ignored (so adjacent 1 KB pages are paired
+ *   to form a 2 KB window).
+ *
+ * Therefore for any bank value N written to R0 or R1, the byte at PPU
+ * address (window_base + offset) must equal chrRom[(N and 0xFE) * 0x400 + offset].
+ *
+ * This is the regression test for the Kirby title-screen sprite corruption bug
+ * (see kirby-title-screen-sprite-overlay-bug-2026-05-18 memory entry).
+ * Before the fix, Mapper4 used a multiplier of 0x800 instead of 0x400,
+ * doubling the read offset and pulling in completely unrelated CHR data.
+ */
+class Mapper4ChrBankingTest {
+
+    /** Build a minimal valid iNES-1.0 image with the supplied PRG and CHR. */
+    private fun buildIne(prg: ByteArray, chr: ByteArray, mapperId: Int = 4): ByteArray {
+        require(prg.size % 0x4000 == 0) { "PRG must be a multiple of 16KB" }
+        require(chr.size % 0x2000 == 0) { "CHR must be a multiple of 8KB" }
+        val header = ByteArray(16).apply {
+            this[0] = 'N'.code.toByte(); this[1] = 'E'.code.toByte()
+            this[2] = 'S'.code.toByte(); this[3] = 0x1A.toByte()
+            this[4] = (prg.size / 0x4000).toByte()
+            this[5] = (chr.size / 0x2000).toByte()
+            // flags6: mapper-low nibble in upper 4 bits
+            this[6] = ((mapperId and 0x0F) shl 4).toByte()
+            // flags7: mapper-high nibble in upper 4 bits
+            this[7] = (mapperId and 0xF0).toByte()
+        }
+        return header + prg + chr
+    }
+
+    /** Stamp distinct bytes into every 1 KB CHR bank so we can detect mis-banking. */
+    private fun makeStampedChr(banks1k: Int): ByteArray {
+        val chr = ByteArray(banks1k * 0x400)
+        for (bank in 0 until banks1k) {
+            // Two distinct bytes per bank: bank number for first byte, ~bank for last byte
+            chr[bank * 0x400] = (bank and 0xFF).toByte()
+            chr[bank * 0x400 + 0x3FF] = (bank xor 0xFF).toByte()
+        }
+        return chr
+    }
+
+    /** Send a (register, value) MMC3 write pair: $8000 select then $8001 data. */
+    private fun mmc3Write(mapper: Mapper4, bankSelect: Int, value: Int) {
+        mapper.cpuWrite(0x8000, bankSelect.toSignedByte())
+        mapper.cpuWrite(0x8001, value.toSignedByte())
+    }
+
+    @Test
+    fun `R1 in inverted mode reads from (bank and 0xFE) times 0x400`() {
+        // Big CHR so bank 186 is in range
+        val chr = makeStampedChr(banks1k = 256)  // 256 KB CHR
+        val prg = ByteArray(0x4000 * 2)          // 32 KB PRG (minimum-ish)
+        val gp = GamePak(buildIne(prg, chr))
+        val mapper = gp.createMapper() as Mapper4
+
+        mmc3Write(mapper, 0x80 or 1, 186)  // R1=186, chrPrgInvert=true → R1 maps to $1800-$1FFF
+
+        assertThat(mapper.ppuRead(0x1800).toUnsignedInt(), equalTo(186))
+        assertThat(mapper.ppuRead(0x1800 + 0x3FF).toUnsignedInt(), equalTo(186 xor 0xFF))
+        // Second 1KB of the 2KB window = next 1KB sub-bank
+        assertThat(mapper.ppuRead(0x1C00).toUnsignedInt(), equalTo(187))
+    }
+
+    @Test
+    fun `R0 in inverted mode reads from (bank and 0xFE) times 0x400`() {
+        val chr = makeStampedChr(banks1k = 256)
+        val prg = ByteArray(0x4000 * 2)
+        val gp = GamePak(buildIne(prg, chr))
+        val mapper = gp.createMapper() as Mapper4
+
+        mmc3Write(mapper, 0x80 or 0, 100)  // R0=100, chrPrgInvert=true → R0 maps to $1000-$17FF
+
+        assertThat(mapper.ppuRead(0x1000).toUnsignedInt(), equalTo(100))
+        assertThat(mapper.ppuRead(0x1400).toUnsignedInt(), equalTo(101))
+    }
+
+    @Test
+    fun `R0 in normal mode reads from (bank and 0xFE) times 0x400`() {
+        val chr = makeStampedChr(banks1k = 256)
+        val prg = ByteArray(0x4000 * 2)
+        val gp = GamePak(buildIne(prg, chr))
+        val mapper = gp.createMapper() as Mapper4
+
+        mmc3Write(mapper, 0x00 or 0, 50)  // R0=50, chrPrgInvert=false → R0 maps to $0000-$07FF
+
+        assertThat(mapper.ppuRead(0x0000).toUnsignedInt(), equalTo(50))
+        assertThat(mapper.ppuRead(0x0400).toUnsignedInt(), equalTo(51))
+    }
+
+    @Test
+    fun `R0_R1 bit 0 is ignored - odd bank value gives same window as even`() {
+        val chr = makeStampedChr(banks1k = 256)
+        val prg = ByteArray(0x4000 * 2)
+        val gp = GamePak(buildIne(prg, chr))
+        val mapper = gp.createMapper() as Mapper4
+
+        // Per spec, bit 0 is ignored on R0/R1, so odd bank value maps to the
+        // same 2KB window as the previous even value.
+        mmc3Write(mapper, 0x80 or 1, 185)
+        assertThat(mapper.ppuRead(0x1800).toUnsignedInt(), equalTo(184))
+    }
+}


### PR DESCRIPTION
## Summary

- **Bug:** Mapper4 R0/R1 (2 KB CHR banks) used multiplier `0x800` instead of `0x400`. Per NESdev MMC3 spec, R0/R1 are 2 KB windows whose bank number is in 1 KB units with bit 0 ignored, so the correct multiplier is `0x400` (with bit-0 masked) — equivalent to `(bank >> 1) * 0x800`.
- **Symptom:** Kirby's title-screen central Kirby sprite rendered as a purple mosaic from frame ~619 onwards. With R1=186 the buggy code read from CHR offset `$5D000` instead of `$2E800`.
- **Fix:** Two-character change in `Mapper4.kt` (`0x0800` -> `0x0400`) on both branches (`chrPrgInvert` true/false) for R0 and R1.

## How the bug was isolated

OAM dumped from Mesen2 (`emu.read` + `emu.memType.nesSpriteRam` via Lua) was byte-for-byte identical to Nestlin's OAM at every sampled frame (500/600/619/625/700/900). Mesen2 rendered Kirby correctly from the *same* OAM, so the bug was downstream of OAM. Pattern-table bytes at `$1800-$1BFF` differed completely between the two, pointing straight at the CHR-bank arithmetic.

This invalidates the prior hypothesis (CPU/NMI/DMA timing) recorded in the `kirby-title-screen-sprite-overlay-bug-2026-05-18` memory entry, which has been updated to reflect the actual root cause.

## What's in the patch

- `src/main/kotlin/.../gamepak/Mapper4.kt` — fix, plus a tighter comment citing the spec
- `src/test/.../gamepak/Mapper4ChrBankingTest.kt` — 4 self-contained regression tests (synthesises an iNES image with stamped CHR; no external ROM)
- `src/test/.../compare/{KirbyOamSnapshotTest, Mesen2OamDumpRunner, KirbyMesenVsNestlinOamTest}.kt` — investigation harnesses kept for future MMC3 debugging; all skip cleanly when ROM/Mesen2 absent and are excluded from the default test pipeline
- `build.gradle.kts` — adds the new compare-package tests to `auxiliaryTests`
- `.claude/skills/mesen/SKILL.md` — corrects the long-standing "emu.read() hangs in Mesen2" note (it works in GUI mode), adds a Lua-in-Kotlin `${'$'}` escape tip
- `.gitignore` — adds `.claude/scheduled_tasks.lock`

## Test plan

- [x] `./gradlew test` — full suite green (1m 56s)
- [x] `Mapper4ChrBankingTest` — 4 tests, all fail on `master`, all pass with fix
- [x] `Mapper4IrqTest`, `GoldenLogTest` — unchanged
- [x] Visual check: Nestlin's Kirby title-screen Kirby now matches Mesen2 pixel-by-pixel