### PR TITLE
Fix audio dropouts: emulation throttle + resampler discard

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
@@ -15,7 +15,8 @@ class Nestlin {
     val apu: Apu
     internal val memory: Memory  // internal for test access
     private var running = false
-    private var lastFrameTimeNanos: Long = 0
+    private var nextSyncDeadlineNanos: Long = 0
+    private var ticksSinceLastSync: Int = 0
 
     init {
         memory = Memory()
@@ -54,17 +55,19 @@ class Nestlin {
 
     fun start() {
         running = true
-        lastFrameTimeNanos = System.nanoTime()
+        nextSyncDeadlineNanos = System.nanoTime()
+        ticksSinceLastSync = 0
 
         try {
             while (running) {
                 (1..3).forEach { ppu.tick() }
                 apu.tick()
                 cpu.tick()
+                ticksSinceLastSync++
 
-                // Check if frame completed and throttle if needed
-                if (ppu.frameJustCompleted()) {
-                    throttleIfEnabled()
+                if (ticksSinceLastSync >= TICKS_PER_SYNC_CHUNK) {
+                    ticksSinceLastSync = 0
+                    syncToWallClock()
                 }
             }
         } finally {
@@ -74,32 +77,49 @@ class Nestlin {
         }
     }
 
-    /**
-     * Throttle emulation speed to match target frame rate.
-     * Uses high-precision timing to sleep until the next frame should start.
-     * Only throttles if speedThrottlingEnabled is true.
-     */
-    private fun throttleIfEnabled() {
+    // Sleeping the emulation thread for ~16 ms per frame starves the APU consumer;
+    // syncing every ~1 ms keeps Apu.audioBuffer continuously fed without changing the
+    // total throttle time.
+    private fun syncToWallClock() {
         if (!config.speedThrottlingEnabled) return
 
-        val currentTime = System.nanoTime()
-        val elapsedNanos = currentTime - lastFrameTimeNanos
-        val targetNanos = config.targetFrameTimeNanos
+        val nanosPerTick = config.targetFrameTimeNanos / TICKS_PER_FRAME
+        nextSyncDeadlineNanos += TICKS_PER_SYNC_CHUNK * nanosPerTick
 
-        if (elapsedNanos < targetNanos) {
-            val sleepNanos = targetNanos - elapsedNanos
-            val sleepMillis = sleepNanos / 1_000_000
-            val remainderNanos = (sleepNanos % 1_000_000).toInt()
+        val now = System.nanoTime()
+        val ahead = nextSyncDeadlineNanos - now
 
-            if (sleepMillis > 0 || remainderNanos > 0) {
+        if (ahead > MIN_SLEEP_NANOS) {
+            try {
+                val sleepMillis = ahead / 1_000_000
+                val remainderNanos = (ahead % 1_000_000).toInt()
                 Thread.sleep(sleepMillis, remainderNanos)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
             }
+        } else if (-ahead > MAX_DRIFT_NANOS) {
+            // Emulation is running slower than wall clock and falling behind. Reset
+            // the deadline so we don't try to "catch up" by skipping all future sleeps
+            // (which would defeat throttling on hosts where the emu can briefly outpace
+            // its target during transient stalls).
+            nextSyncDeadlineNanos = now
         }
-
-        lastFrameTimeNanos = System.nanoTime()
     }
 
     fun stop() {running = false}
+
+    companion object {
+        // NTSC NES CPU ticks per frame, used to derive nanos-per-tick from targetFps.
+        private const val TICKS_PER_FRAME = 29830L
+        // Sync to wall clock every ~1 ms of emulated time (1789 ticks at 1.79 MHz).
+        // Small enough that APU production gaps are barely perceptible to the audio
+        // thread, large enough that sync overhead stays negligible.
+        private const val TICKS_PER_SYNC_CHUNK = 1789
+        // Skip sub-0.1 ms sleeps; JVM/OS timer resolution can't honor them reliably.
+        private const val MIN_SLEEP_NANOS = 100_000L
+        // If wall-clock is more than 100 ms ahead of emulation, give up trying to catch up.
+        private const val MAX_DRIFT_NANOS = 100_000_000L
+    }
 }
 
 class BadHeaderException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/github/alondero/nestlin/apu/AudioResampler.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/apu/AudioResampler.kt
@@ -50,19 +50,18 @@ class AudioResampler(
             position += ratio
         }
 
-        // Discard consumed samples from buffer
-        // Note: position can be negative if we dropped samples when position < 1
-        // In that case, clamp to 0 since we've consumed beyond the buffer start
+        // After the loop, `position` points to the next input sample to interpolate
+        // from. Everything before floor(position) has been fully consumed and can be
+        // discarded; the fractional part stays as the offset for the next call.
         if (position < 0) {
+            // Defensive: push() can decrement position when dropping samples on overflow.
             head = 0
             position = 0.0
         } else {
-            // The CORRECT formula: we consumed `produced` input samples (each output consumes `ratio` samples).
-            // So we should discard `produced` samples, not floor(position).
-            // Note: `produced` is the count of outputs we just generated.
-            if (produced > 0) {
-                discard(produced)
-                position -= produced * ratio
+            val toDiscard = position.toInt()
+            if (toDiscard > 0) {
+                discard(toDiscard)
+                position -= toDiscard
             }
         }
 

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
@@ -341,7 +341,9 @@ class NestlinApplication : FrameListener, App() {
                     val info = DataLine.Info(SourceDataLine::class.java, format)
                     val line = AudioSystem.getLine(info) as? SourceDataLine
                     if (line != null) {
-                        line.open(format, 4096)
+                        // ~93 ms headroom at 44.1 kHz 16-bit mono (~46 ms stereo) to absorb
+                        // emulation-thread throttle jitter.
+                        line.open(format, 8192)
                         line.start()
                         selectedFormat = format
                         bestMatch = line

--- a/src/test/kotlin/com/github/alondero/nestlin/apu/AudioResamplerTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/apu/AudioResamplerTest.kt
@@ -154,4 +154,38 @@ class AudioResamplerTest {
         val produced = resampler.resample(output, 1000)
         assertThat(produced > 0, equalTo(true))
     }
+
+    @Test
+    fun resamplerSurvivesMatchedRateSteadyState() {
+        // Producer pushes 735 samples per 16.67 ms burst (44100/sec). Consumer pulls
+        // 17 × 47 = 799 outputs per burst (≈ 48000/60). At ratio 0.91875, 799 outputs
+        // require 734 inputs — within 1 of the supply. A correct resampler must sustain
+        // this indefinitely without ever returning produced=0.
+
+        val resampler = AudioResampler(44100.0, 48000.0, bufferCapacity = 16384)
+        val outputBuf = ShortArray(64)
+
+        val samplesPerBurst = 735
+        val outputsPerPoll = 47
+        val pollsPerBurst = 17
+        val burstsToSimulate = 60
+
+        var underrunPolls = 0
+        var totalPolls = 0
+
+        for (burst in 0 until burstsToSimulate) {
+            resampler.push(ShortArray(samplesPerBurst) { 100.toShort() })
+            repeat(pollsPerBurst) {
+                val produced = resampler.resample(outputBuf, outputsPerPoll)
+                if (produced == 0) underrunPolls++
+                totalPolls++
+            }
+        }
+
+        assertThat(
+            "expected zero underrun polls over $totalPolls total polls; got $underrunPolls " +
+                "(each is a SourceDataLine starve event)",
+            underrunPolls, equalTo(0)
+        )
+    }
 }


### PR DESCRIPTION
## Summary
Two independent audio bugs surfaced during investigation of user-reported "sometimes dips like a skipped frame with no audio":

- **Producer starvation (root cause on this user's 44.1 kHz device):** the emulation loop slept ~16ms after each frame, blocking all APU sample production for that window. Replaced with a tick-budgeted sync that pauses every ~1789 CPU ticks (~1ms emulated time) so the APU produces continuously.
- **AudioResampler over-discard (root cause on 48 kHz devices):** `resample()` discarded `produced` input samples per call instead of `floor(position)`, draining the input buffer ~9% faster than interpolation needed. Inert at unity ratio so didn't affect this user, but would affect anyone whose audio device prefers 48000 Hz.

Doubled the `SourceDataLine` buffer to 8192 bytes for additional headroom.

## Empirical evidence
- Super Mario Bros, ~1.5 min session, pre-fix: 49,250 underrun events (≈ 530/sec)
- Super Mario Bros, comparable session, post-fix: 83 underrun events (≈ 1/sec) — **~600× reduction**
- New `resamplerSurvivesMatchedRateSteadyState` test reproduces the discard bug (60/1020 underrun polls before, 0 after)

## What was considered and not done
- **Dynamic rate control (Mesen-style)**: the ±0.25% adjustment envelope is too narrow to compensate for the bursty per-frame throttle pattern. No failing test could justify the added complexity. Reconsider if drift over long playback shows up as a separate issue.
- **Silence-on-underrun in audio thread**: tried during investigation, made it worse — splicing zero samples into a live waveform creates step discontinuities = audible clicks (~28/sec, perceived as "really crackly"). Reverted.

## Test plan
- [x] `./gradlew test` — 100 tests, 0 failures, 0 errors
- [x] Manual SMB playback — user confirms improvement vs. pre-fix
- [ ] Reviewer: try on a 48 kHz audio device (e.g., Linux with PulseAudio defaulting to 48000) to validate the resampler fix path

🤖 Generated with [Claude Code](https://claude.com/claude-code)