### PR TITLE
fix: pixel-perfect nearest-neighbor scaling via Canvas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ An NES emulator written in Kotlin for learning purposes. The emulator simulates 
 - **JInputNatives.kt** - JInput native library loader for controller support
 
 ### UI & Testing
-- **ui/Application.kt** - JavaFX UI with 256×240 canvas and File menu (Load Game, Hard Reset, Exit)
+- **ui/Application.kt** - JavaFX UI with Canvas-based nearest-neighbor scaling (see `knowledge/javafx-pixel-scaling.md`), scale modes (1x-4x, Fit), fullscreen, and menus
 - **GoldenLogTest.kt** - Validates CPU execution against nestest.log golden output
 - **testroms/** - Test ROMs (nestest.nes for CPU validation)
 

--- a/knowledge/javafx-pixel-scaling.md
+++ b/knowledge/javafx-pixel-scaling.md
@@ -1,0 +1,39 @@
+# JavaFX Pixel-Perfect Scaling (Nearest-Neighbor)
+
+## Problem
+`ImageView.isSmooth = false` is **unreliable on the Windows Direct3D pipeline** in JavaFX.
+The D3D renderer applies bilinear filtering regardless of the `isSmooth` property, producing
+soft/blurry output when scaling pixel art.
+
+This was discovered when the display scale options (1x-4x, Fit) were added to Nestlin —
+all scaled output appeared "soft" despite `isSmooth = false` being set.
+
+## Solution
+Use `Canvas` + `GraphicsContext.isImageSmoothing = false` instead of `ImageView`.
+
+```kotlin
+// ✗ UNRELIABLE on Windows D3D:
+val imageView = ImageView(frameImage).apply { isSmooth = false }
+imageView.fitWidth = 256.0 * scale
+imageView.fitHeight = 240.0 * scale
+
+// ✓ RELIABLE on all pipelines (D3D, OpenGL, Software) since JavaFX 12:
+val canvas = Canvas(256.0 * scale, 240.0 * scale)
+val gc = canvas.graphicsContext2D.apply { isImageSmoothing = false }
+gc.drawImage(frameImage, 0.0, 0.0, canvas.width, canvas.height)
+```
+
+## Tradeoffs
+- Canvas maintains its own backing buffer at the target resolution (slightly more memory)
+- `gc.drawImage` re-rasterizes each frame (slightly more CPU than a GPU texture blit)
+- Both costs are negligible for NES-resolution content (256×240)
+
+## JavaFX Rendering Pipelines
+- **D3D** — Windows default. `ImageView.isSmooth` is NOT honored.
+- **OpenGL** (`-Dprism.order=es2`) — Second-class on Windows, may have other glitches.
+- **Software** (`-Dprism.order=sw`) — Always works but slow.
+- **No Vulkan backend** exists in JavaFX as of version 21.
+
+## Key Takeaway
+For any pixel-art or nearest-neighbor scaling in JavaFX, always use
+`Canvas.GraphicsContext.isImageSmoothing` — never rely on `ImageView.isSmooth`.

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
@@ -36,8 +36,6 @@ import javax.sound.sampled.DataLine
 import javax.sound.sampled.SourceDataLine
 import kotlin.concurrent.thread
 
-const val DISPLAY_SCALE = 4  // 4x magnification for debugging (legacy constant, kept for compatibility)
-
 // Periodic SRAM flush interval. 10s matches RetroArch's default and means a crash
 // loses at most ~10s of in-game saves. Skipped when batteryDirty is false (no cost).
 private const val BATTERY_FLUSH_INTERVAL_MS = 10_000L

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
@@ -19,7 +19,7 @@ import javafx.scene.control.Menu
 import javafx.scene.control.MenuBar
 import javafx.scene.control.MenuItem
 import com.github.alondero.nestlin.Region
-import javafx.scene.image.ImageView
+import javafx.scene.canvas.Canvas
 import javafx.scene.image.PixelFormat
 import javafx.scene.image.WritableImage
 import javafx.scene.image.Image
@@ -36,7 +36,7 @@ import javax.sound.sampled.DataLine
 import javax.sound.sampled.SourceDataLine
 import kotlin.concurrent.thread
 
-const val DISPLAY_SCALE = 4  // 4x magnification for debugging
+const val DISPLAY_SCALE = 4  // 4x magnification for debugging (legacy constant, kept for compatibility)
 
 // Periodic SRAM flush interval. 10s matches RetroArch's default and means a crash
 // loses at most ~10s of in-game saves. Skipped when batteryDirty is false (no cost).
@@ -48,20 +48,22 @@ fun main(args: Array<String>) {
 
 class NestlinApplication : FrameListener, Application() {
     private lateinit var stage: Stage
-    // Native-resolution backing image; the ImageView's fitWidth/fitHeight drives upscaling.
-    // isSmooth=false selects nearest-neighbor when stretching to the fit-rect, giving crisp
-    // pixel-art edges. (Note: smooth is honored only on the fitWidth/fitHeight path, NOT on
-    // scene-graph scaleX/scaleY transforms — that's why we drive size via fitWidth, not scale.)
+    // Native-resolution backing image written to by the PPU each frame.
     private val frameImage = WritableImage(RESOLUTION_WIDTH, RESOLUTION_HEIGHT)
-    private val imageView = ImageView(frameImage).apply { isSmooth = false }
-    // Group wraps the view so its bounds participate normally in StackPane sizing.
-    private val canvasGroup = Group(imageView)
+    // Canvas + GraphicsContext for pixel-perfect nearest-neighbor upscaling.
+    // JavaFX's ImageView.isSmooth is unreliable on the Windows D3D pipeline (bilinear
+    // filtering is applied regardless). Canvas.GraphicsContext.isImageSmoothing is
+    // reliably honored across all pipelines since JavaFX 12.
+    private val canvas = Canvas((RESOLUTION_WIDTH * 3).toDouble(), (RESOLUTION_HEIGHT * 3).toDouble())
+    private val gc = canvas.graphicsContext2D.apply { isImageSmoothing = false }
+    // Group wraps the canvas so its bounds participate normally in StackPane sizing.
+    private val canvasGroup = Group(canvas)
     private val canvasHolder = StackPane(canvasGroup)
     private var nestlin = Nestlin().also { it.addFrameListener(this) }
     // Hold-Tab fast-forward: disables throttling while held, restores it on release.
     private val fastForward = FastForwardController(nestlin.config)
     // On-screen fast-forward indicator. A scene-graph node (not pixels drawn into frameImage)
-    // so it stays a crisp 16px regardless of the ImageView upscale factor. Gold glyph with a
+    // so it stays a crisp 16px regardless of the canvas upscale factor. Gold glyph with a
     // black outline stays legible over both light and dark scenes. Toggled by the render loop.
     private val fastForwardIndicator = javafx.scene.text.Text(">>").apply {
         font = javafx.scene.text.Font.font("Monospaced", javafx.scene.text.FontWeight.BOLD, 16.0)
@@ -362,10 +364,14 @@ class NestlinApplication : FrameListener, Application() {
                 val pixelWriter = frameImage.pixelWriter
                 val pixelFormat = PixelFormat.getByteRgbInstance()
 
-                // Thread-safe read of frame buffer (native NES resolution; ImageView fit-rect handles upscaling)
+                // Thread-safe read of frame buffer (native NES resolution)
                 synchronized(frameBufferLock) {
                     pixelWriter.setPixels(0, 0, RESOLUTION_WIDTH, RESOLUTION_HEIGHT, pixelFormat, nextFrame, 0, RESOLUTION_WIDTH * 3)
                 }
+
+                // Draw the native-resolution image onto the canvas at scaled size.
+                // gc.isImageSmoothing = false guarantees nearest-neighbor interpolation.
+                gc.drawImage(frameImage, 0.0, 0.0, canvas.width, canvas.height)
 
                 // Show/hide the fast-forward indicator. It's a StackPane-overlaid scene node,
                 // so toggling visibility is all that's needed — no per-frame drawing.
@@ -554,12 +560,12 @@ class NestlinApplication : FrameListener, Application() {
     private fun applyScale(mode: ScaleMode) {
         val factor = mode.factor()
         // Drop any previous binding before swapping mode to avoid leaking listeners.
-        imageView.fitWidthProperty().unbind()
-        imageView.fitHeightProperty().unbind()
+        canvas.widthProperty().unbind()
+        canvas.heightProperty().unbind()
         if (factor != null) {
-            imageView.fitWidth = (RESOLUTION_WIDTH * factor).toDouble()
-            imageView.fitHeight = (RESOLUTION_HEIGHT * factor).toDouble()
-            // Resize the window to the view's natural extent unless fullscreen owns it.
+            canvas.width = (RESOLUTION_WIDTH * factor).toDouble()
+            canvas.height = (RESOLUTION_HEIGHT * factor).toDouble()
+            // Resize the window to the canvas's natural extent unless fullscreen owns it.
             if (!stage.isFullScreen) {
                 stage.sizeToScene()
             }
@@ -567,11 +573,11 @@ class NestlinApplication : FrameListener, Application() {
             // Fit: seed the window at 3x when entering Fit while windowed, so the user
             // always gets a usable starting size before the binding takes over.
             if (!stage.isFullScreen) {
-                imageView.fitWidth = (RESOLUTION_WIDTH * 3).toDouble()
-                imageView.fitHeight = (RESOLUTION_HEIGHT * 3).toDouble()
+                canvas.width = (RESOLUTION_WIDTH * 3).toDouble()
+                canvas.height = (RESOLUTION_HEIGHT * 3).toDouble()
                 stage.sizeToScene()
             }
-            // Then bind fit-rect to live holder dimensions, preserving aspect ratio.
+            // Then bind canvas size to live holder dimensions, preserving aspect ratio.
             // Computed as an integer-or-fractional scale factor, then multiplied back out to
             // pixel dimensions — keeps the aspect ratio locked to 256:240 regardless of
             // window letterboxing.
@@ -584,8 +590,8 @@ class NestlinApplication : FrameListener, Application() {
                 canvasHolder.heightProperty()
             )
             val fitFactor = javafx.beans.binding.Bindings.min(widthFactor, heightFactor)
-            imageView.fitWidthProperty().bind(fitFactor.multiply(RESOLUTION_WIDTH.toDouble()))
-            imageView.fitHeightProperty().bind(fitFactor.multiply(RESOLUTION_HEIGHT.toDouble()))
+            canvas.widthProperty().bind(fitFactor.multiply(RESOLUTION_WIDTH.toDouble()))
+            canvas.heightProperty().bind(fitFactor.multiply(RESOLUTION_HEIGHT.toDouble()))
         }
     }
 


### PR DESCRIPTION
## Problem

Scaled output appeared soft/blurry at all scale factors (1x-4x, Fit). The `ImageView.isSmooth = false` property was set correctly, but **JavaFX's D3D pipeline on Windows ignores it** and always applies bilinear filtering.

## Root Cause

The Windows Direct3D rendering pipeline in JavaFX hardcodes the texture sampler to bilinear interpolation regardless of the `ImageView.isSmooth` property. This is a known long-standing issue with the D3D backend.

## Fix

Replace `ImageView` with `Canvas` + `GraphicsContext.isImageSmoothing = false`, which **is reliably honored** across all JavaFX rendering pipelines (D3D, OpenGL, Software) since JavaFX 12.

### Changes
- Replace `ImageView` with `Canvas` in `NestlinApplication`
- Use `gc.drawImage()` in AnimationTimer for per-frame rendering
- `applyScale()` now resizes canvas dimensions instead of fitWidth/fitHeight
- Fit mode binds canvas size to holder with aspect ratio preservation
- Add `knowledge/javafx-pixel-scaling.md` documenting the finding
- Update `CLAUDE.md` UI section

## Testing
- Compiled successfully
- All tests pass
- Manually verified crisp pixel output at all scale modes (1x, 2x, 3x, 4x, Fit)