### PR TITLE
fix(repo): add .gitattributes to force text handling for source files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,42 @@
+# Force source/text files to be treated as text by Git.
+#
+# Git auto-detects binary vs text by scanning the first ~8KB of each file
+# for NUL bytes. A single stray U+0000 (e.g. an editor/paste accident) flips
+# a file to "binary" — which silently disables 3-way text merging and turns
+# otherwise auto-mergeable edits into "Cannot merge binary files" errors
+# during git merge/rebase/cherry-pick. See issue #106.
+#
+# These explicit `text` attributes override that content-sniffing heuristic,
+# so a rogue byte yields an immediate localized diff failure (and we notice
+# the offending file) rather than a confusing merge surprise later.
+
+# Kotlin — primary source language
+*.kt          text
+*.kts         text
+
+# Build scripts
+*.gradle      text
+build.gradle* text
+settings.gradle* text
+
+# Python tooling (dump_analyzer.py etc.)
+*.py          text
+
+# Lua scripts (Mesen2 harness, tracer scripts)
+*.lua         text
+
+# Docs
+*.md          text
+
+# Config
+*.json        text
+*.yml         text
+*.yaml        text
+*.toml        text
+
+# Shell / batch helpers
+*.sh          text eol=lf
+*.bat         text eol=crlf
+
+# GitHub Actions
+.github/**    text


### PR DESCRIPTION
## Summary

Closes #106.

Git auto-detects binary vs text by scanning the first ~8KB of each file for NUL bytes. A stray `U+0000` anywhere in a Kotlin source file flips it to "binary", which silently disables 3-way text merging. An otherwise auto-mergeable edit then becomes a confusing "Cannot merge binary files" error during `git merge`/`rebase`/`cherry-pick`, with no hint at the file or byte that caused it.

This PR adds a root-level `.gitattributes` that explicitly declares Nestlin's source-file types as `text`, so a rogue byte yields an immediate localized diff failure (and the offending file is obvious) rather than a merge surprise later.

## What it does

| Pattern | Attribute |
|---|---|
| `*.kt`, `*.kts` | `text` (primary Kotlin source) |
| `*.gradle`, `build.gradle*`, `settings.gradle*` | `text` (build scripts) |
| `*.py` | `text` (Python tooling) |
| `*.lua` | `text` (Mesen2 harness scripts) |
| `*.md` | `text` (docs) |
| `*.json`, `*.yml`, `*.yaml`, `*.toml` | `text` (config) |
| `*.sh` | `text eol=lf` |
| `*.bat` | `text eol=crlf` |
| `.github/**` | `text` (Actions workflows) |

The `eol=` directives on the shell/batch helpers match the existing line endings in those files; they take effect for *new* files added after this lands, and existing files in the index can be retrofitted with `git add --renormalize .` if desired.

## Verification

```sh
$ git check-attr -a -- \
    src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt \
    src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt \
    build.gradle.kts dump_analyzer.py .github/workflows/build.yml
src/main/kotlin/.../GamePak.kt: text: set
src/main/kotlin/.../Nestlin.kt:   text: set
build.gradle.kts:                  text: set
dump_analyzer.py:                  text: set
.github/workflows/build.yml:       text: set
```

`GamePak.kt` — the file from the original incident — now resolves to `text: set` regardless of any stray NUL bytes in its content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
