### PR TITLE
Validate iNES header in GamePak constructor (Issue #16)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
@@ -1,14 +1,27 @@
 package com.github.alondero.nestlin.gamepak
 
+import com.github.alondero.nestlin.BadHeaderException
 import com.github.alondero.nestlin.Region
 import com.github.alondero.nestlin.toUnsignedInt
 import java.util.zip.CRC32
 
 private const val TEST_ROM_CRC = 0x9e179d92
+private const val INES_HEADER_SIZE = 16
+private const val PRG_BANK_BYTES = 16384
+private const val CHR_BANK_BYTES = 8192
 
 class GamePak(data: ByteArray, displayName: String = "") {
 
-    val header = Header(data.copyOfRange(0, 16))
+    init {
+        // Issue #16: validate the iNES header BEFORE any slice/copy, so a
+        // corrupt or truncated ROM throws a descriptive BadHeaderException
+        // instead of leaking ArrayIndexOutOfBoundsException from copyOfRange.
+        // Order matters: length first (otherwise reading data[3] is unsafe),
+        // then the 4-byte magic ("NES\x1A"), then the declared PRG/CHR sizes.
+        requireValidHeader(data)
+    }
+
+    val header = Header(data.copyOfRange(0, INES_HEADER_SIZE))
     val name: String = when {
         // NES 2.0 bit 4 (in header byte 7) marks the optional 128-byte title at
         // 0x10..0x90. The spec only guarantees ASCII, but Famicom dumps routinely
@@ -38,9 +51,63 @@ class GamePak(data: ByteArray, displayName: String = "") {
     val region: Region = header.detectedRegion ?: regionFromName(name) ?: Region.NTSC
 
     init {
-        programRom = data.copyOfRange(16, 16 + 16384 * header.programRomSize)
-        chrRom = data.copyOfRange(16 + programRom.size, 16 + programRom.size + 8192 * header.chrRomSize)
+        // Use toUnsignedInt() because Header.programRomSize / chrRomSize are
+        // raw Byte fields. Without it, header.programRomSize = 0xFF (i.e. 255
+        // PRG banks, the spec-allowed max) sign-extends to -1 and the bound
+        // goes negative -- copyOfRange then throws IllegalArgumentException
+        // instead of our BadHeaderException, leaking the wrong exception class
+        // for exactly one input value per field. The validator above already
+        // treats the byte as unsigned; this just keeps the slice consistent.
+        val prgBanks = header.programRomSize.toUnsignedInt()
+        val chrBanks = header.chrRomSize.toUnsignedInt()
+        programRom = data.copyOfRange(INES_HEADER_SIZE, INES_HEADER_SIZE + PRG_BANK_BYTES * prgBanks)
+        chrRom = data.copyOfRange(INES_HEADER_SIZE + programRom.size, INES_HEADER_SIZE + programRom.size + CHR_BANK_BYTES * chrBanks)
         crc = CRC32().apply { update(data)}
+    }
+
+    /**
+     * Reject ROMs that are not a valid iNES file before any header field is
+     * dereferenced. Without this, a truncated or garbage file produces
+     * `ArrayIndexOutOfBoundsException` (from `data.copyOfRange(16, ...)`) or
+     * a silent default-zero `header.programRomSize` / `header.chrRomSize` —
+     * both useless to the user. BadHeaderException is the project's existing
+     * typed signal for this exact class of failure (see RomUtils.validate).
+     */
+    private fun requireValidHeader(data: ByteArray) {
+        if (data.size < INES_HEADER_SIZE) {
+            throw BadHeaderException(
+                "ROM is ${data.size} bytes; iNES header requires at least $INES_HEADER_SIZE bytes"
+            )
+        }
+        if (data[0] != 0x4E.toByte() || data[1] != 0x45.toByte() ||
+            data[2] != 0x53.toByte() || data[3] != 0x1A.toByte()) {
+            throw BadHeaderException(
+                "Missing iNES header magic \"NES\\x1A\" (got bytes " +
+                    "${data[0].toUnsignedInt()}, ${data[1].toUnsignedInt()}, " +
+                    "${data[2].toUnsignedInt()}, ${data[3].toUnsignedInt()})"
+            )
+        }
+        // Read the declared sizes straight from the raw bytes (NOT from
+        // header.programRomSize etc.) so the messages can cite the literal
+        // value the user sees in the header. The numbers are bytes 4 and 5.
+        val prgBanks = data[4].toUnsignedInt()
+        val chrBanks = data[5].toUnsignedInt()
+        val declaredPrgBytes = prgBanks.toLong() * PRG_BANK_BYTES
+        val declaredChrBytes = chrBanks.toLong() * CHR_BANK_BYTES
+        val availableForPrg = data.size - INES_HEADER_SIZE
+        if (declaredPrgBytes > availableForPrg) {
+            throw BadHeaderException(
+                "Header declares $prgBanks 16KB PRG bank(s) (${declaredPrgBytes} bytes) " +
+                    "but ROM is only $data.size bytes ($availableForPrg bytes after the header)"
+            )
+        }
+        val availableForChr = availableForPrg - declaredPrgBytes
+        if (declaredChrBytes > availableForChr) {
+            throw BadHeaderException(
+                "Header declares $chrBanks 8KB CHR bank(s) (${declaredChrBytes} bytes) " +
+                    "but only $availableForChr bytes remain in the ROM after the header and PRG"
+            )
+        }
     }
 
     fun isTestRom() = crc.value == TEST_ROM_CRC

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/GamePakTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/GamePakTest.kt
@@ -1,8 +1,27 @@
 package com.github.alondero.nestlin.gamepak
 
+import com.github.alondero.nestlin.BadHeaderException
 import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.containsSubstring
 import com.natpryce.hamkrest.equalTo
 import org.junit.Test
+
+/**
+ * Run [block] and return the [BadHeaderException] it throws (or fail the test
+ * if it throws something else / doesn't throw). JUnit 4 has no built-in
+ * equivalent of `kotlin.test.assertFailsWith` and we don't pull in
+ * `kotlin-test`, so this 4-line helper is the idiomatic stand-in.
+ */
+private inline fun assertBadHeader(block: () -> Unit): BadHeaderException {
+    try {
+        block()
+    } catch (e: BadHeaderException) {
+        return e
+    } catch (e: Throwable) {
+        throw AssertionError("Expected BadHeaderException, got ${e.javaClass.simpleName}: ${e.message}", e)
+    }
+    throw AssertionError("Expected BadHeaderException, but no exception was thrown")
+}
 
 class GamePakTest {
 
@@ -41,7 +60,7 @@ class GamePakTest {
         // PRG=1 (16KB) + CHR=1 (8KB) + 16-byte header = 24592 bytes minimum.
         val data = ByteArray(24592)
         // NES magic.
-        data[0] = 0x4E; data[1] = 0x45; data[2] = 0x53
+        data[0] = 0x4E; data[1] = 0x45; data[2] = 0x53; data[3] = 0x1A.toByte()
         // PRG=1 bank, CHR=1 bank, mapper 0, vertical mirroring.
         data[4] = 0x01
         data[5] = 0x01
@@ -110,5 +129,98 @@ class GamePakTest {
         val h = Header(header)
         assertThat(h.isNes20, equalTo(false))
         assertThat(h.mapper, equalTo(0x12))
+    }
+
+    // --- GitHub issue #16: GamePak must validate iNES header magic + size. ---
+    // Each test below uses `assertBadHeader { ... }` (defined at top of file)
+    // so the assertion fails cleanly with the message we asked for, instead of
+    // letting ArrayIndexOutOfBoundsException leak out of the constructor.
+
+    @Test
+    fun gamePakWithWrongMagicBytesThrowsBadHeaderException() {
+        // Bytes 0..3 are "FOO\x00" instead of the required "NES\x1A". The
+        // constructor must reject this BEFORE slicing the array (otherwise
+        // `data.copyOfRange(16, ...)` would throw ArrayIndexOutOfBoundsException
+        // with no message about the actual problem).
+        val data = ByteArray(24592) { i ->
+            when (i) { 0 -> 'F'.code.toByte(); 1 -> 'O'.code.toByte(); 2 -> 'O'.code.toByte(); else -> 0 }
+        }
+        val ex = assertBadHeader { GamePak(data) }
+        assertThat(ex.message ?: "", containsSubstring("NES"))
+    }
+
+    @Test
+    fun gamePakWithMissing0x1AByteInHeaderThrowsBadHeaderException() {
+        // Bytes 0..2 are "NES" but byte 3 is 0 (common when someone stubs a
+        // header by writing the ASCII letters but forgets the MS-DOS EOF
+        // marker). The spec requires the full 4-byte magic.
+        val data = ByteArray(24592)
+        data[0] = 0x4E; data[1] = 0x45; data[2] = 0x53
+        // data[3] deliberately left as 0.
+        val ex = assertBadHeader { GamePak(data) }
+        assertThat(ex.message ?: "", containsSubstring("NES"))
+    }
+
+    @Test
+    fun gamePakShorterThanHeaderThrowsBadHeaderException() {
+        // 5 bytes is too short for the 16-byte iNES header; the old constructor
+        // would throw an unhelpful ArrayIndexOutOfBoundsException. The fix
+        // must check length first and throw BadHeaderException with the size
+        // in the message.
+        val data = ByteArray(5)
+        val ex = assertBadHeader { GamePak(data) }
+        assertThat(ex.message ?: "", containsSubstring("16"))
+    }
+
+    @Test
+    fun gamePakWithDeclaredPrgLargerThanFileThrowsBadHeaderException() {
+        // Header is a valid 16-byte iNES header, but programRomSize (byte 4) =
+        // 32 16KB banks = 512KB. The file is only 16 header + 16 PRG = 32 bytes,
+        // so the declared PRG is grossly out of range. The constructor must
+        // refuse rather than letting `copyOfRange(16, 524304)` blow up.
+        val data = ByteArray(32)
+        data[0] = 0x4E; data[1] = 0x45; data[2] = 0x53; data[3] = 0x1A.toByte()
+        data[4] = 32  // declares 32 banks of PRG (512KB)
+        data[5] = 0   // no CHR
+        val ex = assertBadHeader { GamePak(data) }
+        // Message should mention the declared size (in 16KB banks) so the user
+        // can identify the corrupt header byte.
+        assertThat(ex.message ?: "", containsSubstring("32"))
+    }
+
+    @Test
+    fun gamePakWithDeclaredChrLargerThanFileThrowsBadHeaderException() {
+        // Valid magic + valid PRG size, but chrRomSize (byte 5) = 16 8KB banks
+        // = 128KB. The file has no CHR data at all. Old constructor would
+        // throw ArrayIndexOutOfBoundsException on the chrRom slice.
+        val data = ByteArray(16 + 16384)  // header + 1 PRG bank
+        data[0] = 0x4E; data[1] = 0x45; data[2] = 0x53; data[3] = 0x1A.toByte()
+        data[4] = 1   // 1 PRG bank (matches file)
+        data[5] = 16  // declares 16 CHR banks (128KB) but file has none
+        val ex = assertBadHeader { GamePak(data) }
+        assertThat(ex.message ?: "", containsSubstring("16"))
+    }
+
+    /**
+     * Regression: for a 4MB+ file with `programRomSize = 0xFF` (255 banks, the
+     * spec-allowed max), the validator passes (it uses `toUnsignedInt()`), but
+     * `header.programRomSize` is the signed `Byte` -1. If the second init
+     * block naively does `Int * Byte` arithmetic, the slice bound goes
+     * negative and `copyOfRange` throws `IllegalArgumentException` instead of
+     * `BadHeaderException` -- a wrong exception class for exactly the input
+     * that ought to be the *easiest* to handle (the maximum legal value).
+     *
+     * The fix: use `toUnsignedInt()` at the slice site so the consumer and
+     * the validator agree on the type of "PRG bank count".
+     */
+    @Test
+    fun gamePakWithMaxUnsignedPrgBankCountDoesNotThrowIllegalArgument() {
+        val data = ByteArray(16 + 16384 * 255)  // exactly 4,177,936 bytes
+        data[0] = 0x4E; data[1] = 0x45; data[2] = 0x53; data[3] = 0x1A.toByte()
+        data[4] = 0xFF.toByte()  // 255 PRG banks (max legal value, signed -1)
+        data[5] = 0              // no CHR
+        // Should construct cleanly: validator passes, slice uses unsigned.
+        val gp = GamePak(data)
+        assertThat(gp.programRom.size, equalTo(16384 * 255))
     }
 }

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper153Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper153Test.kt
@@ -23,6 +23,8 @@ class Mapper153Test {
         prg16k: Int = 4, chr8k: Int = 2, hasBattery: Boolean = false
     ): GamePak {
         val header = ByteArray(16)
+        header[0] = 'N'.code.toByte(); header[1] = 'E'.code.toByte()
+        header[2] = 'S'.code.toByte(); header[3] = 0x1A.toByte()
         header[4] = prg16k.toByte()
         header[5] = chr8k.toByte()
         // Mapper 153: low nibble = 9, high nibble = 9. Byte 6 = 0x90, byte 7 = 0x90.

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper16Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper16Test.kt
@@ -25,6 +25,8 @@ class Mapper16Test {
     ): GamePak {
         require(prg16k in 1..16) { "prg16k must be 1..16 (16KB units)" }
         val header = ByteArray(16)
+        header[0] = 'N'.code.toByte(); header[1] = 'E'.code.toByte()
+        header[2] = 'S'.code.toByte(); header[3] = 0x1A.toByte()
         header[4] = prg16k.toByte()
         header[5] = chr8k.toByte()
         // Mapper 16 = 0x10. Low nibble in byte 6 high nibble, high nibble in byte 7 high nibble.

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper1Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper1Test.kt
@@ -11,6 +11,8 @@ class Mapper1Test {
     private fun createTestGamePak(prgSize: Int = 2, chrSize: Int = 1): GamePak {
         // Create header (16 bytes)
         val header = ByteArray(16)
+        header[0] = 'N'.code.toByte(); header[1] = 'E'.code.toByte()
+        header[2] = 'S'.code.toByte(); header[3] = 0x1A.toByte()
         header[4] = prgSize.toByte()  // PRG ROM size in 16KB units
         header[5] = chrSize.toByte()    // CHR ROM size in 8KB units
         header[6] = 0x21.toByte()       // Mapper 1, vertical mirroring (bit 0 = 1)

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper206Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper206Test.kt
@@ -33,6 +33,8 @@ class Mapper206Test {
         mirroring: Header.Mirroring = Header.Mirroring.VERTICAL
     ): GamePak {
         val header = ByteArray(16)
+        header[0] = 'N'.code.toByte(); header[1] = 'E'.code.toByte()
+        header[2] = 'S'.code.toByte(); header[3] = 0x1A.toByte()
         header[4] = (prg8k / 2).toByte()           // PRG ROM size in 16KB units
         header[5] = (chr1k / 8).toByte()           // CHR ROM size in 8KB units
         // mapper 206 = 0xCE. flags6 = mapper-low nibble in upper 4 bits, plus bit 0 = mirror.
@@ -57,6 +59,8 @@ class Mapper206Test {
     /** Build a GamePak with stamped CHR for unambiguous read-after-bank-write tests. */
     private fun createStampedGamePak(chr1kBanks: Int, prg8kBanks: Int = 4): GamePak {
         val header = ByteArray(16)
+        header[0] = 'N'.code.toByte(); header[1] = 'E'.code.toByte()
+        header[2] = 'S'.code.toByte(); header[3] = 0x1A.toByte()
         header[4] = (prg8kBanks / 2).toByte()       // 16KB units
         header[5] = (chr1kBanks / 8).toByte()       // 8KB units
         // Mapper 206 = 0xCE: low nibble 0xE in byte 6 bits 4-7, high nibble 0xC in byte 7 bits 4-7.
@@ -289,6 +293,8 @@ class Mapper206Test {
     @Test
     fun `CHR RAM is writable when chrRom is empty`() {
         val header = ByteArray(16)
+        header[0] = 'N'.code.toByte(); header[1] = 'E'.code.toByte()
+        header[2] = 'S'.code.toByte(); header[3] = 0x1A.toByte()
         header[4] = 0x01.toByte()                          // 16KB PRG (1 × 16KB)
         header[5] = 0x00.toByte()                          // 0 CHR ROM
         header[6] = (((206 and 0x0F) shl 4) or 0x00).toByte()   // mapper 206, horizontal mirror

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper4IrqTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper4IrqTest.kt
@@ -8,6 +8,8 @@ class Mapper4IrqTest {
 
     private fun createTestGamePak(prgSize: Int = 2, chrSize: Int = 1): GamePak {
         val header = ByteArray(16)
+        header[0] = 'N'.code.toByte(); header[1] = 'E'.code.toByte()
+        header[2] = 'S'.code.toByte(); header[3] = 0x1A.toByte()
         header[4] = prgSize.toByte()
         header[5] = chrSize.toByte()
         header[6] = 0x04.toByte()       // Mapper 4 (MMC3)

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper69Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper69Test.kt
@@ -21,6 +21,8 @@ class Mapper69Test {
     // prg16k 16KB units, chr8k 8KB units. Defaults give 8 PRG banks (8KB) and 16 CHR banks (1KB).
     private fun createTestGamePak(prg16k: Int = 4, chr8k: Int = 2): GamePak {
         val header = ByteArray(16)
+        header[0] = 'N'.code.toByte(); header[1] = 'E'.code.toByte()
+        header[2] = 'S'.code.toByte(); header[3] = 0x1A.toByte()
         header[4] = prg16k.toByte()
         header[5] = chr8k.toByte()
         header[6] = 0x50.toByte()       // mapper low nibble = 5

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Vrc4Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Vrc4Test.kt
@@ -31,6 +31,8 @@ class Vrc4Test {
         mirroring: Header.Mirroring = Header.Mirroring.VERTICAL
     ): GamePak {
         val header = ByteArray(16)
+        header[0] = 'N'.code.toByte(); header[1] = 'E'.code.toByte()
+        header[2] = 'S'.code.toByte(); header[3] = 0x1A.toByte()
         header[4] = (prg8k / 2).toByte()        // 16KB PRG units
         header[5] = (chr1k / 8).toByte()        // 8KB CHR units
         val mirrorBit = if (mirroring == Header.Mirroring.VERTICAL) 0x01 else 0x00
@@ -170,6 +172,8 @@ class Vrc4Test {
     @Test
     fun `CHR RAM is writable when chrRom is empty`() {
         val header = ByteArray(16)
+        header[0] = 'N'.code.toByte(); header[1] = 'E'.code.toByte()
+        header[2] = 'S'.code.toByte(); header[3] = 0x1A.toByte()
         header[4] = 0x02.toByte()                                       // 32KB PRG
         header[5] = 0x00.toByte()                                       // no CHR ROM
         header[6] = (((25 and 0x0F) shl 4) or 0x00).toByte()            // mapper 25, horizontal

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Vrc4VariantDecodeTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Vrc4VariantDecodeTest.kt
@@ -31,6 +31,8 @@ class Vrc4VariantDecodeTest {
 
     private fun createTestGamePak(mapperNumber: Int): GamePak {
         val header = ByteArray(16)
+        header[0] = 'N'.code.toByte(); header[1] = 'E'.code.toByte()
+        header[2] = 'S'.code.toByte(); header[3] = 0x1A.toByte()
         header[4] = 4.toByte()                                  // 64KB PRG
         header[5] = 1.toByte()                                  // 8KB CHR
         header[6] = (((mapperNumber and 0x0F) shl 4)).toByte()  // horizontal default


### PR DESCRIPTION
## What

Closes #16. The `GamePak` constructor used to slice `data.copyOfRange(16, ...)` without checking the 4-byte iNES magic (`NES\x1A`) or the declared PRG/CHR sizes. A truncated or corrupt ROM threw an unhelpful `ArrayIndexOutOfBoundsException` with no signal about the actual problem.

## Fix

Add a private `requireValidHeader(data)` helper called from a new `init` block at the top of the class. It checks, in order:

1. `data.size >= 16` (otherwise reading `data[3]` is unsafe)
2. bytes 0..3 == `NES\x1A` (cites the actual bytes in the message so a user staring at a hex dump can match the message to the file)
3. declared PRG bytes (`byte 4 * 16384`) fit in the file
4. declared CHR bytes (`byte 5 * 8192`) fit in what remains after PRG

Reuses the existing `BadHeaderException` at `Nestlin.kt:225` that `RomUtils.load` also throws. The two checks form defence-in-depth: `RomUtils.load` is the canonical entry from disk, but tests construct `GamePak` directly.

## Bonus fix: signed-Byte slice site

Code review surfaced an asymmetry: the new validator reads the byte via `data[4].toUnsignedInt()` (so 0..255), but the second `init` block was doing `Int * Byte` arithmetic on `header.programRomSize` (a raw `Byte`). For a 4MB+ file with `data[4] = 0xFF` (the spec-allowed max, signed `-1`), the bound went negative and `copyOfRange` threw `IllegalArgumentException` instead of `BadHeaderException` — a wrong exception class for exactly the input that should be the easiest to handle (the maximum legal value). Coerced to `toUnsignedInt()` at the slice site. Regression test included.

## Test-helper cascade

The new validator surfaced 11 pre-existing latent bugs in mapper test helpers — they were building 16-byte headers from scratch but never set bytes 0..3 to the iNES magic, and were silently passing under the old constructor. The `.apply { this[0..3] = N,E,S,0x1A; ... }` pattern used by 8 other test files was already correct; this is purely a fix to the `ByteArray(16); header[4] = ...` style helpers across `Mapper1Test`, `Mapper4IrqTest`, `Mapper16Test`, `Mapper69Test`, `Mapper153Test`, `Mapper206Test` (3 helpers), `Vrc4Test` (2 helpers), `Vrc4VariantDecodeTest`.

## Tests

- 5 new tests in `GamePakTest` for the validator: wrong magic, missing 0x1A byte, too short, PRG too large, CHR too large. Each uses a small `assertBadHeader` helper that pairs JUnit 4 with Hamkrest `containsSubstring` on the exception message.
- 1 new test for the signed-Byte slice site fix: 0xFF PRG bank count over a 4MB file.
- 1 existing test had a latent `data[3]` omission that's now corrected so the test data is actually a valid iNES file.

## Build

`./gradlew build` passes — 342 tests, 0 failed, 3 pre-existing skips, 0 regressions, shadow JAR built.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
