### PR TITLE
chore: make AI context portable across providers

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
Makes this project's AI agent context portable across providers.

Buildmesh added the following as **symlinks** so non-Claude agents (Codex, OpenCode, Antigravity) read the same context Claude Code uses:

- `AGENTS.md` → `CLAUDE.md` (the cross-tool open standard read by Codex, OpenCode and Antigravity)
- `.agents/skills` → `.claude/skills` (shared Agent Skills directory; Antigravity reads `.agents/skills` natively)

⚠️ These are git symlinks. Checked out on **Windows without Developer Mode**, git materialises them as plain text files containing the target path rather than working symlinks. On macOS, Linux, or Windows with Developer Mode they resolve correctly.

🤖 Generated with [Buildmesh]