### PR TITLE
Fix Mesen2 screenshot capture harness (3 bugs)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,4 +103,16 @@ tasks.register<Test>("testMesenComparison") {
         include("**/${testClass.replace('.', '/')}.class")
     }
     useJUnit()
+    // Forward MESEN2_PATH to the test JVM so the runner can locate Mesen2.
+    // The Gradle daemon may not inherit shell env vars cleanly between invocations,
+    // so we read it explicitly and pass it through.
+    val mesen2Path = System.getenv("MESEN2_PATH")
+    if (mesen2Path != null) {
+        environment("MESEN2_PATH", mesen2Path)
+    }
+    // Show stdout/stderr from tests (e.g. the diff% println) so we can see results.
+    testLogging {
+        events("passed", "failed", "skipped", "standard_out", "standard_error")
+        showStandardStreams = true
+    }
 }

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2ReferenceRunner.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2ReferenceRunner.kt
@@ -24,7 +24,13 @@ object Mesen2ReferenceRunner {
 
     fun getMesen2Path(): Path {
         val path = System.getenv(ENV_VAR) ?: System.getProperty("mesen2.path")
-        return path?.let { Paths.get(it) } ?: Paths.get("tools/Mesen/Mesen.exe")
+        if (path != null) return Paths.get(path)
+        // Default fallback locations to try, in order of preference.
+        val candidates = listOf(
+            Paths.get("tools/Mesen2/Mesen.exe"),
+            Paths.get("tools/Mesen/Mesen.exe")
+        )
+        return candidates.firstOrNull { it.toFile().exists() } ?: candidates.first()
     }
 
     fun isMesen2Available(): Boolean = getMesen2Path().toFile().exists()
@@ -43,10 +49,16 @@ object Mesen2ReferenceRunner {
 
         try {
             // GUI mode: Mesen.exe script.lua rom.nes
-            // The script auto-exits via os.exit() after capturing
+            // The script auto-exits via os.exit() after capturing.
+            // Both paths MUST be absolute — Mesen's working directory is set to its own
+            // install dir, so a relative ROM path silently resolves into the Mesen folder
+            // and the ROM never loads. With no ROM loaded, emulation never starts, no
+            // endFrame callbacks fire, and the script hangs forever.
+            val absoluteScript = scriptPath.toAbsolutePath().toString()
+            val absoluteRom = romPath.toAbsolutePath().toString()
             val process = ProcessBuilder().apply {
                 command(mesenPath.toString(), *MESEN_ARGS.toTypedArray(),
-                        scriptPath.toString(), romPath.toString())
+                        absoluteScript, absoluteRom)
                 directory(mesenDir)
                 redirectError(ProcessBuilder.Redirect.INHERIT)
                 redirectOutput(ProcessBuilder.Redirect.INHERIT)
@@ -83,6 +95,9 @@ object Mesen2ReferenceRunner {
 
     private fun generateCaptureScript(targetFrame: Int, outputFile: String): String {
         // GUI mode: use emu.eventType.endFrame callback, NOT frameadvance loop
+        // NOTE: emu.getScriptDataFolder() does NOT return a trailing path separator
+        // on Windows, so concatenating "screenshot.png" lands the file OUTSIDE the
+        // script's data folder. We add the separator explicitly.
         return """
 local targetFrame = $targetFrame
 local outputFile = "$outputFile"
@@ -93,6 +108,10 @@ function onEndFrame()
     if frame == targetFrame then
         local data = emu.takeScreenshot()
         local basePath = emu.getScriptDataFolder()
+        local sep = string.sub(basePath, -1)
+        if sep ~= "/" and sep ~= "\\" then
+            basePath = basePath .. "\\"
+        end
         local fullPath = basePath .. outputFile
         local f = io.open(fullPath, "wb")
         if f then


### PR DESCRIPTION
## Summary

Three latent bugs prevented `ScreenshotComparisonTest` from ever producing a real Mesen2-vs-Nestlin diff. They were discovered while setting up Phase A diagnostics for the remaining Kirby's Adventure background-flicker bug.

- **Absolute paths required.** `ProcessBuilder` sets Mesen's working directory to its install dir, so relative ROM/script paths resolved into the Mesen folder and never loaded. The Lua frame counter never advanced and the process hung forever. Both paths are now `toAbsolutePath()` before invocation.
- **`emu.getScriptDataFolder()` has no trailing separator on Windows**, so the Lua wrote `screenshot.png` *outside* the script's data folder. Added an explicit separator check before concatenation.
- **Gradle daemon doesn't inherit `MESEN2_PATH` cleanly from the shell.** `testMesenComparison` now reads it via `System.getenv()` and forwards via `environment(...)`. Also enabled `testLogging.showStandardStreams` so diff% output and skip reasons can be seen.

Also reordered the fallback path list to prefer `tools/Mesen2/Mesen.exe` over `tools/Mesen/Mesen.exe` (Mesen v2 is what the harness targets).

## Known residual

After these fixes, Mesen2 successfully launches, runs Kirby for 150 frames in ~2 seconds, and writes a fresh `screenshot.png` to the expected folder — but the test still reports SKIPPED. A `Mesen2ScreenshotException` or `Mesen2ExecutionException` is being thrown and swallowed by the `assumeTrue(false)` catch path without surfacing its message. Next session will surface the residual exception and complete the harness fix before resuming the upward-band flicker hunt.

## Test plan

- [x] `./gradlew build` — BUILD SUCCESSFUL, no regressions in standard test suite
- [ ] `./gradlew testMesenComparison` — currently SKIPPED for residual reason (above)
- [ ] Verify against actual Kirby gameplay flicker once harness fully wired