### PR TITLE
Add FM2 input replayer for deterministic bug reproduction

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/Controller.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Controller.kt
@@ -95,8 +95,20 @@ class Controller {
         } else {
             buttons = buttons and button.mask.inv()
         }
-        
+
         // If strobe is active, update the shift register immediately (transparent latch)
+        if (strobe) {
+            shiftRegister = buttons
+        }
+    }
+
+    /**
+     * Overwrite the entire button bitmap in one shot (bit order: A=0 … Right=7).
+     * Used by the movie replayer to latch a whole frame's input atomically, rather than
+     * issuing eight [setButton] calls. Honours the transparent-latch rule like [setButton].
+     */
+    fun setButtonBitmap(value: Int) {
+        buttons = value and 0xFF
         if (strobe) {
             shiftRegister = buttons
         }

--- a/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
@@ -43,6 +43,7 @@ class Nestlin {
     }
 
     fun getController1() = memory.controller1
+    fun getController2() = memory.controller2
 
     fun load(romPath: Path) {
         val data = romPath.load()

--- a/src/main/kotlin/com/github/alondero/nestlin/movie/Fm2Format.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/movie/Fm2Format.kt
@@ -1,0 +1,140 @@
+package com.github.alondero.nestlin.movie
+
+import com.github.alondero.nestlin.Controller.Button
+import java.security.MessageDigest
+import java.util.Base64
+
+/**
+ * Reader/writer for the FCEUX `.fm2` movie format (text variant).
+ *
+ * FM2 is the de-facto NES TAS interchange format: a header of `key value` lines, then an input log
+ * where every line begins with `|`. We target the *text* form (not `binary 1`) on purpose —
+ * human-readability and diff-ability are the whole point for sharing a bug repro.
+ *
+ * Input-log line layout (non-fourscore, two standard pads):
+ *
+ *     |<commands>|<port0: 8 chars>|<port1: 8 chars>|<port2>|
+ *     |0         |RLDUTSBA        |........        |       |
+ *
+ * Each pad is eight characters in the fixed mnemonic order **R L D U T S B A**
+ * (Right, Left, Down, Up, sTart, Select, B, A). A pressed button shows its letter; an unpressed one
+ * shows `.`. Crucially this is the *reverse* of Nestlin's internal bit order (A=bit0 … Right=bit7),
+ * so the mapping is made explicit in [FM2_LAYOUT] rather than dumping the raw bitmap.
+ */
+object Fm2Format {
+
+    /** FM2 pad columns in written order (leftmost first), paired with the Nestlin button each maps to. */
+    private val FM2_LAYOUT: List<Pair<Char, Button>> = listOf(
+        'R' to Button.RIGHT,
+        'L' to Button.LEFT,
+        'D' to Button.DOWN,
+        'U' to Button.UP,
+        'T' to Button.START,
+        'S' to Button.SELECT,
+        'B' to Button.B,
+        'A' to Button.A,
+    )
+
+    /**
+     * Compute the FM2 `romChecksum`: `base64:` followed by Base64 of the raw 16-byte MD5 of the ROM
+     * *image data* (the iNES file with its 16-byte header stripped — FCEUX hashes PRG+CHR, not the
+     * header). [romImage] is the byte array returned by `Path.load()`.
+     *
+     * Caveat: a ROM carrying a 512-byte trainer would need that skipped too; not handled yet (none
+     * of the in-repo test ROMs have one). Left as a follow-up for exact FCEUX parity.
+     */
+    fun romChecksum(romImage: ByteArray): String {
+        val body = if (romImage.size > 16) romImage.copyOfRange(16, romImage.size) else romImage
+        val md5 = MessageDigest.getInstance("MD5").digest(body)
+        return "base64:" + Base64.getEncoder().encodeToString(md5)
+    }
+
+    /** Serialise [movie] to FM2 text. Lines are `\n`-terminated; `.gitattributes` normalises to CRLF. */
+    fun write(movie: Movie): String {
+        val sb = StringBuilder()
+        sb.appendLine("version ${Movie.FM2_VERSION}")
+        sb.appendLine("emuVersion ${movie.emuVersion}")
+        sb.appendLine("rerecordCount ${movie.rerecordCount}")
+        if (movie.palFlag) sb.appendLine("palFlag 1")
+        sb.appendLine("romFilename ${movie.romFilename}")
+        sb.appendLine("romChecksum ${movie.romChecksum}")
+        sb.appendLine("guid ${movie.guid}")
+        sb.appendLine("fourscore ${movie.fourscore.toFm2()}")
+        sb.appendLine("port0 ${movie.port0}")
+        sb.appendLine("port1 ${movie.port1}")
+        sb.appendLine("port2 ${movie.port2}")
+        movie.inputs.forEach { sb.appendLine(encodeLine(it)) }
+        return sb.toString()
+    }
+
+    /** Parse FM2 text back into a [Movie]. Unknown header keys (comment, subtitle, …) are ignored. */
+    fun read(text: String): Movie {
+        var emuVersion = Movie.NESTLIN_EMU_VERSION
+        var rerecordCount = 0
+        var palFlag = false
+        var romFilename = ""
+        var romChecksum = ""
+        var guid = Movie.ZERO_GUID
+        var fourscore = false
+        var port0 = Movie.PORT_GAMEPAD
+        var port1 = Movie.PORT_GAMEPAD
+        var port2 = Movie.PORT_NONE
+        val inputs = mutableListOf<MovieInput>()
+
+        text.lineSequence().forEach { raw ->
+            val line = raw.trimEnd('\r', '\n')
+            when {
+                line.isEmpty() -> Unit
+                line.startsWith("|") -> inputs.add(decodeLine(line))
+                else -> {
+                    val key = line.substringBefore(' ')
+                    val value = line.substringAfter(' ', "")
+                    when (key) {
+                        "emuVersion" -> emuVersion = value.toIntOrNull() ?: emuVersion
+                        "rerecordCount" -> rerecordCount = value.toIntOrNull() ?: 0
+                        "palFlag" -> palFlag = value.trim() == "1"
+                        "romFilename" -> romFilename = value
+                        "romChecksum" -> romChecksum = value
+                        "guid" -> guid = value
+                        "fourscore" -> fourscore = value.trim() == "1"
+                        "port0" -> port0 = value.toIntOrNull() ?: port0
+                        "port1" -> port1 = value.toIntOrNull() ?: port1
+                        "port2" -> port2 = value.toIntOrNull() ?: port2
+                        // "version", "comment", "subtitle", "binary", … intentionally ignored.
+                    }
+                }
+            }
+        }
+        return Movie(
+            romFilename, romChecksum, palFlag, rerecordCount, guid,
+            fourscore, port0, port1, port2, emuVersion, inputs,
+        )
+    }
+
+    private fun encodeLine(input: MovieInput): String =
+        "|${input.commands}|${encodePad(input.controller1)}|${encodePad(input.controller2)}||"
+
+    private fun encodePad(bitmap: Int): String =
+        FM2_LAYOUT.joinToString("") { (ch, btn) -> if (bitmap and btn.mask != 0) ch.toString() else "." }
+
+    private fun decodeLine(line: String): MovieInput {
+        // split('|') on "|cmd|p0|p1|p2|" yields: ["", cmd, p0, p1, p2, ""].
+        val fields = line.split('|')
+        val commands = fields.getOrNull(1)?.trim()?.toIntOrNull() ?: 0
+        val p1 = decodePad(fields.getOrNull(2) ?: "")
+        val p2 = decodePad(fields.getOrNull(3) ?: "")
+        return MovieInput(p1, p2, commands)
+    }
+
+    private fun decodePad(pad: String): Int {
+        var bitmap = 0
+        FM2_LAYOUT.forEachIndexed { i, (_, btn) ->
+            val ch = pad.getOrNull(i) ?: '.'
+            // FM2 treats '.' and ' ' as released; any other glyph means pressed.
+            if (ch != '.' && ch != ' ') bitmap = bitmap or btn.mask
+        }
+        return bitmap
+    }
+
+    private fun Boolean.toFm2(): String = if (this) "1" else "0"
+}

--- a/src/main/kotlin/com/github/alondero/nestlin/movie/FrameStepper.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/movie/FrameStepper.kt
@@ -1,0 +1,18 @@
+package com.github.alondero.nestlin.movie
+
+import com.github.alondero.nestlin.Nestlin
+
+/**
+ * Advance this emulator by exactly one PPU frame.
+ *
+ * Drives [Nestlin.stepCpuCycle] and watches the existing one-shot
+ * [com.github.alondero.nestlin.ppu.Ppu.frameJustCompleted] flag as the boundary signal. This is the
+ * deterministic seam the movie record/replay engine runs on: no wall clock, no threads, and no
+ * contention with the single-slot render listener.
+ */
+fun Nestlin.runOneFrame() {
+    while (true) {
+        stepCpuCycle()
+        if (ppu.frameJustCompleted()) return
+    }
+}

--- a/src/main/kotlin/com/github/alondero/nestlin/movie/Movie.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/movie/Movie.kt
@@ -1,0 +1,36 @@
+package com.github.alondero.nestlin.movie
+
+/**
+ * In-memory representation of an FM2 movie: header metadata plus the per-frame input log.
+ *
+ * Row N of [inputs] is the controller state visible to the game during frame N. FM2 semantics latch
+ * input once per frame, *before* the frame is emulated — and that frame-quantisation is precisely
+ * what makes replay deterministic, because it removes the real-time jitter of *when* a key event
+ * lands relative to the emulation thread.
+ */
+data class Movie(
+    val romFilename: String,
+    val romChecksum: String,
+    val palFlag: Boolean = false,
+    val rerecordCount: Int = 0,
+    val guid: String = ZERO_GUID,
+    val fourscore: Boolean = false,
+    val port0: Int = PORT_GAMEPAD,
+    val port1: Int = PORT_GAMEPAD,
+    val port2: Int = PORT_NONE,
+    val emuVersion: Int = NESTLIN_EMU_VERSION,
+    val inputs: List<MovieInput> = emptyList(),
+) {
+    val length: Int get() = inputs.size
+
+    companion object {
+        /** FM2 file-format version; "for now it is always 3" per the FCEUX spec. */
+        const val FM2_VERSION = 3
+        /** Reported in the `emuVersion` header so movies are traceable to a Nestlin build. */
+        const val NESTLIN_EMU_VERSION = 1
+        const val ZERO_GUID = "00000000-0000-0000-0000-000000000000"
+        /** FM2 port device codes: 1 = standard gamepad, 0 = nothing connected. */
+        const val PORT_GAMEPAD = 1
+        const val PORT_NONE = 0
+    }
+}

--- a/src/main/kotlin/com/github/alondero/nestlin/movie/MovieInput.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/movie/MovieInput.kt
@@ -1,0 +1,17 @@
+package com.github.alondero.nestlin.movie
+
+/**
+ * One frame's worth of input in a movie's input log.
+ *
+ * [controller1]/[controller2] are button bitmaps in Nestlin's *internal* Controller bit order
+ * (bit 0 = A … bit 7 = Right — see [com.github.alondero.nestlin.Controller.Button]), NOT the FM2
+ * on-disk order. [Fm2Format] translates to/from FM2's reversed `RLDUTSBA` column layout.
+ *
+ * [commands] is the FM2 command field: bit 0 = soft reset, bit 1 = hard reset (power cycle).
+ * Defaults to 0 (no console command this frame).
+ */
+data class MovieInput(
+    val controller1: Int,
+    val controller2: Int = 0,
+    val commands: Int = 0,
+)

--- a/src/main/kotlin/com/github/alondero/nestlin/movie/MoviePlayer.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/movie/MoviePlayer.kt
@@ -1,0 +1,52 @@
+package com.github.alondero.nestlin.movie
+
+import com.github.alondero.nestlin.Nestlin
+import com.github.alondero.nestlin.file.load
+import java.nio.file.Path
+
+/**
+ * Deterministically replays a [Movie] against a cold-booted ROM.
+ *
+ * This is the core of the "ROM + input log reproduces a bug" workflow: given the same ROM and the
+ * same movie, [replay] always lands the machine in byte-identical state, because every source of
+ * non-determinism is removed — throttling off, input quantised to frame boundaries, cold boot.
+ */
+class MoviePlayer {
+
+    /**
+     * Boot [romPath] cold and replay [movie] to completion, returning the [Nestlin] at the final
+     * frame for inspection (save-state fingerprinting, or reading RAM at the bug site).
+     *
+     * @param verifyChecksum when true (default), throws if the ROM's FM2 checksum doesn't match the
+     *   movie's `romChecksum` — catching the "replaying against the wrong ROM" mistake up front.
+     */
+    fun replay(romPath: Path, movie: Movie, verifyChecksum: Boolean = true): Nestlin {
+        if (verifyChecksum && movie.romChecksum.isNotEmpty()) {
+            val image = romPath.load() ?: error("Could not load ROM: $romPath")
+            val actual = Fm2Format.romChecksum(image)
+            require(actual == movie.romChecksum) {
+                "ROM checksum mismatch: movie expects ${movie.romChecksum}, but $romPath hashes to $actual"
+            }
+        }
+        val nestlin = Nestlin().apply {
+            config.speedThrottlingEnabled = false
+            load(romPath)
+        }
+        nestlin.powerReset()
+        replayInto(nestlin, movie)
+        return nestlin
+    }
+
+    /**
+     * Replay [movie] into an already-booted [nestlin]. Each row's input is applied *before* its
+     * frame is stepped, matching FM2's "input latched once per frame" model.
+     */
+    fun replayInto(nestlin: Nestlin, movie: Movie) {
+        for (input in movie.inputs) {
+            nestlin.getController1().setButtonBitmap(input.controller1)
+            nestlin.getController2().setButtonBitmap(input.controller2)
+            // TODO: honour input.commands (soft/hard reset) once a real movie needs mid-run resets.
+            nestlin.runOneFrame()
+        }
+    }
+}

--- a/src/main/kotlin/com/github/alondero/nestlin/movie/MovieRecorder.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/movie/MovieRecorder.kt
@@ -1,0 +1,44 @@
+package com.github.alondero.nestlin.movie
+
+import com.github.alondero.nestlin.Nestlin
+
+/**
+ * Accumulates a [Movie] by snapshotting controller state one row per frame.
+ *
+ * Intended driving loop (headless / scripted):
+ *
+ *     for (frame in 0 until frameCount) {
+ *         applyInputForFrame(frame)        // set the controllers however the run dictates
+ *         nestlin.runOneFrame()
+ *         recorder.captureFrame(nestlin)
+ *     }
+ *
+ * [captureFrame] reads the pad bitmaps *after* the frame ran. Headlessly — where nothing mutates the
+ * pad mid-frame — that equals the input in effect during the frame, so row N == frame N. That
+ * symmetry is exactly what [MoviePlayer] relies on (it applies row N *before* frame N) to reproduce
+ * the run byte-for-byte.
+ *
+ * Real-time UI recording, where the player can change input mid-frame, is a later slice: it must
+ * freeze the pad to a per-frame snapshot so the captured row matches what the game actually polled.
+ */
+class MovieRecorder(
+    private val romFilename: String,
+    private val romChecksum: String,
+    private val palFlag: Boolean = false,
+) {
+    private val inputs = mutableListOf<MovieInput>()
+
+    val frameCount: Int get() = inputs.size
+
+    fun captureFrame(nestlin: Nestlin) {
+        inputs.add(
+            MovieInput(
+                controller1 = nestlin.getController1().buttons,
+                controller2 = nestlin.getController2().buttons,
+            )
+        )
+    }
+
+    fun toMovie(): Movie =
+        Movie(romFilename = romFilename, romChecksum = romChecksum, palFlag = palFlag, inputs = inputs.toList())
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/NestlinThreadSafetyTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/NestlinThreadSafetyTest.kt
@@ -2,8 +2,7 @@ package com.github.alondero.nestlin
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.lang.reflect.Modifier
 
 /**
@@ -67,8 +66,12 @@ class NestlinThreadSafetyTest {
         if (thread.isAlive) {
             thread.interrupt()
             thread.join(1_000)
-            fail("Nestlin.start() did not return within 2s of stop(). " +
-                "The running flag is likely not @Volatile — see issue #12.")
+            // JUnit 5's fail(String) is declared `<V> V`, which Kotlin can't infer here;
+            // throw the underlying assertion error directly (see junit5-migration-lessons memory).
+            throw org.opentest4j.AssertionFailedError(
+                "Nestlin.start() did not return within 2s of stop(). " +
+                    "The running flag is likely not @Volatile — see issue #12."
+            )
         }
     }
 }

--- a/src/test/kotlin/com/github/alondero/nestlin/movie/MovieRoundTripTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/movie/MovieRoundTripTest.kt
@@ -1,0 +1,125 @@
+package com.github.alondero.nestlin.movie
+
+import com.github.alondero.nestlin.Controller.Button
+import com.github.alondero.nestlin.Nestlin
+import com.github.alondero.nestlin.file.load
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.nio.file.Paths
+
+/**
+ * End-to-end tests for the FM2 movie record/replay engine.
+ *
+ * The headline property is **deterministic reproduction**: a movie recorded from a run, persisted to
+ * FM2 text, re-read, and replayed into a cold machine must reproduce the original run byte-for-byte.
+ * That is exactly the guarantee the "ROM + input log reproduces a bug" workflow is built on.
+ */
+class MovieRoundTripTest {
+
+    private val romPath = Paths.get("testroms/nestest.nes")
+
+    /** A deterministic, frame-varying input script so the recorded movie isn't a wall of all-zeros. */
+    private fun scriptedInput(frame: Int): MovieInput {
+        val c1 = when (frame % 4) {
+            0 -> 0
+            1 -> Button.A.mask
+            2 -> Button.A.mask or Button.RIGHT.mask
+            else -> Button.START.mask
+        }
+        return MovieInput(controller1 = c1)
+    }
+
+    private fun snapshot(nes: Nestlin): ByteArray =
+        ByteArrayOutputStream().also { nes.saveState(it) }.toByteArray()
+
+    @Test
+    fun `fm2 pad columns follow the RLDUTSBA mnemonic`() {
+        val movie = Movie(
+            "nestest", "base64:x", inputs = listOf(
+                MovieInput(controller1 = Button.A.mask),
+                MovieInput(controller1 = Button.RIGHT.mask),
+                MovieInput(controller1 = Button.START.mask or Button.B.mask),
+            )
+        )
+        val text = Fm2Format.write(movie)
+
+        assertTrue(text.contains("|0|.......A|........||"), "A is the rightmost pad column\n$text")
+        assertTrue(text.contains("|0|R.......|........||"), "Right is the leftmost pad column\n$text")
+        // RLDUTSBA columns: R0 L1 D2 U3 T4 S5 B6 A7 — so Start=index4, B=index6.
+        assertTrue(text.contains("|0|....T.B.|........||"), "Start renders as T (col 4) and B as B (col 6)\n$text")
+    }
+
+    @Test
+    fun `movie survives an fm2 write then read round-trip`() {
+        val original = Movie(
+            romFilename = "nestest",
+            romChecksum = "base64:abc==",
+            palFlag = true,
+            rerecordCount = 7,
+            inputs = (0 until 30).map { scriptedInput(it) },
+        )
+
+        val parsed = Fm2Format.read(Fm2Format.write(original))
+
+        assertEquals(original.romFilename, parsed.romFilename, "romFilename")
+        assertEquals(original.romChecksum, parsed.romChecksum, "romChecksum")
+        assertEquals(original.palFlag, parsed.palFlag, "palFlag")
+        assertEquals(original.rerecordCount, parsed.rerecordCount, "rerecordCount")
+        assertEquals(original.inputs, parsed.inputs, "input log must round-trip exactly")
+    }
+
+    @Test
+    fun `recording then replaying reproduces byte-identical final state`() {
+        val frames = 90
+        val checksum = Fm2Format.romChecksum(romPath.load()!!)
+
+        // --- Direct scripted run, capturing a movie as we go ---
+        val direct = Nestlin().apply {
+            config.speedThrottlingEnabled = false
+            load(romPath)
+        }
+        direct.powerReset()
+        val recorder = MovieRecorder(romFilename = "nestest", romChecksum = checksum)
+        repeat(frames) { frame ->
+            val input = scriptedInput(frame)
+            direct.getController1().setButtonBitmap(input.controller1)
+            direct.getController2().setButtonBitmap(input.controller2)
+            direct.runOneFrame()
+            recorder.captureFrame(direct)
+        }
+        val expected = snapshot(direct)
+
+        // --- Persist to FM2 text, reload, replay into a fresh cold machine ---
+        val movie = Fm2Format.read(Fm2Format.write(recorder.toMovie()))
+        assertEquals(frames, movie.length, "every frame should have produced one input row")
+
+        val replayed = MoviePlayer().replay(romPath, movie)
+        val actual = snapshot(replayed)
+
+        assertArrayEquals(
+            expected, actual,
+            "Replaying the recorded FM2 movie must reproduce the original run byte-for-byte",
+        )
+    }
+
+    @Test
+    fun `replay rejects a movie whose checksum does not match the ROM`() {
+        val movie = Movie(
+            romFilename = "nestest",
+            romChecksum = "base64:deadbeefdeadbeefdeadbe==",
+            inputs = listOf(MovieInput(controller1 = 0)),
+        )
+        try {
+            MoviePlayer().replay(romPath, movie)
+            org.junit.jupiter.api.Assertions.fail("Expected a checksum-mismatch failure")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(
+                e.message?.contains("checksum mismatch") == true,
+                "Expected a checksum-mismatch message, got: ${e.message}",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds TAS-style input **recording and playback** using the FCEUX `.fm2` movie format. A ROM plus a movie file now reproduces a run **byte-for-byte** — the foundation for "ROM + input log repeats a bug" workflows.

This is the **core engine + headless + test** slice (per design discussion). Real-time UI recording/playback is deferred to follow-up issues.

## How it works

- **Determinism seam** — `Nestlin.runOneFrame()` drives `stepCpuCycle()` until the dormant one-shot `Ppu.frameJustCompleted()` fires. No threads, no wall-clock, no contention with the single-slot render listener. Cold boot is already deterministic (`internalRam.fill(0xFF)`, no RNG).
- **Frame-quantised input** — FM2 latches one input row per frame, applied *before* the frame is emulated. This removes the only source of non-determinism in normal play: the timing of real-time key events relative to the emulation thread.
- **Record/replay symmetry** — replay *applies* row N before frame N; the recorder *captures* row N after. Headlessly nothing mutates the pad mid-frame, so captured == applied — the identity that guarantees reproduction.

## Package `com.github.alondero.nestlin.movie`

| File | Role |
|---|---|
| `Movie` / `MovieInput` | In-memory model; button bitmaps in internal order |
| `Fm2Format` | `.fm2` text read/write + `romChecksum`; maps internal bits ↔ FM2's reversed `RLDUTSBA` columns |
| `MovieRecorder` | Per-frame controller snapshot |
| `MoviePlayer` | Cold-boot + deterministic replay; verifies ROM checksum |
| `FrameStepper` | `Nestlin.runOneFrame()` extension |

## Enabling edits to existing code

- `Controller.setButtonBitmap(Int)` — bulk pad latch (named to dodge the JVM setter clash with `var buttons`).
- `Nestlin.getController2()` — symmetric pad-2 accessor.

## Drive-by fix

`NestlinThreadSafetyTest` still had JUnit 4 imports (a leftover the issue-28 migration missed) and wasn't compiling — converted to JUnit 5 (including the `fail()` phantom-`<V>` workaround).

## Testing

`MovieRoundTripTest` proves the full chain: scripted run → record → write FM2 → re-read FM2 → replay into a fresh machine → **byte-identical `saveState`**. Plus FM2 button-layout and checksum-mismatch-rejection cases. Full `./gradlew build` green.

## Known limits / follow-ups (tracked as issues)

- No real-time UI recording/playback yet (hotkeys, on-screen REC/PLAY indicator).
- `romChecksum` hashes the iNES image minus the 16-byte header; not yet byte-verified against a real FCEUX `.fm2` (trainer not skipped). Cross-emulator load is unconfirmed.
- `commands` field (soft/hard reset) parsed but not yet applied during replay.
- No fourscore (4-controller) support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)