### PR TITLE
Add per-mapper saveState version byte (Issue #100)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/SaveState.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/SaveState.kt
@@ -11,7 +11,11 @@ import java.io.OutputStream
  * Save state file format ("NSTL"):
  *
  *   magic       4 bytes  "NSTL" (0x4E 0x53 0x54 0x4C)
- *   version     int      currently 1; bump on breaking format change
+ *   version     int      currently 2; bump on breaking format change.
+ *                        Version 2 added a per-mapper version byte inside the
+ *                        mapper block (see below) so individual mappers can
+ *                        evolve their own field order without invalidating
+ *                        sibling subsystems. Issue #100.
  *   romCrc      long     CRC32 of the loaded ROM at save time
  *   romMapper   int      mapper id (validated on load)
  *   cpu         block    written by Cpu.saveState
@@ -19,7 +23,10 @@ import java.io.OutputStream
  *   ppu         block    written by Ppu.saveState
  *   apu         block    written by Apu.saveState
  *   ctrl1/ctrl2 block    Controller.saveState x 2
- *   mapper      length-prefixed blob (4-byte int length + bytes from Mapper.saveState)
+ *   mapper      length-prefixed blob (4-byte int length + bytes from Mapper.saveState).
+ *               Inside the blob, the first byte is the mapper's per-mapper
+ *               saveState format version (see Mapper.saveStateVersion). A
+ *               mismatch raises IncompatibleSaveStateException on load.
  *
  * Endianness: big-endian (DataOutputStream default).
  *
@@ -28,7 +35,7 @@ import java.io.OutputStream
  */
 object SaveState {
     private const val MAGIC = 0x4E53544C  // "NSTL"
-    const val VERSION = 1
+    const val VERSION = 2
 
     class IncompatibleSaveStateException(message: String) : RuntimeException(message)
 

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper.kt
@@ -1,5 +1,6 @@
 package com.github.alondero.nestlin.gamepak
 
+import com.github.alondero.nestlin.SaveState
 import java.io.DataInput
 import java.io.DataOutput
 
@@ -23,9 +24,41 @@ interface Mapper {
     // State snapshot for debugging
     fun snapshot(): MapperStateSnapshot? = null
 
-    // Save state persistence. Default no-op for mappers that have no mutable state.
-    fun saveState(out: DataOutput) {}
-    fun loadState(input: DataInput) {}
+    /**
+     * Format version of this mapper's saveState block. Bump when fields are
+     * added, removed, or reordered — loadState rejects mismatches loudly
+     * instead of silently deserialising garbage. See Issue #100.
+     */
+    val saveStateVersion: Int get() = 1
+
+    /**
+     * Save state persistence. The default implementation writes a 1-byte
+     * per-mapper version stamp (see [saveStateVersion]) so every mapper block
+     * is uniformly versioned. Mappers with state override this method and
+     * MUST call `super.saveState(out)` first, then write their own fields.
+     */
+    fun saveState(out: DataOutput) {
+        out.writeByte(saveStateVersion)
+    }
+
+    /**
+     * Load state persistence. The default implementation reads the 1-byte
+     * per-mapper version stamp and rejects mismatches with
+     * [SaveState.IncompatibleSaveStateException]. Mappers with state override
+     * this method and MUST call `super.loadState(input)` first, then read
+     * their own fields.
+     */
+    fun loadState(input: DataInput) {
+        // readUnsignedByte so the comparison is sign-safe for versions 128..255.
+        // readByte().toInt() sign-extends, which would make 200 load as -56.
+        val version = input.readUnsignedByte().toInt()
+        if (version != saveStateVersion) {
+            throw SaveState.IncompatibleSaveStateException(
+                "${this::class.simpleName} save state version $version not supported " +
+                "(expected $saveStateVersion)"
+            )
+        }
+    }
 
     /** The cartridge's PRG-RAM ($6000-$7FFF) for battery persistence. Null when the mapper has none. */
     fun batteryBackedRam(): ByteArray? = null

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper1.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper1.kt
@@ -151,6 +151,7 @@ class Mapper1(private val gamePak: GamePak) : Mapper {
     }
 
     override fun saveState(out: DataOutput) {
+        super.saveState(out)
         out.writeInt(shiftReg)
         out.writeByte(controlReg.toInt())
         out.writeInt(chrBank0)
@@ -162,6 +163,7 @@ class Mapper1(private val gamePak: GamePak) : Mapper {
     }
 
     override fun loadState(input: DataInput) {
+        super.loadState(input)
         shiftReg = input.readInt()
         controlReg = input.readByte()
         chrBank0 = input.readInt()

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper10.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper10.kt
@@ -135,6 +135,7 @@ class Mapper10(private val gamePak: GamePak) : Mapper {
     override fun currentMirroring(): Mapper.MirroringMode = mirroringMode
 
     override fun saveState(out: DataOutput) {
+        super.saveState(out)
         out.writeInt(prgBank)
         out.writeInt(chrBank0FD)
         out.writeInt(chrBank0FE)
@@ -147,6 +148,7 @@ class Mapper10(private val gamePak: GamePak) : Mapper {
     }
 
     override fun loadState(input: DataInput) {
+        super.loadState(input)
         prgBank = input.readInt()
         chrBank0FD = input.readInt()
         chrBank0FE = input.readInt()

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper11.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper11.kt
@@ -64,6 +64,7 @@ class Mapper11(private val gamePak: GamePak) : Mapper {
     }
 
     override fun saveState(out: DataOutput) {
+        super.saveState(out)
         out.writeInt(chrBank)
         out.writeInt(prgBank)
         out.writeBoolean(chrRam != null)
@@ -71,6 +72,7 @@ class Mapper11(private val gamePak: GamePak) : Mapper {
     }
 
     override fun loadState(input: DataInput) {
+        super.loadState(input)
         chrBank = input.readInt()
         prgBank = input.readInt()
         val hasChrRam = input.readBoolean()

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper2.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper2.kt
@@ -76,6 +76,7 @@ class Mapper2(private val gamePak: GamePak) : Mapper {
     }
 
     override fun saveState(out: DataOutput) {
+        super.saveState(out)
         out.writeInt(prgBank)
         out.writeInt(chrBank)
         out.writeBoolean(chrRam != null)
@@ -83,6 +84,7 @@ class Mapper2(private val gamePak: GamePak) : Mapper {
     }
 
     override fun loadState(input: DataInput) {
+        super.loadState(input)
         prgBank = input.readInt()
         chrBank = input.readInt()
         val hasChrRam = input.readBoolean()

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper206.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper206.kt
@@ -159,6 +159,7 @@ class Mapper206(private val gamePak: GamePak) : Mapper {
     }
 
     override fun saveState(out: DataOutput) {
+        super.saveState(out)
         out.writeInt(prgBank6)
         out.writeInt(prgBankA)
         for (b in chrBanks) out.writeInt(b)
@@ -169,6 +170,7 @@ class Mapper206(private val gamePak: GamePak) : Mapper {
     }
 
     override fun loadState(input: DataInput) {
+        super.loadState(input)
         prgBank6 = input.readInt()
         prgBankA = input.readInt()
         for (i in chrBanks.indices) chrBanks[i] = input.readInt()

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper3.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper3.kt
@@ -78,12 +78,14 @@ class Mapper3(private val gamePak: GamePak) : Mapper {
     }
 
     override fun saveState(out: DataOutput) {
+        super.saveState(out)
         out.writeInt(chrBank)
         out.writeBoolean(chrRam != null)
         if (chrRam != null) out.write(chrRam)
     }
 
     override fun loadState(input: DataInput) {
+        super.loadState(input)
         chrBank = input.readInt()
         val hasChrRam = input.readBoolean()
         if (hasChrRam && chrRam != null) input.readFully(chrRam)

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper34.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper34.kt
@@ -67,6 +67,7 @@ class Mapper34(private val gamePak: GamePak) : Mapper {
     }
 
     override fun saveState(out: DataOutput) {
+        super.saveState(out)
         out.writeInt(prgBank)
         out.writeInt(chrBank)
         out.writeBoolean(chrRam != null)
@@ -74,6 +75,7 @@ class Mapper34(private val gamePak: GamePak) : Mapper {
     }
 
     override fun loadState(input: DataInput) {
+        super.loadState(input)
         prgBank = input.readInt()
         chrBank = input.readInt()
         val hasChrRam = input.readBoolean()

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper4.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper4.kt
@@ -235,6 +235,7 @@ class Mapper4(private val gamePak: GamePak) : Mapper {
     override fun isIrqPending(): Boolean = scanlineCounter.isIrqPending()
 
     override fun saveState(out: DataOutput) {
+        super.saveState(out)
         out.writeInt(prgBank6)
         out.writeInt(prgBankA)
         for (b in chrBanks) out.writeInt(b)
@@ -251,6 +252,7 @@ class Mapper4(private val gamePak: GamePak) : Mapper {
     }
 
     override fun loadState(input: DataInput) {
+        super.loadState(input)
         prgBank6 = input.readInt()
         prgBankA = input.readInt()
         for (i in chrBanks.indices) chrBanks[i] = input.readInt()

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper5.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper5.kt
@@ -301,6 +301,7 @@ class Mapper5(private val gamePak: GamePak) : Mapper {
     override fun isIrqPending(): Boolean = irqPending
 
     override fun saveState(out: DataOutput) {
+        super.saveState(out)
         out.writeInt(prgBank8000)
         out.writeInt(prgBankA000)
         out.writeInt(prgBankC000)
@@ -328,6 +329,7 @@ class Mapper5(private val gamePak: GamePak) : Mapper {
     }
 
     override fun loadState(input: DataInput) {
+        super.loadState(input)
         prgBank8000 = input.readInt()
         prgBankA000 = input.readInt()
         prgBankC000 = input.readInt()

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper66.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper66.kt
@@ -80,6 +80,7 @@ class Mapper66(private val gamePak: GamePak) : Mapper {
     )
 
     override fun saveState(out: DataOutput) {
+        super.saveState(out)
         out.writeInt(prgBank)
         out.writeInt(chrBank)
         out.writeBoolean(chrRam != null)
@@ -87,6 +88,7 @@ class Mapper66(private val gamePak: GamePak) : Mapper {
     }
 
     override fun loadState(input: DataInput) {
+        super.loadState(input)
         prgBank = input.readInt()
         chrBank = input.readInt()
         val hasChrRam = input.readBoolean()

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper69.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper69.kt
@@ -156,6 +156,7 @@ class Mapper69(private val gamePak: GamePak) : Mapper {
     }
 
     override fun saveState(out: DataOutput) {
+        super.saveState(out)
         out.writeInt(command)
         for (b in chrBanks) out.writeInt(b)
         for (b in prgBanks) out.writeInt(b)
@@ -173,6 +174,7 @@ class Mapper69(private val gamePak: GamePak) : Mapper {
     }
 
     override fun loadState(input: DataInput) {
+        super.loadState(input)
         command = input.readInt()
         for (i in chrBanks.indices) chrBanks[i] = input.readInt()
         for (i in prgBanks.indices) prgBanks[i] = input.readInt()

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper7.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper7.kt
@@ -61,12 +61,14 @@ class Mapper7(private val gamePak: GamePak) : Mapper {
     }
 
     override fun saveState(out: DataOutput) {
+        super.saveState(out)
         out.writeInt(prgBank)
         out.writeInt(mirroringBit)
         out.write(chrRam)
     }
 
     override fun loadState(input: DataInput) {
+        super.loadState(input)
         prgBank = input.readInt()
         mirroringBit = input.readInt()
         input.readFully(chrRam)

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper9.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper9.kt
@@ -120,6 +120,7 @@ class Mapper9(private val gamePak: GamePak) : Mapper {
     override fun currentMirroring(): Mapper.MirroringMode = mirroringMode
 
     override fun saveState(out: DataOutput) {
+        super.saveState(out)
         out.writeInt(prgBank)
         out.writeInt(chrBank0FD)
         out.writeInt(chrBank0FE)
@@ -131,6 +132,7 @@ class Mapper9(private val gamePak: GamePak) : Mapper {
     }
 
     override fun loadState(input: DataInput) {
+        super.loadState(input)
         prgBank = input.readInt()
         chrBank0FD = input.readInt()
         chrBank0FE = input.readInt()

--- a/src/test/kotlin/com/github/alondero/nestlin/SaveStateTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/SaveStateTest.kt
@@ -148,4 +148,49 @@ class SaveStateTest {
         assertThat(magic, equalTo(0x4E53544C))
         assertThat(version, equalTo(SaveState.VERSION))
     }
+
+    /**
+     * Issue #100: the mapper block must carry a per-mapper version byte that
+     * loadState rejects on mismatch. A save made by a future Mapper4 that
+     * added a field (e.g. 3-cycle A12 filter state) would carry version 2;
+     * the current code expects version 1, so it must refuse the load loudly
+     * instead of silently reading garbage into PRG-bank registers.
+     *
+     * Test strategy: take a real round-trippable save, then mutate ONLY the
+     * per-mapper version byte. The mapper block is the LAST length-prefixed
+     * blob in the file, so its data bytes are the very last bytes of the
+     * file. For Mapper0 (which has no other state), the data is exactly one
+     * byte — the version stamp — which is the file's final byte.
+     */
+    @Test
+    fun `mapper block with unknown version is rejected with a clear message`() {
+        val nes = newNestlinAtReset()
+        runCpuSteps(nes, 500)
+        val bytes = snapshot(nes).copyOf()
+
+        // The per-mapper version byte is the LAST byte of the file: for a
+        // mapper with no other state (Mapper0), saveState writes only the
+        // version stamp and nothing else.
+        val versionByteOffset = bytes.size - 1
+        assertThat(
+            "Sanity check: the final byte should be the per-mapper version (1)",
+            bytes[versionByteOffset].toInt() and 0xFF,
+            equalTo(1)
+        )
+        bytes[versionByteOffset] = 99.toByte()
+
+        try {
+            restore(nes, bytes)
+            fail("Expected IncompatibleSaveStateException for mapper version 99")
+        } catch (e: SaveState.IncompatibleSaveStateException) {
+            assertTrue(
+                "Expected the message to mention the rejected version, got: ${e.message}",
+                e.message?.contains("99") == true
+            )
+            assertTrue(
+                "Expected the message to identify the mapper, got: ${e.message}",
+                e.message?.contains("Mapper0") == true
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the structural problem called out in [Issue #100](https://github.com/alondero/nestlin/issues/100): the NSTL save-state mapper block was length-prefixed but **not version-stamped**, so adding a field to any mapper's `saveState`/`loadState` would silently corrupt the entire state on load. The user sees a save that loads but the game crashes, with no error.

## What this PR does

- Adds a 1-byte per-mapper version prefix inside the mapper block, written by `Mapper.saveState` and checked by `Mapper.loadState`. A mismatch raises `IncompatibleSaveStateException` with a clear message naming the mapper and the rejected/expected versions.
- Bumps top-level `SaveState.VERSION` 1 → 2 so pre-fix saves are rejected at the wrapper level with a clear error instead of being silently misread.
- Updates all 13 mappers that implement `saveState`/`loadState`: 1, 2, 3, 4, 5, 7, 9, 10, 11, 34, 66, 69, 206. Each now calls `super.saveState(out)` / `super.loadState(input)` as the first line.
- Includes Mapper66 (GxROM, added in master PR #96) and Mapper206 (DxROM / Namcot 108, added in master PR #97) — both lacked the per-mapper version byte per the issue's explicit call-out, so this PR closes the half-fix.
- Adds a regression test in `SaveStateTest` that mutates the per-mapper version byte to 99 on a real round-trippable save and asserts the exception is thrown with a clear message.

## Latent fix

The implementation also corrects a sign-extension bug found by code review: `loadState` used `input.readByte().toInt()` which sign-extends, meaning any future per-mapper version 128..255 would load as a negative number and always fail the check. Bumped to `input.readUnsignedByte().toInt()` so the full 1-byte range works.

## Test plan (from Issue #100)

- [x] Save state under current format → reload → assert equal (existing `save then load then save is byte-identical` test still passes)
- [x] Mutate mapper version to 99 → load → assert `IncompatibleSaveStateException` with a clear message (new test)
- [x] All mappers that implement `saveState`/`loadState` updated in one PR (otherwise individual mappers would silently desync — see issue §"Test plan #3")

## Why bundled with the top-level version bump

The issue notes: *"ideally bundled with a saveState format version 2 bump at the top level so old saves get a clear error message."* This makes the breaking-format change atomic and obvious to users upgrading.

## Build status

`./gradlew build` green on top of master (commit ec0a8cd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)