### PR TITLE
Add pause/resume emulation toggle

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/EmulatorConfig.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/EmulatorConfig.kt
@@ -20,7 +20,13 @@ data class EmulatorConfig(
      * PAL (Europe): 50.007 FPS
      * Default: 60.0 (NTSC approximation)
      */
-    var targetFps: Double = 60.0
+    var targetFps: Double = 60.0,
+
+    /**
+     * Pause emulation. When true, the emulation loop short-circuits each
+     * iteration without ticking CPU/PPU/APU. Toggled from the UI's Emulation menu.
+     */
+    var paused: Boolean = false
 ) {
     /**
      * Target time per frame in nanoseconds.

--- a/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
@@ -58,6 +58,12 @@ class Nestlin {
 
         try {
             while (running) {
+                if (config.paused) {
+                    Thread.sleep(10)
+                    // Reset throttle baseline so the first frame after resume isn't sped up
+                    lastFrameTimeNanos = System.nanoTime()
+                    continue
+                }
                 (1..3).forEach { ppu.tick() }
                 apu.tick()
                 cpu.tick()

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
@@ -71,6 +71,10 @@ class NestlinApplication : FrameListener, App() {
     private val inputConfig = InputConfig.load()
     private lateinit var gamepadInput: GamepadInput
 
+    // Held to keep the menu's check state in sync with keyboard shortcuts and
+    // to clear pause when starting a fresh game via Load / Hard Reset.
+    private var pauseMenuItem: javafx.scene.control.CheckMenuItem? = null
+
     override fun start(stage: Stage) {
         this.stage = stage.apply {
             title = "Nestlin"
@@ -106,6 +110,22 @@ class NestlinApplication : FrameListener, App() {
             settingsMenu.items.add(throttleMenuItem)
             menuBar.menus.add(settingsMenu)
 
+            // Emulation menu
+            val emulationMenu = javafx.scene.control.Menu("Emulation")
+
+            val pauseItem = javafx.scene.control.CheckMenuItem("Pause")
+            pauseItem.isSelected = nestlin.config.paused
+            pauseItem.accelerator = javafx.scene.input.KeyCombination.keyCombination("Ctrl+P")
+            pauseItem.setOnAction {
+                nestlin.config.paused = pauseItem.isSelected
+                updateTitle()
+                println("[APP] Emulation ${if (nestlin.config.paused) "paused" else "resumed"}")
+            }
+            pauseMenuItem = pauseItem
+
+            emulationMenu.items.add(pauseItem)
+            menuBar.menus.add(emulationMenu)
+
             // Create layout with menu bar and canvas
             val root = javafx.scene.layout.VBox()
             root.children.addAll(menuBar, canvas)
@@ -118,6 +138,13 @@ class NestlinApplication : FrameListener, App() {
                     nestlin.config.speedThrottlingEnabled = !nestlin.config.speedThrottlingEnabled
                     throttleMenuItem.isSelected = nestlin.config.speedThrottlingEnabled
                     println("[APP] Speed throttling ${if (nestlin.config.speedThrottlingEnabled) "enabled" else "disabled"}")
+                    event.consume()
+                } else if (event.code == javafx.scene.input.KeyCode.P && event.isControlDown) {
+                    // Ctrl+P toggles pause
+                    nestlin.config.paused = !nestlin.config.paused
+                    pauseMenuItem?.isSelected = nestlin.config.paused
+                    updateTitle()
+                    println("[APP] Emulation ${if (nestlin.config.paused) "paused" else "resumed"}")
                     event.consume()
                 } else {
                     handleInput(event.code, true)
@@ -268,14 +295,22 @@ class NestlinApplication : FrameListener, App() {
             currentRomPath = romPath
             nestlin.load(romPath)
             nestlin.powerReset()
+            clearPauseState()
             updateTitle()
             startEmulation()
         }
     }
 
+    // Reset pause so a new game session always begins running.
+    private fun clearPauseState() {
+        nestlin.config.paused = false
+        pauseMenuItem?.isSelected = false
+    }
+
     private fun updateTitle() {
         val gameName = nestlin.currentGameName()
-        stage.title = if (gameName.isNotEmpty()) "Nestlin - $gameName" else "Nestlin"
+        val base = if (gameName.isNotEmpty()) "Nestlin - $gameName" else "Nestlin"
+        stage.title = if (nestlin.config.paused) "$base (Paused)" else base
     }
 
     private fun handleHardReset() {
@@ -289,6 +324,7 @@ class NestlinApplication : FrameListener, App() {
         stopEmulation()
         nestlin.load(currentRomPath!!)
         nestlin.powerReset()
+        clearPauseState()
         updateTitle()
         startEmulation()
     }


### PR DESCRIPTION
## Summary
- New top-level **Emulation** menu with a `Pause` `CheckMenuItem` (Ctrl+P accelerator).
- Emulation loop short-circuits on `config.paused` with a 10 ms sleep; throttle baseline resets each paused iteration so resume doesn't race a stale clock.
- Pause clears on Load Game / Hard Reset; window title shows `(Paused)` while frozen.

## Design notes
- Halting CPU/PPU/APU ticks naturally idles audio (existing underrun path in `audioPlaybackLoop`) and freezes the canvas (PPU stops emitting frames), so no explicit silencing or frame-hold needed.
- Mirrors the existing `Settings → Throttle` / `Ctrl+T` pattern for consistency.
- `Ctrl+P` chosen over plain `P` / `Space` since plain letters are claimed by controller mapping via `InputConfig`.

## Test plan
- [x] `./gradlew build -x test` — green
- [x] `./gradlew test` — full suite green (incl. `GoldenLogTest` for no-regression on CPU timing path)
- [ ] Manual smoke test in a JavaFX session:
  - [ ] `Emulation → Pause` freezes game, title shows `(Paused)`, audio falls silent
  - [ ] Clicking again resumes from the same frame
  - [ ] `Ctrl+P` toggles in sync with the menu checkmark
  - [ ] Pause → `Hard Reset` / `Load Game...` starts new run un-paused, checkmark cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)