### PR TITLE
Fix CI release build artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build uberJar
-        run: ./gradlew uberJar
+        run: ./gradlew shadowJar
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -31,7 +31,7 @@ jobs:
           tag_name: v${{ inputs.version }}
           release_name: Nestlin v${{ inputs.version }}
           draft: true
-          artifacts: build/libs/nestlin-standalone.jar
+          artifacts: build/libs/nestlin-all.jar
           artifact_errors: fail
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("jvm") version "1.9.22"
     application
     id("org.openjfx.javafxplugin") version "0.1.0"
+    id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
 repositories {
@@ -90,6 +91,11 @@ tasks.test {
     auxiliaryTests.forEach { testClass ->
         exclude("**/${testClass.replace('.', '/')}.class")
     }
+}
+
+tasks.register<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("uberJar") {
+    archiveBaseName.set("nestlin-standalone")
+    archiveClassifier.set("")
 }
 
 // Separate task to run Mesen comparison tests only when explicitly invoked


### PR DESCRIPTION
The Build Release workflow was failing because:
- It tried to run a custom uberJar task that didn't exist
- It referenced 
estlin-standalone.jar which was an empty stub

Changes:
- Use shadowJar task (provided by Shadow plugin) which produces 
estlin-all.jar (12.94 MB fat JAR with all dependencies)
- Updated workflow to use correct artifact path

Fixes the issue where no artifact was uploaded to releases.