### PR TITLE
fix(ci): make Build Release produce a downloadable runnable JAR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # softprops/action-gh-release needs write access to create the release.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -23,15 +26,15 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build uberJar
-        run: ./gradlew shadowJar
+        run: ./gradlew uberJar
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ inputs.version }}
-          release_name: Nestlin v${{ inputs.version }}
+          name: Nestlin v${{ inputs.version }}
           draft: true
-          artifacts: build/libs/nestlin-all.jar
-          artifact_errors: fail
+          files: build/libs/nestlin-all.jar
+          fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,14 +26,19 @@ application {
     mainClass.set("com.github.alondero.nestlin.ui.ApplicationKt")
 }
 
+// The built-in shadowJar IS the runnable fat JAR. The application plugin makes
+// the shadow plugin set Main-Class from application.mainClass automatically.
+// archiveFileName pins the output to build/libs/nestlin-all.jar regardless of
+// version/classifier, so the release workflow has a stable path to attach.
 tasks.named<ShadowJar>("shadowJar") {
-    archiveClassifier.set("standalone")
+    archiveFileName.set("nestlin-all.jar")
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    archiveBaseName.set("nestlin")
 }
 
+// Friendly alias so `./gradlew uberJar` still works for humans and the CI step.
 tasks.register("uberJar") {
     group = "build"
+    description = "Builds the standalone runnable fat JAR (build/libs/nestlin-all.jar)"
     dependsOn("shadowJar")
 }
 
@@ -105,11 +110,6 @@ tasks.test {
     auxiliaryTests.forEach { testClass ->
         exclude("**/${testClass.replace('.', '/')}.class")
     }
-}
-
-tasks.register<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("uberJar") {
-    archiveBaseName.set("nestlin-standalone")
-    archiveClassifier.set("")
 }
 
 // Separate task to run Mesen comparison tests only when explicitly invoked


### PR DESCRIPTION
## Problem

The **Build Release** workflow ([failing run](https://github.com/alondero/nestlin/actions/runs/26708312035/job/78713712708)) fails before producing any artifact:

> Cannot add task 'uberJar' as a task with that name already exists.

`build.gradle.kts` registered `uberJar` **twice** — a plain alias *and* a second `ShadowJar` task. Behind that were two more latent bugs that would have surfaced next:

1. The configured `shadowJar` used `archiveClassifier = "standalone"`, emitting `nestlin-standalone.jar`, but the workflow attaches `build/libs/nestlin-all.jar` — a path mismatch.
2. The release step passed inputs that **don't exist** on `softprops/action-gh-release@v2` (`release_name`, `artifacts`, `artifact_errors`), so it could never attach the JAR.

## Fix

- **build.gradle.kts**: consolidate to a single fat JAR. The built-in `shadowJar` is pinned to `build/libs/nestlin-all.jar` via `archiveFileName`; `uberJar` remains only as a friendly alias depending on it. Removes the conflicting registration.
- **build.yml**: correct the softprops inputs (`name`, `files`, `fail_on_unmatched_files`), add `permissions: contents: write`, and run `./gradlew uberJar` to match the step name.

## Verification

`./gradlew uberJar` is **green** locally and produces `build/libs/nestlin-all.jar` (16.6 MB) with `Main-Class: com.github.alondero.nestlin.ui.ApplicationKt`. The app uses the launcher-wrapper pattern (`main()` calls `Application.launch(...)`), so a classpath fat JAR runs without the "JavaFX runtime components are missing" error.

## Caveat

`org.openjfx.javafxplugin` bundles JavaFX **natives for the build platform only**. Built on the Linux CI runner, the JAR is runnable on Linux; Windows/macOS users would need their own JavaFX natives. Producing per-OS artifacts is out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)