### PR TITLE
docs: refresh CLAUDE.md and README to match current project state (closes #19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,319 +1,98 @@
-# Nestlin - NES Emulator in Kotlin
+# Nestlin — NES Emulator (Kotlin)
 
-## Project Overview
-An NES emulator written in Kotlin for learning purposes. The emulator simulates the Nintendo Entertainment System's CPU (Ricoh 2A03), PPU (Picture Processing Unit), and APU (Audio Processing Unit).
+Personal learning project. 6502 CPU + 2C02 PPU + 2A03 APU. JavaFX 21 UI, Mesen2 as reference oracle.
 
-## Common Commands
+## Build / Test / Run
 
 ```bash
-# Build the project
+# Build (produces runnable JAR via shadowJar at build/libs/nestlin-all.jar)
 ./gradlew build
 
-# Run tests
+# Run the unit-test suite (CPU, PPU, APU, mapper, region tests)
 ./gradlew test
 
-# Run a specific test
-./gradlew test --tests GoldenLogTest
+# Run the Mesen2-comparison suite (needs Mesen2 on disk — see CLAUDE.local.md)
+./gradlew testMesenComparison
 
-# Run the emulator with a ROM
-./gradlew run --args="testroms/nestest.nes"
+# Run the emulator UI
+./gradlew run --args="path/to/rom.nes"
 
-# Run with debug logging
-./gradlew run --args="testroms/nestest.nes --debug"
-
-# Clean build artifacts
-./gradlew clean
+# Optional flags on the run command
+./gradlew run --args="rom.nes --debug"             # verbose CPU logging
+./gradlew run --args="rom.nes --region=pal"        # override NTSC/PAL auto-detect
+./gradlew run --args="rom.nes --no-audio"          # mute audio
 ```
 
-## Architecture & File Locations
+**Requirements:** JDK 21 (Gradle toolchain pinned in `build.gradle.kts`), Kotlin 1.9.22, JavaFX 21.0.1.
 
-### Core Components
-- **Nestlin.kt** - Main emulator orchestration (CPU:PPU:APU tick ratio is 1:3:1)
-- **cpu/Cpu.kt** - 6502 CPU implementation with registers and processor status
-- **cpu/Opcodes.kt** - 6502 opcode implementations (151 opcodes including unofficial, 604 pages)
-- **ppu/Ppu.kt** - Picture Processing Unit with full background/sprite rendering (~590 lines)
-- **ppu/PpuAddressedMemory.kt** - PPU registers ($2000-$2007) and VRAM addressing
-- **Memory.kt** - CPU memory map with proper mirroring
-- **gamepak/GamePak.kt** - ROM loading and iNES format parsing
-- **gamepak/Header.kt** - iNES header parsing including NO-INTRO ROM name detection
-- **Apu.kt** - Audio Processing Unit with 5 channels (Pulse×2, Triangle, Noise, DMC)
+## File Layout
 
-### Audio Channels (apu/)
-- **PulseChannel.kt** - Pulse wave generator (×2 channels)
-- **TriangleChannel.kt** - Triangle wave generator
-- **NoiseChannel.kt** - Pseudo-random noise generator
-- **DmcChannel.kt** - Delta modulation channel
-- **FrameCounter.kt** - APU frame sequencer
-- **Envelope.kt** - Volume envelope generator
-- **Sweep.kt** - Pulse sweep unit
-- **LengthCounter.kt** - Sound length counter
-- **AudioBuffer.kt** - Circular audio sample buffer
-- **AudioResampler.kt** - Linear resampling for consistent audio rate
-
-### Input (input/)
-- **GamepadInput.kt** - Gamepad/controller input handling
-- **InputConfig.kt** - Input configuration
-- **JInputNatives.kt** - JInput native library loader for controller support
-
-### UI & Testing
-- **ui/Application.kt** - JavaFX UI with Canvas-based nearest-neighbor scaling (see `knowledge/javafx-pixel-scaling.md`), scale modes (1x-4x, Fit), fullscreen, and menus
-- **GoldenLogTest.kt** - Validates CPU execution against nestest.log golden output
-- **testroms/** - Test ROMs (nestest.nes for CPU validation)
-
-### Developer Tools
-- **dump_analyzer.py** - Parse 64KB NES CPU memory dumps (`.dmp` files) and query memory regions, registers, I/O state. Run from project root:
-  ```python
-  from dump_analyzer import parse_dump, analyze_multiple_dumps
-  a = parse_dump("kirbyframe3-cpumem.dmp")
-  a.cpu.summary()       # PC, SP, A, X, Y, P registers
-  a.ppu.as_dict()       # PPU registers $2000-$2007
-  a.apu.summary()       # APU registers $4000-$401F
-  a.hexdump_region(0x6000, 0x6100)  # hex view of any address range
-  ```
-  Memory map: `$0000-$07FF` RAM, `$2000-$2007` PPU, `$4000-$401F` APU/I/O, `$8000-$FFFF` PRG ROM.
-
-## NES Architecture Essentials
-
-### Timing
-- CPU runs at 1.79 MHz (~559 ns per cycle)
-- PPU runs 3x faster than CPU (3 PPU cycles per CPU cycle)
-- Each frame = 262 scanlines × 341 cycles = 89,342 PPU cycles
-- Runs at ~60 FPS (NTSC)
-
-### Memory Maps
-
-**CPU Address Space ($0000-$FFFF)**
-- `$0000-$07FF`: 2KB internal RAM (mirrored to $1FFF)
-- `$2000-$2007`: PPU registers (mirrored to $3FFF)
-- `$4000-$4017`: APU and I/O registers
-- `$4020-$FFFF`: Cartridge space (PRG ROM)
-- `$FFFC-$FFFD`: Reset vector (program start address)
-
-**PPU Address Space ($0000-$3FFF)**
-- `$0000-$1FFF`: Pattern tables (CHR ROM - tile graphics)
-- `$2000-$2FFF`: Nametables (4×1KB background maps)
-- `$3F00-$3F1F`: Palette RAM (colors)
-
-### PPU Rendering Phases (per scanline)
-1. **Cycles 1-256**: Visible scanline - fetch tiles and render pixels
-2. **Cycles 257-320**: Sprite evaluation for next scanline
-3. **Cycles 321-336**: Fetch first 2 tiles for next scanline
-4. **Cycles 337-340**: Unused fetches
-
-Each tile fetch takes 8 cycles (4 memory accesses × 2 cycles each):
-- Nametable byte (which tile)
-- Attribute table byte (palette/color)
-- Pattern table low byte (pixel bitmap bit 0)
-- Pattern table high byte (pixel bitmap bit 1)
-
-### PPU Registers (VRAM Address)
-The 15-bit VRAM address register has this structure:
 ```
-yyy NN YYYYY XXXXX
-||| || ||||| +++++-- coarse X scroll (0-31)
-||| || +++++-------- coarse Y scroll (0-29)
-||| |+-------------- horizontal nametable select
-||| +--------------- vertical nametable select
-+++----------------- fine Y scroll (0-7)
+src/main/kotlin/com/github/alondero/nestlin/
+├── Nestlin.kt              # top-level orchestrator; stepCpuCycle() is the test seam
+├── EmulatorConfig.kt       # user-tweakable runtime flags (throttle, pause, region)
+├── Region.kt               # NTSC vs PAL timing constants — single source of truth
+├── Memory.kt               # CPU bus: RAM, PPU regs, APU regs, mapper dispatch
+├── Controller.kt           # $4016/$4017 + gamepad state
+├── Apu.kt                  # 5 channels + frame counter + mixer
+├── SaveState.kt            # .nstl binary format
+├── SaveRam.kt              # .sav battery-backed PRG-RAM persistence
+├── cpu/                    # 6502 core + 151 opcodes + addressing modes
+├── ppu/                    # 2C02: rendering, OAM, palette, vram address, regs
+├── apu/                    # channels, envelope, sweep, length, frame counter, resampler
+├── gamepak/                # iNES header + Mapper0..69 dispatch (see MAPPER_SUPPORT.md)
+├── input/                  # keyboard + JInput gamepad (config at ~/.config/nestlin/input.json)
+├── ui/                     # JavaFX Application (Canvas-based nearest-neighbour scaling), menus, scaling, fast-forward, screenshots
+├── file/                   # .nes + .7z loading
+└── log/                    # CPU trace logger
+
+src/test/kotlin/.../compare/  # Mesen2 oracle tests (state diff, not pixels) — see docs/TESTING_STRATEGY.md
+testroms/                    # nestest.nes is the only ROM in git
 ```
 
-## Code Style & Conventions
+## Conventions
 
-### Kotlin Guidelines
-- Use `data class` for simple structs (Registers, ProcessorStatus)
-- Extension functions for bit operations (isBitSet, clearBit, letBit)
-- Operator overloading for memory access (`memory[addr]`)
-- When/ranges for memory mapping (`in 0x0000..0x1FFF`)
+- **Kotlin idiom:** `data class` for value types, extension functions for bit ops (`isBitSet`, `clearBit`), operator overloading for memory (`memory[addr]`), `when/ranges` for memory mapping.
+- **Unsigned handling:** Kotlin's lack of unsigned primitives means `and 0xFF` / `and 0xFFFF` after arithmetic; use `Byte.toUnsignedInt()` when widening.
+- **Subsystem ownership:** CPU, PPU, APU, mapper each own their own `saveState`/`loadState`. `SaveState` orchestrates — never reach into a subsystem's internals.
+- **Testing:** JUnit 4 + Hamkrest. **Default to state diff, not pixel diffs** (see `docs/TESTING_STRATEGY.md`). For bugs: write the failing test first, see it fail, fix, see it pass.
+- **Memory mirroring** is encoded as a `when` over the address — see `Memory.kt` for the canonical example.
+- **Bugs always get a regression test, even pre-existing ones** (per global CLAUDE.md).
 
-### Naming Conventions
-- CPU opcodes use descriptive names: `branchOp`, `storeOp`, `addToA`
-- Addressing modes suffixed: `indirectX()`, `zeroPaged()`, `absoluteAdr()`
-- PPU timing constants: `PRE_RENDER_SCANLINE`, `POST_RENDER_SCANLINE`
+## Current Status (2026-06)
 
-### Unsigned Integer Handling
-Kotlin doesn't have unsigned primitives (pre-1.3), so use extension functions:
-- `Byte.toUnsignedInt()` - Convert signed byte to 0-255 range
-- `Short.toSignedShort()` / `Int.toSignedByte()` - Safe conversions
-- Always mask with `and 0xFF` or `and 0xFFFF` after arithmetic
+**Working:**
+- CPU: all 151 opcodes including unofficial; `GoldenLogTest` is the regression bar.
+- PPU: full background + sprite rendering, sprite-0 hit, 8x16 sprites, A12 edge to mapper.
+- APU: 5 channels (Pulse×2, Triangle, Noise, DMC), PAL/NTSC tables, mixer.
+- Mappers: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 34, 69.** Details + per-mapper game coverage in `MAPPER_SUPPORT.md`.
+- Region: NTSC + PAL auto-detect (iNES header → NO-INTRO filename → user override).
+- Save state (`.nstl`, F5/F8 + menu) and save RAM (`.sav`, FCEUX-compatible).
+- Battery RAM persistence for mappers 1/4/5 (mappers with `$6000-$7FFF` PRG-RAM).
+- JavaFX UI: Canvas-based 1x/2x/3x/4x/Fit scaling, fullscreen (F11), hold-Tab fast-forward, pause (Ctrl+P), throttle toggle (Ctrl+T), screenshot (S), gamepad via JInput.
 
-## Current Implementation Status
+**Known limits:**
+- Mapper 5 is a stub — Castlevania III not yet playable (needs bank-select decode rewrite, fill mode, multiplier output, scanline IRQ).
+- Some mappers (5) lack audio expansion.
+- JInput native libs need platform-specific setup (documented in `CLAUDE.local.md`).
 
-### Working
-- CPU: 151 opcodes implemented (including unofficial opcodes) with proper addressing modes
-- Memory system with correct mirroring and open-bus behavior
-- ROM loading (iNES format, mapper 0)
-- Golden log test framework (validates CPU execution)
-- **Full PPU rendering**: Background with shift registers, attribute tables, palette indexing
-- **Full sprite rendering**: Sprite evaluation, 8-sprite-per-scanline limit, sprite 0 hit detection
-- **Full APU audio**: 5 channels (2 Pulse, Triangle, Noise, DMC) with proper mixing formulas
-- **Controller input**: $4016/$4017 implemented with strobe functionality
-- **Frame rate throttling**: Configurable speed throttling with toggle
-- **NTSC and PAL timing**: Region auto-detected from the iNES/NES 2.0 header and NO-INTRO filename, with a manual override (Emulation → Region menu, or `--region=pal|ntsc`). PAL uses 312 scanlines, 50 Hz, the 3.2:1 PPU:CPU ratio, and PAL APU frame-counter/noise/DMC tables. All region constants live in `Region.kt`; subsystems read them via `Nestlin.applyRegion()`. Covered by `RegionDetectionTest`, `RegionTimingTest`, `PalApuTimingTest`, and validated end-to-end by `KickOffPalSmokeTest` (Kick Off (Europe) auto-detects PAL and boots to a rendered screen — rendering on by frame 10, PPUMASK $FE) and `GimmickPalBootTest` (Mr. Gimmick (Europe) boots to a rendered image under PAL).
-- **Screenshot capture**: PNG screenshot saving with timestamp
-- **File menu**: Load Game, Hard Reset Game, and Exit via UI menu
-- **Window title**: Displays game name (NO-INTRO field or filename) or "Nestlin" when no game loaded
+## Testing Strategy (one-paragraph version)
 
-### Incomplete / Known Issues
-- **Only mapper 0**: No support for MMC1, MMC3, or other mappers
-- **CPU cycle timing**: Some opcodes may not have exact cycle counts
-- **JInput controller support**: Native libraries need platform-specific setup
+Read `docs/TESTING_STRATEGY.md` before adding tests. The pyramid, top to bottom:
 
-## Testing Procedures
+1. **Structured state diff** against Mesen2 — `Mesen2StateCapturer` → JSON of CPU/PPU/RAM/OAM/palette; byte-compare with `StateComparator`. This is the workhorse. `Mapper10RegressionTest` is the worked example.
+2. **Hook-based behaviour assertions** — `emu.addMemoryCallback` for cycle-sensitive bugs (MMC3 A12, NMI counts, `$2002` polling).
+3. **Pixel diffs are a last resort** — `ScreenshotComparisonTest` exists but tells you *nothing about why*. Don't add new pixel-diff cases.
+4. **Anti-patterns:** `assumeTrue(mesen2Available)` silent skips; dumping files to `build/` expecting eyeballs; reflection into private `Cpu`/`Ppu` fields. Each false-greens CI or breaks on rename.
 
-### Running the Golden Log Test
-The test compares CPU execution against a known-good log from nestest.nes:
+## Local-only context
 
-```bash
-./gradlew test --tests GoldenLogTest
-```
+- Per-machine ROM/emu paths, env vars, and worktree quirks live in `CLAUDE.local.md` (gitignored). Read it on first session.
 
-The test will fail when it encounters:
-1. An unimplemented opcode (UnhandledOpcodeException)
-2. A register mismatch (PC, A, X, Y, P, SP)
-3. A flag discrepancy (zero, carry, negative, overflow)
+## Common gotchas
 
-**Test ROM Details:**
-- Located at: `testroms/nestest.nes`
-- Expected output: `src/test/resources/nestest.log`
-- Runs in "automation mode" starting at $C000 instead of reset vector
-- CRC32: 0x9e179d92
-
-### Adding New Opcodes
-1. Add to `Opcodes` map in init block (Opcodes.kt)
-2. Use helper functions: `branchOp`, `storeOp`, `load`, `opWithA`, etc.
-3. Set correct `workCyclesLeft` (check 6502 reference)
-4. Run golden log test to verify
-
-### Cross-Emulator Regression Testing
-
-**Read `docs/TESTING_STRATEGY.md` first.** It defines the test pyramid Nestlin
-follows, with explicit recipes per bug symptom in Section 6. The summary:
-
-**Default to structured-state comparison, not pixel diffs.** Mesen2 exposes
-`emu.getState()`, `emu.read(addr, nesPpuMemory)`, `nesSpriteRam`,
-`nesSecondarySpriteRam`, `nesPaletteRam`, `nesNametableRam`, `nesChrRom`,
-`mapper.chrMemoryOffset*`. Byte-compare these between Nestlin and Mesen2 at a
-frame boundary — that's the workhorse layer. The infra is in
-`src/test/kotlin/.../compare/`:
-
-- `Mesen2StateCapturer` — Lua → JSON CPU/PPU/RAM/OAM/palette snapshot at frame N (headless `--testRunner`, ~0.5s).
-- `NestlinStateCapturer` — same shape, in-process.
-- `EmulatorStateSnapshot` + `StateComparator` — payload-agnostic diff.
-- `Mapper*.snapshot()` — per-mapper bank/register/IRQ state (extend it when adding a new mapper).
-
-**Hook-based behaviour assertions** are the structured replacement for
-"compare pixels and hope" on cycle-sensitive bugs (MMC3 A12, NMI counts,
-$2002 polling). Use `emu.addMemoryCallback(cb, "read", "nesPpuMemory", 0x1000, 0x1FFF, …)`.
-
-**Pixel diffs are the last resort.** `ScreenshotComparisonTest` exists and works:
-```bash
-./gradlew test --tests ScreenshotComparisonTest
-```
-but a passing pixel diff tells you nothing about *why* something is right, and a
-failing one buries the cause. Reach for it only when the bug is genuinely
-visual (palette glitch, raster effect) and you've already ruled out the structured
-levels. Don't add new pixel-diff cases — extend state diff coverage instead.
-
-**Anti-patterns to avoid** (see strategy doc §2.4):
-- `assumeTrue(mesen2Available)` silent skips (false-greens CI without the oracle).
-- Tests that dump files to `build/` expecting a human to eyeball them — these aren't regression tests, they're debugging aides; if you write one, mark it clearly and don't put it under `test/`.
-- Reflection into private `Cpu`/`Ppu` fields — break on rename. Expose a stable testing API instead.
-
-**When you find a bug, follow Section 6's recipe table** for the cheapest test
-that reproduces it. CHR-banking bugs are state diffs on `mapper.chrMemoryOffset*` and
-`nesChrRom` — not screenshots (see Star Soldier `Mapper3Test` /
-`StarSoldierMapper3RegressionTest` for the worked example).
-
-**Mesen2 setup:** `MESEN2_PATH` env var, or absolute fallback to
-`X:\src\nestlin\tools\Mesen2\Mesen.exe`. Local-only paths and gotchas live in
-`CLAUDE.local.md` and the `mesen2-capture-harness-gotchas-*` memory entry.
-
-## Development Workflow
-
-### Explore-Plan-Code Pattern
-When adding significant features (like PPU rendering):
-1. Read relevant files first without modifying
-2. Create implementation plan in this file or comments
-3. Implement incrementally with tests
-4. Verify against test ROMs
-
-### Branch Strategy
-- Feature branches: `feature/ppu-rendering`, `feature/mapper1`
-- Test after each logical unit (don't batch unrelated changes)
-- Keep commits atomic and descriptive
-
-## Important Warnings
-
-### PPU Implementation Details
-- **Shift registers shift every cycle**, but reload every 8 cycles
-- **Attribute table addressing**: Uses coarse X/Y scroll to select 2×2 tile quadrant
-- **Cycle timing is critical** - off-by-one errors cause visual glitches
-- **V-blank flag** must be set at exact cycle (241, cycle 1)
-- **Sprite evaluation** happens during cycles 257-320 for next scanline
-- **Pre-loading**: First two tiles pre-loaded at cycle 0 before rendering begins
-
-### CPU Edge Cases
-- **BRK vs IRQ**: B flag handling differs (see ProcessorStatus.asByte())
-- **JMP indirect bug**: 6502 has page boundary bug (see Opcodes.kt JMP indirect implementation)
-- **RTS increments PC**: Returns to address+1, not exact return address
-- **Decimal mode**: NES CPU ignores this flag (no BCD arithmetic)
-
-### Memory Mirroring
-- RAM mirrors every $0800 bytes
-- PPU registers mirror every 8 bytes
-- Nametables have complex mirroring (depends on cartridge)
-
-### iNES ROM Format
-- Standard iNES 1.0 ROMs: 16-byte header, no embedded ROM name
-- NO-INTRO format: 16-byte header + 128-byte ROM name field at offset 0x10 (only when byte 7 has bit 4/$10 set)
-- ROM files smaller than 144 bytes cannot have a NO-INTRO name field
-- Display name fallback uses filename (without .nes/.7z extension) when NO-INTRO name not present
-
-## Useful References
-- [NESdev Wiki](https://www.nesdev.org/wiki/) - Comprehensive NES documentation
-- [6502 Instruction Reference](http://www.6502.org/tutorials/6502opcodes.html) - Opcode details
-- [PPU Rendering](https://www.nesdev.org/wiki/PPU_rendering) - Scanline timing
-- [nestest.nes Guide](https://www.qmtpro.com/~nes/misc/nestest.txt) - Test ROM info
-
-## Environment Setup
-
-### Requirements
-- Kotlin 1.1.0
-- Gradle (wrapper included)
-- Java 8+ (for JavaFX)
-
-### Dependencies
-- kotlin-stdlib 1.1.0
-- JavaFX/OpenJFX (UI) via `org.openjfx.javafxplugin`
-- Apache Commons Compress (for .7z ROMs)
-- JUnit + Hamkrest (testing)
-
-### IDE Setup
-IntelliJ IDEA recommended:
-- Import as Gradle project
-- Kotlin plugin should auto-configure
-- Run configurations: point to Application.kt main()
-
-## Documentation Approach
-
-### Permanent Documentation (CLAUDE.md)
-Contains stable, enduring information:
-- Architecture and file locations
-- Code conventions and patterns
-- Build commands and environment setup
-- NES hardware fundamentals
-
-### Ephemeral Status (todo.md, knowledge/)
-Contains transient session state:
-- **todo.md** - Current focus, what's been tried, hypotheses, next steps
-- **knowledge/** - Novel discoveries and debugging findings
-
-**Rule:** Don't put transient status in CLAUDE.md. It bloat every session's context window. Use todo.md or knowledge/ instead.
-
-### Mapper Support (MAPPER_SUPPORT.md)
-Documents mapper compatibility status:
-- What mappers are implemented
-- Known issues per mapper
-- Test ROMs for each mapper
-
-When adding a new mapper, update MAPPER_SUPPORT.md.
+- **Gradle daemon may not inherit shell env vars** between invocations. If a test reports `SKIPPED` unexpectedly, `./gradlew --stop` then re-run. The `testMesenComparison` task explicitly forwards `MESEN2_PATH`.
+- **Save state semantics:** `performWithEmulationPaused` (in `Application.kt`) stops the emulation thread before serialising CPU/PPU/APU state. Don't bypass it from menu handlers.
+- **Cycle accounting:** every mapper IRQ either counts A12 edges (MMC3) or CPU cycles (FME-7) — never both. `Mapper.tickCpuCycle()` is the per-CPU-cycle hook; default no-op.
+- **PPU vblank latch:** `nmiOccurred` is cleared at the pre-render scanline AND on `$2002` read; games that poll `$2002` only at the wrong cadence (Gimmick!) used to deadlock — see `PpuAddressedMemory.clearVBlankAtPreRender` and `gimmick-nmi-prerender-latch-fix-2026-06-01`.
+- **Worktree scope:** when running inside `.claude/worktrees/<name>/`, the parent repo's `testroms/` and `tools/` are accessed via absolute paths in Kotlin/Lua; `.worktreeinclude` copies `CLAUDE.local.md` only.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,202 @@
 # Nestlin
 
-![Nestlin Logo](src/main/resources/images/nestlin-logo.png)
+![Nestlin logo](src/main/resources/images/nestlin-logo.png)
 
-An NES emulator written in Kotlin.
+A Nintendo Entertainment System emulator written in Kotlin. Personal learning project: full CPU, PPU, APU emulation, twelve mappers, NTSC + PAL timing, save states, battery-backed save RAM, and a Mesen2-driven state-diff regression suite.
 
-## Building
+> **What it is:** a from-scratch NES emulator — not a wrapper around libretro. Every cycle the PPU renders, the APU mixes, and the CPU executes is implemented in this codebase.
+>
+> **What it isn't:** production-grade. It's a hobby project; some peripherals and edge-case mapper behaviours remain unimplemented.
+
+---
+
+## Features
+
+- **6502 CPU** — all 151 documented + unofficial opcodes, validated against `nestest.nes` (`GoldenLogTest`).
+- **2C02 PPU** — background + sprite rendering, sprite-0 hit, 8×8 and 8×16 sprites, A12 edge exposed to mappers.
+- **2A03 APU** — 5 channels (Pulse ×2, Triangle, Noise, DMC), frame counter, NTSC + PAL period tables, host-rate resampling.
+- **12 mappers** — see *Supported mappers* below.
+- **NTSC and PAL** — auto-detected from the iNES/NES 2.0 header and the NO-INTRO filename, with a manual `--region=` override.
+- **Save states** (`.nstl`) and **battery-backed save RAM** (`.sav`, FCEUX/Mesen-compatible).
+- **Input** — configurable keyboard and gamepad (via JInput); default keymap written to `~/.config/nestlin/input.json` on first run.
+- **Display** — 1×/2×/3×/4× integer scale, Fit-to-window, fullscreen, nearest-neighbour pixel scaling.
+- **Quality-of-life** — hold-Tab fast-forward, pause, speed-throttle toggle, screenshot capture, recent-ROMs menu.
+
+---
+
+## Supported mappers
+
+| # | Name | Notes |
+|---|------|-------|
+| 0 | NROM | Donkey Kong, Super Mario Bros. |
+| 1 | MMC1 / SxROM | Tetris, Zelda (PRG-RAM + battery). |
+| 2 | CNROM / UNROM | Castlevania, Contra, Duck Hunt. |
+| 3 | CNROM | Star Soldier, Paperboy. |
+| 4 | MMC3 / TxROM | Mega Man 4-6, Kirby's Adventure (PRG-RAM + A12-IRQ + battery). |
+| 5 | MMC5 | **Stub** — Castlevania III not yet playable. |
+| 7 | AxROM | Marble Madness, Battletoads. |
+| 9 | MMC2 / PxROM | Mike Tyson's Punch-Out!! (CHR latches). |
+| 10 | MMC4 / FxROM | Fire Emblem Gaiden (CHR latches + PRG-RAM + battery). |
+| 11 | Color Dreams | Bible Adventures. |
+| 34 | BNROM / NINA-001 | Deadly Towers. |
+| 69 | Sunsoft FME-7 | Batman: Return of the Joker, Gimmick! (CPU-cycle-clocked IRQ). |
+
+For per-mapper game coverage, edge-case notes, and known issues, see **[`MAPPER_SUPPORT.md`](MAPPER_SUPPORT.md)**.
+
+---
+
+## Requirements
+
+- **JDK 21** (the Gradle toolchain pin will download it automatically if missing)
+- **Kotlin 1.9.22** (managed by Gradle)
+- A display server (X11 / Windows / macOS) — required by JavaFX
+- *(Optional, for cross-emulator regression tests)* **Mesen 2** at `MESEN2_PATH` (defaults to `tools/Mesen2/Mesen.exe`)
+
+---
+
+## Build & Run
 
 ```bash
+# Build the runnable fat JAR
 ./gradlew build
+
+# Run with a ROM
+./gradlew run --args="path/to/rom.nes"
 ```
 
-This produces a runnable distribution in `build/distributions/`.
+On Windows:
 
-## Running
-
-```bash
-# Run the emulator
-./build/distributions/nestlin/bin/nestlin path/to/rom.nes
-
-# Run tests
-./gradlew test
+```bat
+gradlew.bat build
+gradlew.bat run --args="path/to/rom.nes"
 ```
+
+Convenience wrapper that builds-then-runs: `./nestlin.sh path/to/rom.nes` (or `nestlin.bat` on Windows).
+
+The runnable fat JAR is at `build/libs/nestlin-all.jar` (built by `shadowJar`; the Gradle `application` plugin also produces `./gradlew installDist` → `build/install/nestlin/bin/nestlin` if you prefer the wrapper-script form).
+
+### Command-line flags
+
+| Flag | Purpose |
+|------|---------|
+| `--debug` | Verbose CPU instruction logging to stdout. |
+| `--region=pal\|ntsc` | Override the ROM's auto-detected region. |
+| `--no-audio` | Disable audio output. |
+| `--screenshot-interval N --screenshot-duration N` | Automated capture mode for validation harnesses. |
+
+### Supported ROM formats
+
+- `.nes` — iNES and NES 2.0 headers (NO-INTRO filenames are recognised for display + region).
+- `.7z` — 7-Zip archives (single-ROM); transparent to the rest of the pipeline.
+
+---
 
 ## Controls
 
-**Menu**
-- **File → Load Game...** (Ctrl+O): Load a new ROM
-- **File → Hard Reset Game** (Ctrl+R): Reload and restart the current ROM
-- **File → Exit** (Ctrl+Q): Exit the emulator
+### File menu
 
-**Keyboard**
-- **S**: Capture screenshot
-- **Ctrl+T**: Toggle frame rate throttling
+| Action | Description |
+|--------|-------------|
+| Load Game… | Open a `.nes` or `.7z`. |
+| Load Recent | Quick access to recently played ROMs. |
+| Hard Reset Game | Reload and power-cycle the current ROM. Preserves battery RAM. |
+| Save State… | Snapshot to a chosen `.nstl` file. |
+| Load State… | Restore from a `.nstl` file. |
+| Exit | Flush battery RAM and quit. |
 
-## Supported Formats
+### Settings
 
-- `.nes` - iNES ROM format
-- `.7z` - 7-Zip archives containing ROM files
-- **Mapper 0** (NROM) and **Mapper 1** (MMC1) supported
+| Action | Shortcut | Description |
+|--------|----------|-------------|
+| Speed Throttling (60 FPS) | Ctrl+T | Toggle wall-clock pacing. |
+| Scale | — | 1× / 2× / 3× / 4× / Fit-to-window. |
+| Fullscreen | F11 | Toggle fullscreen. |
+| Pause | Ctrl+P | Pause/resume emulation. |
 
-## Key Mappings
+### Emulation
 
-Key mappings are configurable in `~/.config/nestlin/input.json`
+| Action | Shortcut | Description |
+|--------|----------|-------------|
+| Quick Save State | F5 | Save to `savestates/<rom>.quick.nstl`. |
+| Quick Load State | F8 | Load the matching quick-save slot. |
+| Fast-Forward | hold Tab | Disable throttling while held. |
+| Screenshot | S | Save the current frame to `screenshots/`. |
+
+### Default keyboard mapping (NES gamepad)
+
+| NES | Keyboard |
+|-----|----------|
+| A | Z |
+| B | X |
+| Select | Space |
+| Start | Enter |
+| D-Pad | Arrow keys |
+
+Edit `~/.config/nestlin/input.json` to remap. The default file is written automatically on first run.
+
+### Gamepad
+
+Any controller JInput recognises works out of the box (Xbox layout by default). Edit the `gamepad` section of `~/.config/nestlin/input.json` for other layouts.
+
+---
+
+## Testing
+
+```bash
+# Fast suite (CPU/PPU/APU/mapper unit tests; ~minutes)
+./gradlew test
+
+# Cross-emulator suite (boots Mesen2 as an oracle; needs MESEN2_PATH)
+./gradlew testMesenComparison
+```
+
+The test strategy prefers **structured state diffs** (CPU regs, OAM, palette, mapper banks, CHR window) over pixel diffs. Pixels are a downstream, lossy view; a byte-equal state is a much stronger claim. Full reasoning lives in **[`docs/TESTING_STRATEGY.md`](docs/TESTING_STRATEGY.md)**.
+
+The CPU has a single gold-standard regression: **`GoldenLogTest`** runs `nestest.nes` in automation mode and byte-compares the trace against `src/test/resources/nestest.log`. New CPU work that breaks this test isn't ready to merge.
+
+---
+
+## Project structure
+
+| Path | What's there |
+|------|--------------|
+| `src/main/kotlin/.../cpu/` | 6502 core + 151 opcodes + addressing modes. |
+| `src/main/kotlin/.../ppu/` | 2C02 rendering pipeline, OAM, palette, register decode. |
+| `src/main/kotlin/.../apu/` | Channels, envelope, sweep, length counter, frame counter, resampler. |
+| `src/main/kotlin/.../gamepak/` | iNES parsing + per-mapper implementations. |
+| `src/main/kotlin/.../ui/` | JavaFX application, menus, scaling, fast-forward. |
+| `src/main/kotlin/.../input/` | Keyboard + JInput gamepad, JSON config. |
+| `src/test/kotlin/.../compare/` | Mesen2 oracle tests (state diff, not pixels). |
+| `docs/` | Strategy + historical design notes. |
+| `testroms/` | `nestest.nes` (the only ROM in git). |
+| `tools/` | Local-only emulators (not in git; see `CLAUDE.local.md`). |
+
+---
+
+## Documentation
+
+- **[`MAPPER_SUPPORT.md`](MAPPER_SUPPORT.md)** — which mappers are working, what games are known to play, and what each one's quirks are.
+- **[`docs/TESTING_STRATEGY.md`](docs/TESTING_STRATEGY.md)** — the test pyramid and how to add a new regression test the right way.
+- **[`docs/PPU_RENDERING_PLAN.md`](docs/PPU_RENDERING_PLAN.md)** — original design notes for background + sprite rendering.
+- **[`docs/DONKEY_KONG_RENDERING_PLAN.md`](docs/DONKEY_KONG_RENDERING_PLAN.md)** — milestone-by-milestone walkthrough of bringing up rendering on a real game.
+- **[`NES_REFERENCE_GUIDE_FINDINGS.md`](NES_REFERENCE_GUIDE_FINDINGS.md)** — distilled findings from the NESdev wiki and other reference material; the implementation's "why" notes.
+- **[`dump_analyzer.py`](dump_analyzer.py)** — parse 64KB CPU memory dumps (`.dmp`) from debug sessions and query them by region, register, or address. Useful for post-mortem debugging.
+
+---
+
+## Contributing
+
+This is a personal learning project, so the bar for "ready to merge" is mostly "the maintainer is happy with it." The minimum bar in practice:
+
+1. **Build is green** (`./gradlew build`).
+2. **Tests are green** (`./gradlew test`); add a failing test first for any bug you find.
+3. **No new `assumeTrue`-skipped tests** (see `docs/TESTING_STRATEGY.md` §2.4 — silent skips false-green CI).
+4. **Prefer state-diff regression tests over pixel-diff ones.**
+
+For new mappers, see the "Adding New Mappers" section of `MAPPER_SUPPORT.md`.
+
+---
+
+## License
+
+[MIT](LICENSE).


### PR DESCRIPTION
## Summary

Resolves #19. Doc-only refresh of the two top-level project docs to bring them in line with the codebase as it stands in 2026-06.

### CLAUDE.md — 360 → 97 lines (~73% smaller)

The previous version was a context-tax: every agent session loads it, but most of the NES reference material (timing diagrams, register layouts, opcode tables, iNES format) duplicates what's in the code comments and `NES_REFERENCE_GUIDE_FINDINGS.md`. Trimmed to what an agent actually needs to make changes confidently: build/test/run commands, file layout, conventions, current status, testing-strategy summary, local-only-context pointer, common gotchas.

**Removed stale claims:**
- Kotlin 1.1.0 → actually 1.9.22
- Java 8+ (for JavaFX) → actually 21 (Gradle toolchain pinned)
- "Only mapper 0" / "No support for MMC1, MMC3" → 12 mappers implemented (0, 1, 2, 3, 4, 5, 7, 9, 10, 11, 34, 69)
- "Ppu.kt ~590 lines" → 779
- "Opcodes.kt … 604 pages" → 957 lines
- "Some opcodes may not have exact cycle counts" → all 151 pass GoldenLogTest
- "File menu: Load Game, Hard Reset Game, and Exit" → now includes Save/Load State, Recent ROMs, full Settings, gamepad support

**Added:**
- `--region=`, `--debug`, `--no-audio`, `--screenshot-interval/--screenshot-duration` CLI flags
- Full default keymap (Z/X/Space/Enter/arrows) + gamepad config path
- F5/F8/Tab/F11/Ctrl+P/Ctrl+T shortcuts
- Pointers to `MAPPER_SUPPORT.md` and `docs/TESTING_STRATEGY.md`
- Test-strategy pyramid summary (state diff > hooks > pixel diffs)

### README.md — 1-sentence → 206 lines

The previous version was a wall, not a door. Expanded to:
- What it is and isn't (from-scratch NES emulator, hobby project, not libretro)
- Feature highlights (CPU, PPU, APU, mappers, region, save state, save RAM, input, display, QoL)
- Supported mappers table with one-line notes per mapper
- Requirements (JDK 21, Kotlin 1.9.22, display server, optional Mesen 2)
- Build & Run for both Linux/macOS and Windows
- Command-line flags table
- Supported ROM formats (`.nes` + `.7z`, NO-INTRO recognition)
- Full Controls tables: File menu / Settings / Emulation / keyboard / gamepad
- Testing instructions (fast suite + Mesen2 comparison suite)
- Project structure
- Documentation pointers (`MAPPER_SUPPORT.md`, `docs/TESTING_STRATEGY.md`, `docs/PPU_RENDERING_PLAN.md`, `docs/DONKEY_KONG_RENDERING_PLAN.md`, `NES_REFERENCE_GUIDE_FINDINGS.md`, `dump_analyzer.py`)
- Contributing bar (build green, tests green, no new `assumeTrue` skips, prefer state-diff over pixel-diff)
- MIT license

### Doc-review pass

After the first draft, a careful cross-check against `Application.kt`, the mapper Kotlin files, and `MAPPER_SUPPORT.md` caught:

- **Phantom shortcuts**: Ctrl+O (Load Game), Ctrl+R (Hard Reset), Ctrl+Q (Exit) — none are actually bound in `Application.kt` (only F11 and Ctrl+P have `setAccelerator` calls). Removed the Shortcut column for the File menu table.
- **Mislabeled mappers**: Mapper 2 `UxROM / CNROM` → `CNROM / UNROM`; Mapper 3 `CNROM (NINA-003)` → `CNROM`; Mapper 34 `BnROM / NINA-003 / BNROM variant` → `BNROM / NINA-001`. All three now match the mapper KDoc and `MAPPER_SUPPORT.md`.
- **JAR launch claim softened**: `java -jar build/libs/nestlin-all.jar` may not work cleanly on JavaFX 21 modular JARs; rewrote to point at the `shadowJar` output and call out `./gradlew installDist` → `build/install/nestlin/bin/nestlin` as the wrapper-script alternative.

## Verification

- `./gradlew compileKotlin compileTestKotlin` — green both before and after the doc-review fixes (doc-only changes can't break Kotlin).
- All 7 README cross-references resolve to real files.
- `git status` — clean working tree on `docs/claude-readme-accuracy`.

## Notes for reviewer

- This PR is docs-only — no source/test changes. Safe to review by reading the diff.
- Diff stat: `2 files changed, 299 insertions(+), 363 deletions(-)` (CLAUDE.md nets –263 lines, README.md nets +161 lines).
- No new memory entries added; the doc-rewrite patterns here are generic engineering hygiene, not project-specific knowledge worth encoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
