### PR TITLE
Add on-screen toast for save-state save/load (Issue #129)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
@@ -70,6 +70,35 @@ class NestlinApplication : FrameListener, Application() {
         strokeWidth = 1.0
         isVisible = false
     }
+    // Save-state feedback toast (issue #129). Same scene-graph approach as
+    // the fast-forward indicator — overlaid on canvasHolder rather than
+    // pixels poked into frameImage, so it stays a crisp 18px no matter the
+    // canvas upscale or fullscreen state. Anchored bottom-centre per the
+    // issue. The pill is semi-transparent so the game pixels it partially
+    // covers stay visible during the brief display window.
+    //
+    // Why Label instead of Text: Label gets a CSS-backed pill background +
+    // internal padding for free. Outlined Text was legible on dark scenes
+    // but disappeared on bright NES backdrops (Kirby's pink title screen);
+    // a 72%-opacity black pill is the standard "transient overlay" treatment.
+    private val toastController = ToastController()
+    private val toastIndicator = javafx.scene.control.Label("").apply {
+        font = javafx.scene.text.Font.font("Monospaced", javafx.scene.text.FontWeight.BOLD, 18.0)
+        // Pill: semi-transparent black background, rounded ends, generous
+        // horizontal padding so short messages still look like a pill not
+        // a square. Background-radius matches the height so the corners
+        // form true semicircles, mobile-toast style.
+        style = "-fx-background-color: rgba(0, 0, 0, 0.72);" +
+                "-fx-background-radius: 14;" +
+                "-fx-padding: 6 14 6 14;"
+        // Cap the width and wrap long error messages (e.g. multi-line
+        // IncompatibleSaveStateException diagnostics) so the pill never
+        // extends past the canvas at small upscale factors.
+        maxWidth = (RESOLUTION_WIDTH * 2).toDouble()
+        isWrapText = true
+        textAlignment = javafx.scene.text.TextAlignment.CENTER
+        isVisible = false
+    }
     private var running = false
     // Frame buffer synchronization for thread-safe screenshot capture
     private val frameBufferLock = Any()
@@ -268,6 +297,16 @@ class NestlinApplication : FrameListener, Application() {
             StackPane.setAlignment(fastForwardIndicator, javafx.geometry.Pos.TOP_RIGHT)
             StackPane.setMargin(fastForwardIndicator, javafx.geometry.Insets(4.0, 6.0, 0.0, 0.0))
 
+            // Save-state toast: pinned bottom-centre with a 28px inset. The
+            // pill is semi-transparent (0.72 alpha) so the game pixels behind
+            // it remain visible — important because at integer scales the
+            // canvas fills the holder bottom-up and there is no letterbox
+            // gap to sit in. Toast duration is brief (~1s success / ~2.5s
+            // error) so the partial occlusion is tolerable.
+            canvasHolder.children.add(toastIndicator)
+            StackPane.setAlignment(toastIndicator, javafx.geometry.Pos.BOTTOM_CENTER)
+            StackPane.setMargin(toastIndicator, javafx.geometry.Insets(0.0, 0.0, 28.0, 0.0))
+
             // Letterbox area outside the scaled canvas paints black.
             canvasHolder.style = "-fx-background-color: black;"
             // Decouple holder's min size from the Group's bounds. Without this, the scaled
@@ -420,6 +459,11 @@ class NestlinApplication : FrameListener, Application() {
                 if (fastForwardIndicator.isVisible != fastForward.active) {
                     fastForwardIndicator.isVisible = fastForward.active
                 }
+
+                // Save-state toast: pull from the controller each frame. We're
+                // already on the JavaFX Application Thread (AnimationTimer.handle
+                // runs here), so direct scene-node mutation is safe.
+                refreshToastIndicator(System.currentTimeMillis())
             }
 
         }.start()
@@ -576,6 +620,9 @@ class NestlinApplication : FrameListener, Application() {
             nestlin.powerReset()
             nestlin.loadBatteryRam(romPath)
             clearPauseState()
+            // Drop any stale "Saved/Loaded slot N" message from the previous ROM
+            // before its slot CRC changes underneath the user.
+            toastController.clear()
             updateTitle()
             // Refresh the slot menu: new ROM = new CRC = different slot files.
             updateSlotMenu()
@@ -671,6 +718,9 @@ class NestlinApplication : FrameListener, Application() {
         nestlin.load(path)
         nestlin.powerReset()
         clearPauseState()
+        // Drop any stale "Saved/Loaded slot N" toast from the previous ROM —
+        // the slot CRC changes underneath the user (parallel to handleLoadGame).
+        toastController.clear()
         updateTitle()
         // Refresh slot menu so each slot's label reflects disk state for
         // the new ROM's CRC. Without this, a user loading ROM B would see
@@ -693,9 +743,11 @@ class NestlinApplication : FrameListener, Application() {
             try {
                 nestlin.saveState(file.toPath())
                 println("[STATE] Saved to: ${file.absolutePath}")
+                showToast("Saved ${file.name}")
             } catch (e: Exception) {
                 println("[STATE] Save failed: ${e.message}")
                 e.printStackTrace()
+                showToast("Save failed: ${e.message ?: "unknown error"}", ToastSeverity.ERROR)
                 Platform.runLater { showError("Save Failed", e.message ?: "Unknown error") }
             }
         }
@@ -714,12 +766,19 @@ class NestlinApplication : FrameListener, Application() {
             try {
                 nestlin.loadState(file.toPath())
                 println("[STATE] Loaded from: ${file.absolutePath}")
+                showToast("Loaded ${file.name}")
             } catch (e: SaveState.IncompatibleSaveStateException) {
+                // The toast itself is the user feedback; the legacy modal
+                // Alert was the only feedback before issue #129 and is now
+                // redundant with the red pill (and intrusive — it pauses
+                // gameplay until the user clicks OK). Keep the println for
+                // log diagnostics.
                 println("[STATE] Incompatible save: ${e.message}")
-                Platform.runLater { showError("Incompatible Save State", e.message ?: "") }
+                showToast("Incompatible: ${e.message ?: "unknown reason"}", ToastSeverity.ERROR)
             } catch (e: Exception) {
                 println("[STATE] Load failed: ${e.message}")
                 e.printStackTrace()
+                showToast("Load failed: ${e.message ?: "unknown error"}", ToastSeverity.ERROR)
                 Platform.runLater { showError("Load Failed", e.message ?: "Unknown error") }
             }
         }
@@ -745,10 +804,12 @@ class NestlinApplication : FrameListener, Application() {
                 nestlin.saveState(stateOut)
                 saveStateSlotManager.save(slot, stateOut.toByteArray(), frameRgb)
                 println("[STATE] Saved slot $slot: ${saveStateSlotManager.statePath(slot)}")
+                showToast("Saved to slot $slot")
                 Platform.runLater { updateSlotMenu() }
             } catch (e: Exception) {
                 println("[STATE] Slot $slot save failed: ${e.message}")
                 e.printStackTrace()
+                showToast("Slot $slot save failed: ${e.message ?: "unknown error"}", ToastSeverity.ERROR)
             }
         }
     }
@@ -766,14 +827,19 @@ class NestlinApplication : FrameListener, Application() {
                 val stateBytes = saveStateSlotManager.loadStateBytes(slot)
                 nestlin.loadState(java.io.ByteArrayInputStream(stateBytes))
                 println("[STATE] Loaded slot $slot: ${saveStateSlotManager.statePath(slot)}")
+                showToast("Loaded slot $slot")
             } catch (e: java.nio.file.NoSuchFileException) {
                 println("[STATE] Slot $slot is empty")
+                showToast("Slot $slot is empty", ToastSeverity.SUBTLE)
             } catch (e: SaveState.IncompatibleSaveStateException) {
+                // Toast alone — see handleLoadState's parallel branch for the
+                // rationale on dropping the modal Alert for issue #129.
                 println("[STATE] Slot $slot is incompatible: ${e.message}")
-                Platform.runLater { showError("Incompatible Save State", e.message ?: "") }
+                showToast("Slot $slot incompatible: ${e.message ?: "unknown reason"}", ToastSeverity.ERROR)
             } catch (e: Exception) {
                 println("[STATE] Slot $slot load failed: ${e.message}")
                 e.printStackTrace()
+                showToast("Slot $slot load failed: ${e.message ?: "unknown error"}", ToastSeverity.ERROR)
             }
         }
     }
@@ -839,6 +905,37 @@ class NestlinApplication : FrameListener, Application() {
         alert.headerText = null
         alert.contentText = message
         alert.showAndWait()
+    }
+
+    /**
+     * Show a save-state toast (issue #129) at the current wall-clock. Thread-safe:
+     * only mutates the controller's volatile field, never a scene-graph node. The
+     * AnimationTimer picks it up on the next frame via [refreshToastIndicator].
+     */
+    private fun showToast(text: String, severity: ToastSeverity = ToastSeverity.INFO) {
+        toastController.show(text, severity, System.currentTimeMillis())
+    }
+
+    /**
+     * Reflect the controller's current toast (or its absence) onto the JavaFX
+     * Label. Called every frame from the AnimationTimer. The text fill is
+     * looked up from a per-severity constant (TOAST_FILLS) to avoid allocating
+     * a new Color every frame — Paint.equals is reference-based on parsed
+     * colours, so a fresh Color.web() would force textFill = ... on every
+     * frame even though the visible colour is unchanged.
+     */
+    private fun refreshToastIndicator(nowMillis: Long) {
+        val toast = toastController.currentToast(nowMillis)
+        if (toast == null) {
+            if (toastIndicator.isVisible) toastIndicator.isVisible = false
+            return
+        }
+        // Only mutate the scene node when content actually changes, mirroring
+        // the fast-forward indicator's cheap-toggle pattern.
+        if (toastIndicator.text != toast.text) toastIndicator.text = toast.text
+        val targetFill = TOAST_FILLS.getValue(toast.severity)
+        if (toastIndicator.textFill != targetFill) toastIndicator.textFill = targetFill
+        if (!toastIndicator.isVisible) toastIndicator.isVisible = true
     }
 
     private fun handleHardReset() {
@@ -1095,6 +1192,16 @@ class NestlinApplication : FrameListener, Application() {
             javafx.scene.input.KeyCode.F5, javafx.scene.input.KeyCode.F6,
             javafx.scene.input.KeyCode.F7, javafx.scene.input.KeyCode.F8,
             javafx.scene.input.KeyCode.F9
+        )
+
+        // Per-severity text fill for the save-state toast (issue #129).
+        // Hoisted to a constant map so refreshToastIndicator doesn't allocate
+        // a new Color per AnimationTimer frame (Paint comparison is
+        // reference-based for Color.web-parsed colours).
+        private val TOAST_FILLS: Map<ToastSeverity, javafx.scene.paint.Color> = mapOf(
+            ToastSeverity.INFO   to javafx.scene.paint.Color.web("#FFFFFF"),
+            ToastSeverity.SUBTLE to javafx.scene.paint.Color.web("#CCCCCC"),
+            ToastSeverity.ERROR  to javafx.scene.paint.Color.web("#FF6B6B"),
         )
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/ToastController.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/ToastController.kt
@@ -1,0 +1,91 @@
+package com.github.alondero.nestlin.ui
+
+/**
+ * Visual severity of a save-state toast (GitHub issue #129).
+ *
+ * Each severity carries its own auto-dismiss window. The numbers come from
+ * the issue spec: ~1s for successful saves/loads ("Saved to slot 3"), a
+ * slightly longer ~1.2s for subtle no-op feedback ("Slot 3 is empty"), and
+ * ~2.5s for errors so the user has time to read the diagnostic before it
+ * fades. The colours live on the JavaFX overlay so this enum stays pure
+ * Kotlin and unit-testable without booting a JavaFX toolkit.
+ */
+enum class ToastSeverity(val durationMillis: Long) {
+    /** Success path: "Saved to slot 3", "Loaded slot 3". */
+    INFO(1_000L),
+    /** Soft no-op: "Slot 3 is empty". Slightly longer because the user is
+     *  most likely re-orienting after an unexpected non-effect. */
+    SUBTLE(1_200L),
+    /** Failure path: "Save Failed: …". Stays on screen long enough to read. */
+    ERROR(2_500L),
+}
+
+/**
+ * A single toast message scheduled for display, with the absolute wall-clock
+ * time it should disappear. [ToastController] composes these from
+ * `(text, severity, nowMillis)` triples; the JavaFX overlay reads them.
+ */
+data class ToastMessage(
+    val text: String,
+    val severity: ToastSeverity,
+    val displayUntilMillis: Long,
+)
+
+/**
+ * Pure-data controller for the save-state toast/HUD overlay (issue #129).
+ *
+ * Owns the single-toast-at-a-time policy:
+ *  * `show(text, severity, nowMillis)` replaces whatever's currently on screen
+ *    with a fresh message whose dismiss window starts at `nowMillis`.
+ *  * `currentToast(nowMillis)` returns the current toast or null if it has
+ *    expired. The JavaFX render loop polls this each frame and reflects the
+ *    result onto its scene-graph `Text` node.
+ *
+ * Why pure: keeps the logic testable without a JavaFX toolkit, and lets the
+ * clock be injected (`nowMillis`) so the "show fires while a previous toast
+ * is still visible" case can be exercised deterministically. The call site
+ * in `Application.kt` passes `System.currentTimeMillis()`.
+ *
+ * Why replace (not queue): when the user rattles off `F1, F2, F3` in a burst,
+ * they want to see the *latest* outcome, not wait through three sequential
+ * reads. The issue explicitly allows either "queue OR replace cleanly".
+ */
+class ToastController {
+    @Volatile
+    private var current: ToastMessage? = null
+
+    /**
+     * Display [text] at [severity] starting at [nowMillis]. Replaces any
+     * existing toast — the new toast's dismiss window starts from this call,
+     * NOT from the original (otherwise a burst of saves would dismiss the
+     * latest message instantly because it inherited an older clock).
+     */
+    fun show(text: String, severity: ToastSeverity, nowMillis: Long) {
+        current = ToastMessage(
+            text = text,
+            severity = severity,
+            displayUntilMillis = nowMillis + severity.durationMillis,
+        )
+    }
+
+    /**
+     * The toast that should be visible at [nowMillis], or null if the most
+     * recent toast has expired (or there has never been one). Cheap — safe
+     * to call from the render loop.
+     */
+    fun currentToast(nowMillis: Long): ToastMessage? {
+        val c = current ?: return null
+        if (nowMillis >= c.displayUntilMillis) {
+            // Clear the slot once the window closes so a stale reference
+            // can't pin a now-invisible message in memory indefinitely.
+            current = null
+            return null
+        }
+        return c
+    }
+
+    /** Force-dismiss the current toast (e.g. on ROM unload). */
+    fun clear() {
+        current = null
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/ui/ToastControllerTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ui/ToastControllerTest.kt
@@ -1,0 +1,147 @@
+package com.github.alondero.nestlin.ui
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.absent
+import com.natpryce.hamkrest.present
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the pure-data layer behind the save-state toast/HUD (GitHub issue #129).
+ *
+ * The JavaFX `Text` overlay node (built in `ToastOverlay`) is driven by this
+ * controller; the controller itself owns the "what should be on screen right
+ * now?" decision so the rules are exercised without spinning up a JavaFX
+ * toolkit. The render loop polls [ToastController.currentToast] every frame
+ * (cheap) and reflects the result into the scene-graph node.
+ */
+class ToastControllerTest {
+
+    @Test
+    fun `controller is empty before any show call`() {
+        val c = ToastController()
+        assertThat(c.currentToast(nowMillis = 0L), absent())
+    }
+
+    @Test
+    fun `show makes the message visible immediately`() {
+        val c = ToastController()
+        c.show("Saved to slot 3", ToastSeverity.INFO, nowMillis = 1_000L)
+
+        val toast = c.currentToast(nowMillis = 1_000L)
+        assertThat(toast, present())
+        assertThat(toast!!.text, equalTo("Saved to slot 3"))
+        assertThat(toast.severity, equalTo(ToastSeverity.INFO))
+    }
+
+    @Test
+    fun `INFO toast auto-expires after its default duration`() {
+        val c = ToastController()
+        c.show("Saved to slot 3", ToastSeverity.INFO, nowMillis = 0L)
+
+        // Still visible at the very end of the window.
+        assertThat(
+            c.currentToast(nowMillis = ToastSeverity.INFO.durationMillis - 1),
+            present()
+        )
+        // Gone the instant the window closes.
+        assertThat(
+            c.currentToast(nowMillis = ToastSeverity.INFO.durationMillis),
+            absent()
+        )
+    }
+
+    @Test
+    fun `ERROR toast lives 2500ms — longer than INFO`() {
+        val c = ToastController()
+        c.show("Save Failed: disk full", ToastSeverity.ERROR, nowMillis = 0L)
+
+        // Still visible at the moment INFO would have expired.
+        assertThat(
+            c.currentToast(nowMillis = ToastSeverity.INFO.durationMillis),
+            present()
+        )
+        // Visible just before the ERROR cutoff …
+        assertThat(
+            c.currentToast(nowMillis = ToastSeverity.ERROR.durationMillis - 1),
+            present()
+        )
+        // … and gone at it.
+        assertThat(
+            c.currentToast(nowMillis = ToastSeverity.ERROR.durationMillis),
+            absent()
+        )
+    }
+
+    @Test
+    fun `SUBTLE toast for empty-slot loads has its own duration`() {
+        val c = ToastController()
+        c.show("Slot 3 is empty", ToastSeverity.SUBTLE, nowMillis = 0L)
+
+        assertThat(
+            c.currentToast(nowMillis = ToastSeverity.SUBTLE.durationMillis - 1),
+            present()
+        )
+        assertThat(
+            c.currentToast(nowMillis = ToastSeverity.SUBTLE.durationMillis),
+            absent()
+        )
+    }
+
+    @Test
+    fun `second show replaces the first — no queue, no flicker`() {
+        val c = ToastController()
+        c.show("Loaded slot 1", ToastSeverity.INFO, nowMillis = 0L)
+        // 50ms later, user fires Shift+F2.
+        c.show("Saved to slot 2", ToastSeverity.INFO, nowMillis = 50L)
+
+        val toast = c.currentToast(nowMillis = 60L)
+        assertThat(toast, present())
+        // Replace semantics: only the latest message is visible.
+        assertThat(toast!!.text, equalTo("Saved to slot 2"))
+    }
+
+    @Test
+    fun `replacement extends the visible window — new clock from latest show`() {
+        val c = ToastController()
+        c.show("Loaded slot 1", ToastSeverity.INFO, nowMillis = 0L)
+        c.show("Saved to slot 2", ToastSeverity.INFO, nowMillis = 800L)
+
+        // The original toast would have expired at INFO.durationMillis.
+        // After the replacement, the new toast must still be visible at that
+        // moment because its window starts at 800ms.
+        val deepIntoOriginalWindow = ToastSeverity.INFO.durationMillis - 1
+        val replacementShouldStillBeVisible = c.currentToast(nowMillis = deepIntoOriginalWindow)
+        assertThat(replacementShouldStillBeVisible, present())
+        assertThat(replacementShouldStillBeVisible!!.text, equalTo("Saved to slot 2"))
+
+        // And the replacement is visible at 800 + INFO.durationMillis - 1.
+        assertThat(
+            c.currentToast(nowMillis = 800L + ToastSeverity.INFO.durationMillis - 1),
+            present()
+        )
+        // Gone the instant the replacement's own window closes.
+        assertThat(
+            c.currentToast(nowMillis = 800L + ToastSeverity.INFO.durationMillis),
+            absent()
+        )
+    }
+
+    @Test
+    fun `INFO toast lasts approximately one second per the issue spec`() {
+        // The issue asks for ~1s for INFO and ~2.5s for ERROR. Pinning the
+        // exact values here means any future tweak has to be conscious and
+        // gets reviewed in the diff.
+        assertThat(ToastSeverity.INFO.durationMillis, equalTo(1_000L))
+        assertThat(ToastSeverity.SUBTLE.durationMillis, equalTo(1_200L))
+        assertThat(ToastSeverity.ERROR.durationMillis, equalTo(2_500L))
+    }
+
+    @Test
+    fun `clear immediately removes the current toast`() {
+        val c = ToastController()
+        c.show("Loaded slot 1", ToastSeverity.INFO, nowMillis = 0L)
+        c.clear()
+        assertThat(c.currentToast(nowMillis = 1L), absent())
+    }
+}


### PR DESCRIPTION
## What

Adds an on-screen feedback toast for save-state save/load events — resolves #129.

Before: pressing Shift+F3 silently wrote `savestates/<crc>.slot-3.nstl` and a load on an empty slot was a `println`-only no-op. Now every save/load surfaces a bottom-centre pill so the user sees what happened.

## How

Two-layer split mirroring the existing `fastForwardIndicator`:

* **`ui/ToastController.kt`** — pure Kotlin, `@Volatile current: ToastMessage?`. `show(text, severity, nowMillis)` replaces the active toast and resets its dismiss clock; `currentToast(nowMillis)` returns null after expiry. No JavaFX dependency, so unit tests run in ~36ms without booting a toolkit.
* **`ui/Application.kt`** — `javafx.scene.control.Label` overlaid on `canvasHolder` via `StackPane.setAlignment(BOTTOM_CENTER)`, styled as a `rgba(0,0,0,0.72)` rounded pill. `AnimationTimer.handle()` polls the controller every frame and reflects state onto the Label.

| Severity | Duration | Colour | Used for |
|---|---|---|---|
| `INFO` | 1.0s | `#FFFFFF` | "Saved to slot 3", "Loaded slot 3" |
| `SUBTLE` | 1.2s | `#CCCCCC` | "Slot 3 is empty" |
| `ERROR` | 2.5s | `#FF6B6B` | save/load failures |

**Replace, not queue.** A burst of `F1, F2, F3` shows only the latest outcome — the issue allows either, and queueing would force the user through sequential reads of keys they may not have meant.

## Callsites wired

* `handleSlotSave` (Shift+F1..F9) → "Saved to slot N" / ERROR
* `handleSlotLoad` (F1..F9) → "Loaded slot N" / SUBTLE "Slot N is empty" / ERROR with mapper-mismatch detail
* `handleSaveState` (File → Save State… dialog) → "Saved \<file\>" / ERROR
* `handleLoadState` (File → Load State… dialog) → "Loaded \<file\>" / ERROR
* `handleLoadGame` + `loadRom` (Recent menu) → `toastController.clear()` on ROM swap so a stale message doesn't linger over a different CRC

## Code-review fixes in-PR

A high-effort review surfaced six findings worth fixing before merge — all applied:

1. **Dropped the duplicate modal Alert for `IncompatibleSaveStateException`** in `handleLoadState` and `handleSlotLoad`. The red pill is sufficient and avoids the modal that paused gameplay until OK.
2. **Added missing `toastController.clear()` to `loadRom`** (Recent menu path). Was an asymmetry with `handleLoadGame`.
3. **Hoisted per-severity `Color` constants to `TOAST_FILLS` map** so the render loop doesn't allocate a Color object per frame (was `Color.web("#FFFFFF")` 60×/sec when a toast was visible).
4. **Constrained Label `maxWidth = 2× canvas` and enabled `isWrapText`** so long error diagnostics (verbose `IncompatibleSaveStateException` messages) don't run off-canvas at 1x scale.
5. **Corrected misleading "letterbox" comment.** The pill sits over game pixels at integer scales — the comment now explains the partial occlusion is tolerated because the display window is brief.
6. Two-claim verifier **refuted** the strong claims that `Label.focusTraversable=true` (it's actually `false` per `Labeled`'s override) and that menu-accelerator + scene-key-filter double-fire `handleSlotLoad` (live-evidence: 4 F1 presses → 4 log lines, not 8).

## Deferred (not in this PR)

The review also surfaced two altitude-level observations worth follow-up issues but **out of scope** here:

* Rename `ToastController` → `OverlayMessageBus` and document the generic contract, so future transient overlays (mute toggle, recording started, screenshot saved) reuse it instead of duplicating the pattern.
* Extract a `HudSlot` abstraction collapsing `fastForwardIndicator` and `toastIndicator` (and the next overlay) into a list of registered slots; right now there are two parallel `children.add + setAlignment + setMargin + render-loop poll` recipes.

## Acceptance criteria

| AC | Coverage |
|---|---|
| Shift+F1..F9 → "Saved to slot N" within one frame | `handleSlotSave` ✓ |
| F1..F9 → "Loaded slot N" on success | `handleSlotLoad` success ✓ |
| F1..F9 on empty → "Slot N is empty" (subtler) | SUBTLE severity ✓ |
| Auto-dismiss ~1s / ~2.5s errors | `ToastSeverity.durationMillis` ✓ |
| Visible in fullscreen | `canvasHolder` overlay, sibling to fastForwardIndicator ✓ |
| Doesn't block input | Label isn't focusTraversable; no event filter ✓ |
| Multiple toasts cleanly — no flicker | Replace, with dismiss-clock reset on each `show()` ✓ |

## Tests

9 new tests in `ToastControllerTest` cover empty state, show, per-severity auto-expiry, replace semantics, dismiss-clock reset on replacement (catches inheriting the old expiry), spec-pinned durations, and clear. Full suite **368 pass, 0 fail, 3 pre-existing skips**.

Closes #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
