### PR TITLE
Fix sprite X off-by-one (rendered at OAM X-1, now at OAM X)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/Ppu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/Ppu.kt
@@ -290,11 +290,12 @@ class Ppu(var memory: Memory) {
     }
 
     private fun buildActiveSprite(entry: SecondaryOamEntry, low: Byte, high: Byte): ActiveSprite {
+        // +1 so the counter reaches zero on the cycle whose frame column equals OAM X.
         val active = ActiveSprite(
             data = entry.sprite,
             tileDataLow = low,
             tileDataHigh = high,
-            xCounter = entry.sprite.x
+            xCounter = entry.sprite.x + 1
         )
         if (entry.sprite.horizontalFlip) {
             active.shiftLow = reverseBits(low.toUnsignedInt() and 0xFF)

--- a/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuSpriteXPositionTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuSpriteXPositionTest.kt
@@ -1,0 +1,55 @@
+package com.github.alondero.nestlin.ppu
+
+import com.github.alondero.nestlin.Memory
+import com.github.alondero.nestlin.toSignedByte
+import com.github.alondero.nestlin.ui.FrameListener
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.Test
+
+class PpuSpriteXPositionTest {
+
+    @Test
+    fun `sprite renders at OAM X coordinate, not one pixel to the left`() {
+        val memory = Memory()
+        val ppu = Ppu(memory)
+
+        val chr = ByteArray(0x2000)
+        chr[0x0000] = 0xFF.toSignedByte()
+        chr[0x0008] = 0x00.toSignedByte()
+        memory.ppuAddressedMemory.ppuInternalMemory.loadChrRom(chr)
+
+        memory.ppuAddressedMemory.ppuInternalMemory[0x3F11] = 0x30.toSignedByte()
+
+        // OAM Y semantics: sprite at Y=99 renders on scanline 100.
+        with(memory.ppuAddressedMemory.objectAttributeMemory) {
+            this[0] = 99.toSignedByte()
+            this[1] = 0x00.toSignedByte()
+            this[2] = 0x00.toSignedByte()
+            this[3] = 100.toSignedByte()
+        }
+
+        memory.ppuAddressedMemory.mask.register = 0b00010000
+
+        var captured: Frame? = null
+        ppu.addFrameListener(object : FrameListener {
+            override fun frameUpdated(frame: Frame) {
+                if (captured == null) captured = frame
+            }
+        })
+
+        // One NTSC frame is 89342 PPU cycles; cap at 2x to fail fast if frame completion regresses.
+        val maxTicks = 2 * 89342
+        var ticks = 0
+        while (captured == null && ticks < maxTicks) {
+            ppu.tick()
+            ticks++
+        }
+        val frame = requireNotNull(captured) { "PPU did not complete a frame within $maxTicks ticks" }
+
+        val whiteRgb = NesPalette.getRgb(0x30)
+        val firstWhiteColumn = frame.scanlines[100].indexOfFirst { it == whiteRgb }
+
+        assertThat(firstWhiteColumn, equalTo(100))
+    }
+}


### PR DESCRIPTION
## Summary
- Sprite X counter was initialised to `sprite.x`; activation and first MSB output happened on the cycle the counter reached zero, placing the leftmost sprite pixel at frame column `sprite.x - 1` instead of `sprite.x`.
- Fix: initialise to `sprite.x + 1` so activation lands one cycle later and the first pixel aligns with the OAM X coordinate.
- Visible in SMB as items leaking out the left edge of "?" blocks (sprite-behind-background priority makes the misalignment obvious) and Mario peeking out the left side of pipes; other scenarios hide it because sprites are usually surrounded by transparent space.

## Test plan
- [x] New `PpuSpriteXPositionTest` reproduces the bug pre-fix (sprite at OAM X=100 rendered first pixel at column 99) and passes post-fix.
- [x] Full `./gradlew test` suite green — no regressions in sprite-related tests (Kirby OAM snapshots, Mapper4 verification, A12 edge timing, etc.).
- [x] Visual confirmation in SMB: items emerging from "?" blocks and Mario entering pipes both render correctly aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)