### PR TITLE
Fullscreen toggle (F11) and integer/Fit display scaling

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
@@ -13,12 +13,14 @@ import javafx.animation.AnimationTimer
 import javafx.application.Application
 import javafx.application.Platform
 import javafx.scene.Scene
+import javafx.scene.Group
 import javafx.scene.canvas.Canvas
 import javafx.scene.control.Menu
 import javafx.scene.control.MenuBar
 import javafx.scene.control.MenuItem
 import javafx.scene.image.PixelFormat
 import javafx.scene.layout.StackPane
+import javafx.scene.layout.VBox
 import javafx.stage.FileChooser
 import javafx.stage.Stage
 import tornadofx.App
@@ -31,23 +33,34 @@ import javax.sound.sampled.DataLine
 import javax.sound.sampled.SourceDataLine
 import kotlin.concurrent.thread
 
-const val DISPLAY_SCALE = 4  // 4x magnification for debugging
-
 fun main(args: Array<String>) {
     Application.launch(NestlinApplication::class.java, *args)
 }
 
 class NestlinApplication : FrameListener, App() {
     private lateinit var stage: Stage
-    private val scaledWidth = RESOLUTION_WIDTH * DISPLAY_SCALE
-    private val scaledHeight = RESOLUTION_HEIGHT * DISPLAY_SCALE
-    private var canvas = Canvas(scaledWidth.toDouble(), scaledHeight.toDouble())
+    private var canvas = Canvas(RESOLUTION_WIDTH.toDouble(), RESOLUTION_HEIGHT.toDouble())
+    // Group wraps the canvas so its visual scale contributes to layout bounds, letting the
+    // StackPane size to the scaled extent and centre the canvas in fullscreen / fit modes.
+    private val canvasGroup = Group(canvas)
+    private val canvasHolder = StackPane(canvasGroup)
     private var nestlin = Nestlin().also { it.addFrameListener(this) }
     private var running = false
     // Frame buffer synchronization for thread-safe screenshot capture
     private val frameBufferLock = Any()
-    // 4x larger buffer to hold magnified pixels
-    private var nextFrame = ByteArray(scaledHeight * scaledWidth * 3)
+    // Native-resolution RGB buffer. Upscaling is handled by Canvas.scaleX/Y, not by replication.
+    private var nextFrame = ByteArray(RESOLUTION_HEIGHT * RESOLUTION_WIDTH * 3)
+
+    private var displayConfig = DisplayConfig.load()
+    private val scaleMenuItems = mutableMapOf<ScaleMode, javafx.scene.control.RadioMenuItem>()
+
+    // Cached windowed dimensions so we can restore the stage explicitly on fullscreen exit
+    // (JavaFX on Windows doesn't always restore prior size reliably, especially in Fit mode
+    // where the canvas scale is bound reactively to the holder width).
+    private var windowedWidth: Double = 0.0
+    private var windowedHeight: Double = 0.0
+
+    private val mouseNearTopProperty = javafx.beans.property.SimpleBooleanProperty(false)
 
     // Current ROM path for Hard Reset functionality
     private var currentRomPath: Path? = null
@@ -77,7 +90,9 @@ class NestlinApplication : FrameListener, App() {
     private var pauseMenuItem: javafx.scene.control.CheckMenuItem? = null
 
     override fun start(stage: Stage) {
-        this.stage = stage.apply {
+        // Assign lateinit *before* the apply block — applyScale (called inside) reads this.stage.
+        this.stage = stage
+        stage.apply {
             title = "Nestlin"
 
             // Create menu bar
@@ -114,7 +129,26 @@ class NestlinApplication : FrameListener, App() {
                 println("[APP] Speed throttling ${if (throttleMenuItem.isSelected) "enabled" else "disabled"}")
             }
 
-            settingsMenu.items.add(throttleMenuItem)
+            // Scale submenu (1x / 2x / 3x / 4x / Fit) as a mutually-exclusive radio group.
+            val scaleMenu = javafx.scene.control.Menu("Scale")
+            val scaleGroup = javafx.scene.control.ToggleGroup()
+            ScaleMode.values().forEach { mode ->
+                val item = javafx.scene.control.RadioMenuItem(mode.label())
+                item.toggleGroup = scaleGroup
+                item.isSelected = displayConfig.scale == mode
+                item.setOnAction {
+                    setScaleMode(mode)
+                }
+                scaleMenu.items.add(item)
+                scaleMenuItems[mode] = item
+            }
+
+            val fullscreenItem = javafx.scene.control.CheckMenuItem("Fullscreen")
+            fullscreenItem.isSelected = displayConfig.fullscreen
+            fullscreenItem.accelerator = javafx.scene.input.KeyCombination.keyCombination("F11")
+            fullscreenItem.setOnAction { setFullscreen(fullscreenItem.isSelected) }
+
+            settingsMenu.items.addAll(throttleMenuItem, scaleMenu, fullscreenItem)
             menuBar.menus.add(settingsMenu)
 
             // Emulation menu
@@ -133,11 +167,69 @@ class NestlinApplication : FrameListener, App() {
             emulationMenu.items.add(pauseItem)
             menuBar.menus.add(emulationMenu)
 
-            // Create layout with menu bar and canvas
-            val root = javafx.scene.layout.VBox()
-            root.children.addAll(menuBar, canvas)
+            // Create layout with menu bar and the canvas holder. VBox.setVgrow lets the
+            // holder expand to fill remaining vertical space in fullscreen / Fit mode.
+            val root = VBox()
+            root.children.addAll(menuBar, canvasHolder)
+            VBox.setVgrow(canvasHolder, javafx.scene.layout.Priority.ALWAYS)
+
+            // Letterbox area outside the scaled canvas paints black.
+            canvasHolder.style = "-fx-background-color: black;"
+            // Decouple holder's min size from the Group's bounds. Without this, the scaled
+            // canvas's visual extent propagates upward through the StackPane as a min-size
+            // constraint, preventing the stage from shrinking back after fullscreen exit
+            // and trapping Fit mode at the fullscreen scale value.
+            canvasHolder.minWidth = 0.0
+            canvasHolder.minHeight = 0.0
 
             scene = Scene(root)
+            scene.fill = javafx.scene.paint.Color.BLACK
+
+            // Apply persisted scale + fullscreen now that the scene exists.
+            applyScale(displayConfig.scale)
+            isFullScreen = displayConfig.fullscreen
+            fullScreenExitHint = ""
+            fullScreenExitKeyCombination = javafx.scene.input.KeyCombination.NO_MATCH
+
+            // Menu reveals when (a) not in fullscreen, (b) mouse is near the top edge, or
+            // (c) any submenu is already open (so dropdowns don't vanish mid-click).
+            // Accelerator F11 lives on the Scene and still fires while menu is hidden.
+            val anyMenuShowing = javafx.beans.binding.Bindings.createBooleanBinding(
+                { menuBar.menus.any { it.isShowing } },
+                *menuBar.menus.map { it.showingProperty() }.toTypedArray()
+            )
+            val menuRevealed = fullScreenProperty().not()
+                .or(mouseNearTopProperty)
+                .or(anyMenuShowing)
+            menuBar.visibleProperty().bind(menuRevealed)
+            menuBar.managedProperty().bind(menuRevealed)
+
+            // Reveal threshold: top 4 logical pixels. Tight enough not to interfere with
+            // gameplay; generous enough that a fast mouse-to-top motion still triggers.
+            scene.addEventFilter(javafx.scene.input.MouseEvent.MOUSE_MOVED) { e ->
+                mouseNearTopProperty.set(stage.isFullScreen && e.sceneY < 4.0)
+            }
+
+            fullScreenProperty().addListener { _, wasFs, nowFs ->
+                if (nowFs && !wasFs) {
+                    // Capture pre-fullscreen size for explicit restore on exit.
+                    if (width > 0) windowedWidth = width
+                    if (height > 0) windowedHeight = height
+                } else if (wasFs && !nowFs && windowedWidth > 0) {
+                    // Explicitly restore — JavaFX's auto-restore isn't reliable on Windows,
+                    // and in Fit mode the canvas scale is bound to the holder so a stuck-large
+                    // stage means a stuck-large canvas that overflows the window frame.
+                    width = windowedWidth
+                    height = windowedHeight
+                }
+                if (displayConfig.fullscreen != nowFs) {
+                    displayConfig = displayConfig.copy(fullscreen = nowFs)
+                    DisplayConfig.save(displayConfig)
+                }
+                fullscreenItem.isSelected = nowFs
+                // Reset hover state on transition so the menu isn't stuck visible.
+                if (!nowFs) mouseNearTopProperty.set(false)
+            }
 
             scene.setOnKeyPressed { event ->
                 when {
@@ -166,6 +258,7 @@ class NestlinApplication : FrameListener, App() {
                         handleQuickLoadState()
                         event.consume()
                     }
+                    // F11 is handled by the Fullscreen menu accelerator (see Settings menu).
                     else -> handleInput(event.code, true)
                 }
             }
@@ -189,9 +282,9 @@ class NestlinApplication : FrameListener, App() {
                 val pixelWriter = canvas.graphicsContext2D.pixelWriter
                 val pixelFormat = PixelFormat.getByteRgbInstance()
 
-                // Thread-safe read of frame buffer
+                // Thread-safe read of frame buffer (native NES resolution; Canvas scale handles upscaling)
                 synchronized(frameBufferLock) {
-                    pixelWriter.setPixels(0, 0, scaledWidth, scaledHeight, pixelFormat, nextFrame, 0, scaledWidth*3)
+                    pixelWriter.setPixels(0, 0, RESOLUTION_WIDTH, RESOLUTION_HEIGHT, pixelFormat, nextFrame, 0, RESOLUTION_WIDTH * 3)
                 }
             }
 
@@ -327,6 +420,56 @@ class NestlinApplication : FrameListener, App() {
     private fun clearPauseState() {
         nestlin.config.paused = false
         pauseMenuItem?.isSelected = false
+    }
+
+    private fun setScaleMode(mode: ScaleMode) {
+        if (displayConfig.scale != mode) {
+            displayConfig = displayConfig.copy(scale = mode)
+            DisplayConfig.save(displayConfig)
+        }
+        scaleMenuItems[mode]?.isSelected = true
+        applyScale(mode)
+        println("[APP] Display scale set to ${mode.label()}")
+    }
+
+    private fun setFullscreen(enable: Boolean) {
+        stage.isFullScreen = enable
+        // fullScreenProperty listener persists the change.
+    }
+
+    private fun applyScale(mode: ScaleMode) {
+        val factor = mode.factor()
+        // Drop any previous binding before swapping mode to avoid leaking listeners.
+        canvas.scaleXProperty().unbind()
+        canvas.scaleYProperty().unbind()
+        if (factor != null) {
+            canvas.scaleX = factor.toDouble()
+            canvas.scaleY = factor.toDouble()
+            // Resize the window to the canvas's natural extent unless fullscreen owns it.
+            if (!stage.isFullScreen) {
+                stage.sizeToScene()
+            }
+        } else {
+            // Fit: seed the window at 3x when entering Fit while windowed, so the user
+            // always gets a usable starting size before the binding takes over.
+            if (!stage.isFullScreen) {
+                canvas.scaleX = 3.0
+                canvas.scaleY = 3.0
+                stage.sizeToScene()
+            }
+            // Then bind scale to live holder dimensions, preserving aspect ratio.
+            val widthFactor = javafx.beans.binding.Bindings.createDoubleBinding(
+                { (canvasHolder.width / RESOLUTION_WIDTH).coerceAtLeast(1.0) },
+                canvasHolder.widthProperty()
+            )
+            val heightFactor = javafx.beans.binding.Bindings.createDoubleBinding(
+                { (canvasHolder.height / RESOLUTION_HEIGHT).coerceAtLeast(1.0) },
+                canvasHolder.heightProperty()
+            )
+            val fitBinding = javafx.beans.binding.Bindings.min(widthFactor, heightFactor)
+            canvas.scaleXProperty().bind(fitBinding)
+            canvas.scaleYProperty().bind(fitBinding)
+        }
     }
 
     private fun updateTitle() {
@@ -614,24 +757,14 @@ class NestlinApplication : FrameListener, App() {
 
     override fun frameUpdated(frame: Frame) {
         synchronized(frameBufferLock) {
-            // Replicate each pixel DISPLAY_SCALE times in both X and Y dimensions
+            // Write directly at native 256x240 — upscaling is the Canvas's job.
             frame.scanlines.withIndex().forEach { (y, scanline) ->
+                val rowBase = y * RESOLUTION_WIDTH * 3
                 scanline.withIndex().forEach { (x, pixel) ->
-                    val r = (pixel shr 16).toByte()
-                    val g = (pixel shr 8).toByte()
-                    val b = pixel.toByte()
-
-                    // Write this pixel DISPLAY_SCALE x DISPLAY_SCALE times
-                    for (dy in 0 until DISPLAY_SCALE) {
-                        for (dx in 0 until DISPLAY_SCALE) {
-                            val scaledX = x * DISPLAY_SCALE + dx
-                            val scaledY = y * DISPLAY_SCALE + dy
-                            val pixIdx = (scaledY * scaledWidth + scaledX) * 3
-                            nextFrame[pixIdx] = r
-                            nextFrame[pixIdx + 1] = g
-                            nextFrame[pixIdx + 2] = b
-                        }
-                    }
+                    val idx = rowBase + x * 3
+                    nextFrame[idx] = (pixel shr 16).toByte()
+                    nextFrame[idx + 1] = (pixel shr 8).toByte()
+                    nextFrame[idx + 2] = pixel.toByte()
                 }
             }
         }
@@ -666,7 +799,7 @@ class NestlinApplication : FrameListener, App() {
         // Run file I/O on background thread to avoid blocking the UI
         thread {
             try {
-                val path = screenshotManager.saveScreenshot(frameData, scaledWidth, scaledHeight)
+                val path = screenshotManager.saveScreenshot(frameData, RESOLUTION_WIDTH, RESOLUTION_HEIGHT)
                 println("[SCREENSHOT] Saved to: $path")
             } catch (e: IOException) {
                 println("[SCREENSHOT] File I/O error: ${e.message}")

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/DisplayConfig.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/DisplayConfig.kt
@@ -1,0 +1,61 @@
+package com.github.alondero.nestlin.ui
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import java.io.File
+
+enum class ScaleMode {
+    X1, X2, X3, X4, FIT;
+
+    fun factor(): Int? = when (this) {
+        X1 -> 1
+        X2 -> 2
+        X3 -> 3
+        X4 -> 4
+        FIT -> null
+    }
+
+    fun label(): String = when (this) {
+        X1 -> "1x"
+        X2 -> "2x"
+        X3 -> "3x"
+        X4 -> "4x"
+        FIT -> "Fit"
+    }
+}
+
+data class DisplayConfig(
+    val scale: ScaleMode = ScaleMode.X3,
+    val fullscreen: Boolean = false
+) {
+    companion object {
+        private val gson: Gson = GsonBuilder().setPrettyPrinting().create()
+
+        private val defaultConfigDir = File(System.getProperty("user.home"), ".config/nestlin")
+
+        fun configFile(dir: File = defaultConfigDir): File = File(dir, "display.json")
+
+        fun load(dir: File = defaultConfigDir): DisplayConfig {
+            val file = configFile(dir)
+            return try {
+                if (file.exists()) {
+                    gson.fromJson(file.readText(), DisplayConfig::class.java) ?: DisplayConfig()
+                } else {
+                    DisplayConfig()
+                }
+            } catch (e: Exception) {
+                println("[DISPLAY] Error loading config: ${e.message}, using defaults")
+                DisplayConfig()
+            }
+        }
+
+        fun save(config: DisplayConfig, dir: File = defaultConfigDir) {
+            try {
+                dir.mkdirs()
+                configFile(dir).writeText(gson.toJson(config))
+            } catch (e: Exception) {
+                println("[DISPLAY] Error saving config: ${e.message}")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/ui/DisplayConfigTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ui/DisplayConfigTest.kt
@@ -1,0 +1,57 @@
+package com.github.alondero.nestlin.ui
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class DisplayConfigTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private fun dir(): File = tempFolder.root
+
+    @Test
+    fun `defaults to 3x scale and windowed`() {
+        val config = DisplayConfig()
+        assertThat(config.scale, equalTo(ScaleMode.X3))
+        assertThat(config.fullscreen, equalTo(false))
+    }
+
+    @Test
+    fun `load returns defaults when no file exists`() {
+        val loaded = DisplayConfig.load(dir())
+        assertThat(loaded, equalTo(DisplayConfig()))
+    }
+
+    @Test
+    fun `save then load round-trips`() {
+        val original = DisplayConfig(scale = ScaleMode.FIT, fullscreen = true)
+        DisplayConfig.save(original, dir())
+
+        val loaded = DisplayConfig.load(dir())
+        assertThat(loaded, equalTo(original))
+    }
+
+    @Test
+    fun `load falls back to defaults on malformed JSON`() {
+        DisplayConfig.configFile(dir()).writeText("{not valid json")
+        val loaded = DisplayConfig.load(dir())
+        assertThat(loaded, equalTo(DisplayConfig()))
+    }
+
+    @Test
+    fun `ScaleMode factor returns expected integer for fixed scales`() {
+        assertThat(ScaleMode.X1.factor(), equalTo<Int?>(1))
+        assertThat(ScaleMode.X2.factor(), equalTo<Int?>(2))
+        assertThat(ScaleMode.X3.factor(), equalTo<Int?>(3))
+        assertThat(ScaleMode.X4.factor(), equalTo<Int?>(4))
+    }
+
+    @Test
+    fun `ScaleMode FIT has null factor (computed at render time)`() {
+        assertThat(ScaleMode.FIT.factor(), equalTo<Int?>(null))
+    }
+}


### PR DESCRIPTION
Closes #46.

## Summary
- Adds Settings → Scale submenu (1x / 2x / 3x / 4x / Fit) and an F11 Fullscreen menu item with accelerator. Default scale is 3x.
- Persists selection to `~/.config/nestlin/display.json` (same config home as `input.json`).
- In fullscreen, the menu bar hides but reveals on mouse-to-top; black letterbox bars preserve the 256:240 aspect ratio at every scale.
- Rendering switches from per-frame software pixel replication into a `scaledWidth × scaledHeight` buffer to native 256 × 240 + `Canvas.scaleX/Y`. Removes ~1M byte-writes/frame at 4x and makes letterboxing automatic.

## Acceptance criteria (from #46)
- [x] F11 toggles fullscreen via `Stage.setFullScreen`
- [x] Settings menu has scale options 1x / 2x / 3x / 4x / Fit
- [x] Selected scale persists across restarts (in the same config home as `input.json`)
- [x] No aspect-ratio stretching at any scale option

## Notable subtleties (worth a review pass)
- `canvasHolder.minWidth/minHeight = 0` is load-bearing. The `Group(canvas)` wrapper is intentional (without it `sizeToScene()` would size to the canvas's *layout* bounds, ignoring scale), but it also propagates the scaled visual extent upward as a StackPane min-size constraint. That created a layout deadlock where the stage couldn't shrink back from fullscreen → holder couldn't shrink → Fit-mode binding never fired → canvas stayed at the fullscreen scale value. Setting holder min to 0 breaks the cycle.
- Explicit `windowedWidth/Height` capture-on-enter and restore-on-exit defends against JavaFX's unreliable auto-restore on Windows.
- The hover-reveal threshold is 4 logical pixels at the top of the scene; an `anyMenuShowing` clause keeps the menu visible while a dropdown is open so it doesn't vanish mid-click.
- In Fit mode, entering Fit while windowed seeds the stage at 3x so the user always lands with a usable starting size before the binding takes over.

## Test plan
- [x] `./gradlew build` — green (full test suite passes; new `DisplayConfigTest` covers defaults, round-trip, malformed-JSON fallback, factor mapping)
- [x] Manual: scale 1x / 2x / 3x / 4x — window resizes crisply, aspect preserved at each step
- [x] Manual: Fit mode — drag-resize preserves aspect with black letterbox
- [x] Manual: F11 enter/exit fullscreen — menu hides + hover-reveal works; window restores after exit even in Fit mode (the layout-deadlock fix above)
- [x] Manual: persistence — exit and relaunch picks up saved scale + fullscreen state from `display.json`
- [ ] Manual: Linux / macOS verification (developed and tested on Windows 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)