### PR TITLE
Remove TornadoFX in favour of plain JavaFX/OpenJFX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,7 +260,7 @@ When adding significant features (like PPU rendering):
 
 ### Dependencies
 - kotlin-stdlib 1.1.0
-- TornadoFX (JavaFX wrapper)
+- JavaFX/OpenJFX (UI) via `org.openjfx.javafxplugin`
 - Apache Commons Compress (for .7z ROMs)
 - JUnit + Hamkrest (testing)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,10 +27,6 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.22")
     implementation("org.apache.commons:commons-compress:1.25.0")
     implementation("org.tukaani:xz:1.9")
-    implementation("no.tornado:tornadofx:1.7.20") {
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-reflect")
-    }
 
     // Gamepad/controller support (JInput)
     implementation("net.java.jinput:jinput:2.0.10")

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
@@ -21,7 +21,6 @@ import javafx.scene.image.PixelFormat
 import javafx.scene.layout.StackPane
 import javafx.stage.FileChooser
 import javafx.stage.Stage
-import tornadofx.App
 import java.io.IOException
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -37,7 +36,7 @@ fun main(args: Array<String>) {
     Application.launch(NestlinApplication::class.java, *args)
 }
 
-class NestlinApplication : FrameListener, App() {
+class NestlinApplication : FrameListener, Application() {
     private lateinit var stage: Stage
     private val scaledWidth = RESOLUTION_WIDTH * DISPLAY_SCALE
     private val scaledHeight = RESOLUTION_HEIGHT * DISPLAY_SCALE


### PR DESCRIPTION
## Summary
- Removes the abandoned `no.tornado:tornadofx:1.7.20` dependency (no release since 2021) called out as a JDK-21 compatibility risk in #27.
- `NestlinApplication` now extends `javafx.application.Application` directly. TornadoFX was only used as a shallow superclass — no DSL, `View`, `Fragment`, `EventBus`, `find<>` or `FX.*` was in use anywhere in the codebase.
- Updates the dependency line in `CLAUDE.md` to reflect the change.

## Why plain JavaFX over Compose Desktop / other Kotlin UI frameworks
The UI surface is one `Canvas` + menu bar + a few `FileChooser`s + an `Alert`. The OpenJFX 21 plugin is already configured (`build.gradle.kts`), and every UI call site already uses raw JavaFX. A Compose port would be a full rewrite of `Application.kt` (`AnimationTimer`, `Platform.runLater`, threading model, canvas blit path) for zero functional gain.

## Test plan
- [x] `./gradlew build` — green (test suite included).
- [x] Runtime smoke: `./gradlew run --args="testroms/nestest.nes --screenshot-interval 2 --screenshot-duration 4"` — JavaFX window launches, audio device opens, gamepad initialises, automated screenshot timer fires, `handleExit()` shuts everything down cleanly. Pre-existing `UnhandledOpcodeException` for unofficial NOP `0x04` was observed during nestest's GUI-launch path; this is a CPU coverage gap unrelated to the UI swap and will be filed separately.

Closes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)