### PR TITLE
Headless `replay` subcommand: FM2 replay-as-test (issue #62)

### DIFF
--- a/.claude/skills/replay-bug/SKILL.md
+++ b/.claude/skills/replay-bug/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: replay-bug
+description: Reproduce a reported NES game bug (hang, freeze, crash, graphical glitch, desync) deterministically from a ROM + an FM2 input log, using Nestlin's headless `replay` command. Invoke whenever a user reports or attaches a bug repro for a specific game, says the emulator hangs/freezes/crashes on a ROM, hands you an `.fm2` file, asks to reproduce or bisect a game-specific failure, or wants to turn a repro into a regression fingerprint/bundle. This is the first step before debugging any game-specific issue.
+---
+
+# Replay-as-test: reproduce a game bug from a ROM + FM2
+
+Nestlin has a headless `replay` subcommand (issue #62). Given a ROM and an `.fm2` movie it
+**deterministically** boots cold, replays the inputs, and lands the machine in the exact state the
+bug occurs in — no GUI, no wall clock, no threads. The same (ROM, FM2) pair produces byte-identical
+state on every machine. This is how you reproduce a user-reported bug before you debug it.
+
+## When to use this
+
+- A user reports "game X hangs / freezes / crashes / glitches when I do Y" — get or record an FM2,
+  then replay it to land the failure state on demand.
+- A user attaches an `.fm2` (often inside a `.zip`) to an issue. That file + the ROM **is** the repro.
+- You need a stable, repeatable starting point to bisect, instrument, or compare against Mesen2.
+- You want to capture a deterministic fingerprint so the fix gets a regression gate.
+
+## The command
+
+```bash
+# Build once (shadow JAR):
+./gradlew shadowJar      # → build/libs/nestlin-all.jar
+
+# Record mode — print fingerprints + write a PNG of the frame reached:
+java -jar build/libs/nestlin-all.jar replay <rom.nes> <movie.fm2>
+
+# Capture a specific (mid-movie) frame instead of the final one:
+java -jar build/libs/nestlin-all.jar replay <rom.nes> <movie.fm2> --frame N --png out.png
+
+# Verify mode — assert the run reproduces a previously-recorded fingerprint:
+java -jar build/libs/nestlin-all.jar replay <rom.nes> <movie.fm2> \
+    --expect-state <sha> --expect-frame <sha>
+```
+
+Flags: `--frame N` (replay only the first N input frames), `--png PATH` (default `<movie>.png`),
+`--expect-state`/`--expect-frame` (switch to verify mode), `--no-verify-checksum` (skip the
+ROM-vs-movie guard).
+
+**Output** (record mode) is machine-readable lines: `rom=`, `movie=`, `frames=`, `state=<sha256>`,
+`frame=<sha256>`, `png=<path>`.
+
+**Exit codes** — branch on these in CI/agents:
+
+| Code | Meaning |
+|---|---|
+| `0` | ran clean (record), or verify matched |
+| `1` | verify mismatch (a diff line names which of state/frame differs) |
+| `2` | usage error, or the ROM's checksum doesn't match the movie's `romChecksum` |
+| `3` | the emulator **threw** mid-replay (crash, unimplemented mapper) — a clean failure, not a stack trace |
+
+## The two fingerprints, and the key diagnostic
+
+- `state=` — SHA-256 over the full `SaveState` serialisation (CPU + RAM + PPU + APU + mapper). The
+  authoritative, pixel-independent fingerprint. Prefer this for regression gates (state diff beats
+  pixel diff — project policy).
+- `frame=` — SHA-256 over the RGB framebuffer. Pairs with the PNG; this is the *human* artefact.
+
+**A hang does not throw.** It replays to the end and lands in a frozen frame → `exit 0`, and the
+PNG/hash reveal the freeze. So a clean exit with a frozen-looking PNG is the expected shape of a
+hang repro, not a failure of the tool.
+
+**Diagnostic trick — run `--frame N` at several points and compare the two hashes:**
+
+- `frame=` frozen (identical across frames) **but** `state=` still advancing ⇒ the CPU is executing
+  while the display is stuck → a **render/blank bug**, not a CPU lockup.
+- both frozen ⇒ the CPU has genuinely stalled (spin loop / deadlock) → look at the PC / NMI/IRQ path.
+
+This is exactly how issue #141 (Akira hangs on game start, Mapper 33) was characterised: title screen
+(frame 100) renders, but from ~frame 333 `frame=` froze while `state=` kept advancing — a render bug.
+
+## Reproducing a reported bug — workflow
+
+1. **Get the FM2.** If attached to an issue inside a zip, download + extract it. FM2 is text; its
+   header carries `romChecksum` (base64 MD5 of PRG+CHR), so the movie self-identifies its ROM.
+2. **Find the ROM.** Local working ROMs are under `X:\src\nestlin\testroms\`; the full NO-INTRO
+   library is at `S:\Media\Nintendo NES\Games\` (see `CLAUDE.local.md` for all paths). Use the exact
+   filename from the FM2's `romFilename` header.
+3. **Replay it.** Run record mode. The checksum guard (`exit 2`) tells you immediately if you grabbed
+   the wrong ROM dump.
+4. **Confirm the bug.** Open the PNG (`Read` the `png=` path). Use `--frame N` to capture before/after
+   the failing transition and apply the state-vs-frame diagnostic above.
+5. **Hand off to the right tool.** `replay` reproduces and fingerprints; for *why* it diverges,
+   compare against the Mesen2 oracle (see the **mesen** skill) at the first diverging frame.
+
+## Turning a repro into a regression gate
+
+Record the `state=` hash once, then add a verify-mode invocation (or a test that calls
+`com.github.alondero.nestlin.cli.ReplayCommand.run` with `expectState`) so the fix can't silently
+regress. The bundle is just **ROM + FM2** — no savestate needed (replay always cold-boots; the FM2's
+`romChecksum` pins the ROM). Caveat: most ROMs are not in git (only `nestest.nes` is), so a committed
+bundle against a NO-INTRO ROM must skip cleanly when the ROM is absent (e.g. on CI without the
+library); a bundle against `nestest.nes` always runs.
+
+## Code touchpoints
+
+| File | Role |
+|---|---|
+| `src/main/kotlin/com/github/alondero/nestlin/cli/ReplayCli.kt` | arg parsing → `Parsed.Ok/Error` |
+| `src/main/kotlin/com/github/alondero/nestlin/cli/ReplayCommand.kt` | boot + replay + hash + PNG; `Options`/`Outcome`; exit-code constants |
+| `src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt` | `main` dispatches `replay` **before** `Application.launch` (so JavaFX never starts) |
+| `src/main/kotlin/com/github/alondero/nestlin/movie/` | the FM2 format + deterministic replay engine `replay` builds on (see the FM2 memory entries) |
+| `src/test/kotlin/com/github/alondero/nestlin/cli/` | `ReplayCommandTest` / `ReplayCliTest` — the worked examples |
+
+## Worktree caveat
+
+Determinism needs the game's **mapper** to be implemented on the branch you build. A mapper landed on
+`master` may be absent on an older worktree branch — symptom is `exit 3` "Mapper N not implemented".
+Fix: `git checkout master -- <mapper files>` into the worktree (or merge master) before replaying.
+
+## See also
+
+- **mesen** skill — the reference-emulator oracle for *why* a frame diverges, once `replay` has
+  reproduced *that* a frame diverges.
+- **nes-emulation-expert** skill — hardware/timing reasoning for the underlying bug.
+- FM2 engine background: memory entries `movie-replay-fm2-engine-2026-06-04`,
+  `movie-live-record-play-2026-06-06`, `replay-as-test-cli-issue-62-2026-06-07`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,15 @@ Personal learning project. 6502 CPU + 2C02 PPU + 2A03 APU. JavaFX 21 UI, Mesen2 
 ./gradlew run --args="rom.nes --debug"             # verbose CPU logging
 ./gradlew run --args="rom.nes --region=pal"        # override NTSC/PAL auto-detect
 ./gradlew run --args="rom.nes --no-audio"          # mute audio
+
+# Headless replay-as-test (issue #62): deterministically replay an FM2 against a ROM,
+# print state=/frame= SHA-256 fingerprints + write a PNG of the frame reached. No display.
+# This is the "agent takes a ROM + an .fm2 bug repro and lands the exact state" entry point.
+java -jar build/libs/nestlin-all.jar replay rom.nes bug.fm2            # record: print hashes + PNG
+java -jar build/libs/nestlin-all.jar replay rom.nes bug.fm2 --frame N  # capture a mid-movie frame
+java -jar build/libs/nestlin-all.jar replay rom.nes bug.fm2 \
+    --expect-state <sha> --expect-frame <sha>                          # verify: exit 0 match / 1 mismatch
+# Exit codes: 0 ok/match · 1 hash mismatch · 2 usage/checksum · 3 emulator threw mid-replay.
 ```
 
 **Requirements:** JDK 21 (Gradle toolchain pinned in `build.gradle.kts`), Kotlin 1.9.22, JavaFX 21.0.1.
@@ -37,6 +46,7 @@ src/main/kotlin/com/github/alondero/nestlin/
 ├── Apu.kt                  # 5 channels + frame counter + mixer
 ├── SaveState.kt            # .nstl binary format
 ├── SaveRam.kt              # .sav battery-backed PRG-RAM persistence
+├── cli/                    # headless `replay` subcommand (ReplayCli args → ReplayCommand): FM2 replay-as-test
 ├── cpu/                    # 6502 core + 151 opcodes + addressing modes
 ├── ppu/                    # 2C02: rendering, OAM, palette, vram address, regs
 ├── apu/                    # channels, envelope, sweep, length, frame counter, resampler

--- a/src/main/kotlin/com/github/alondero/nestlin/cli/ReplayCli.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cli/ReplayCli.kt
@@ -1,0 +1,101 @@
+package com.github.alondero.nestlin.cli
+
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Argument parsing + stdout wiring for the headless `replay` subcommand. Kept separate from
+ * [ReplayCommand] (the emulation/hashing logic) so the latter stays trivially unit-testable with
+ * fabricated [ReplayCommand.Options] and an in-memory [Appendable], and separate from
+ * `Application.main` so the JavaFX file never grows CLI-parsing responsibilities.
+ *
+ * Grammar:
+ *
+ *     nestlin replay <rom.nes> <movie.fm2>
+ *         [--frame N]              replay only the first N input frames (capture a mid-movie frame)
+ *         [--png PATH]             where to write the captured frame (default: <movie>.png)
+ *         [--expect-state HEX]     assert the state hash; verify mode
+ *         [--expect-frame HEX]     assert the frame hash; verify mode
+ *         [--no-verify-checksum]   skip the ROM-vs-movie checksum guard
+ */
+object ReplayCli {
+
+    val USAGE = """
+        usage: nestlin replay <rom.nes> <movie.fm2> [options]
+
+          --frame N             replay only the first N input frames
+          --png PATH            output PNG path (default: <movie>.png)
+          --expect-state HEX    assert state hash matches (verify mode; exit 1 on mismatch)
+          --expect-frame HEX    assert frame hash matches (verify mode; exit 1 on mismatch)
+          --no-verify-checksum  skip the ROM/movie checksum guard
+
+        With no --expect-* the command records: it prints state=/frame= hashes and writes a PNG.
+        With --expect-* it verifies: exit 0 on a byte-identical reproduction, 1 otherwise.
+    """.trimIndent()
+
+    /** A parsed argument vector: either runnable [Options] or a usage [error]. */
+    sealed interface Parsed {
+        data class Ok(val options: ReplayCommand.Options) : Parsed
+        data class Error(val message: String) : Parsed
+    }
+
+    /** Entry point used by `main`. [args] excludes the leading `replay` token. */
+    fun main(args: List<String>, out: Appendable = System.out): Int =
+        when (val parsed = parse(args)) {
+            is Parsed.Error -> {
+                out.appendLine("ERROR: ${parsed.message}")
+                out.appendLine(USAGE)
+                ReplayCommand.EXIT_USAGE
+            }
+            is Parsed.Ok -> ReplayCommand.run(parsed.options, out).exitCode
+        }
+
+    fun parse(args: List<String>): Parsed {
+        val positional = mutableListOf<String>()
+        var frame: Int? = null
+        var png: Path? = null
+        var expectState: String? = null
+        var expectFrame: String? = null
+        var verifyChecksum = true
+
+        var i = 0
+        fun value(): String? {
+            if (i + 1 >= args.size) return null
+            return args[++i]
+        }
+        while (i < args.size) {
+            val arg = args[i]
+            when (arg) {
+                "--frame" -> {
+                    val v = value() ?: return Parsed.Error("$arg requires a value")
+                    frame = v.toIntOrNull() ?: return Parsed.Error("$arg must be an integer, got '$v'")
+                    if (frame < 0) return Parsed.Error("$arg must be >= 0")
+                }
+                "--png" -> png = (value() ?: return Parsed.Error("$arg requires a value")).let(Paths::get)
+                "--expect-state" -> expectState = value() ?: return Parsed.Error("$arg requires a value")
+                "--expect-frame" -> expectFrame = value() ?: return Parsed.Error("$arg requires a value")
+                "--no-verify-checksum" -> verifyChecksum = false
+                else -> {
+                    if (arg.startsWith("--")) return Parsed.Error("unknown option '$arg'")
+                    positional.add(arg)
+                }
+            }
+            i++
+        }
+
+        if (positional.size != 2) {
+            return Parsed.Error("expected <rom.nes> <movie.fm2>, got ${positional.size} positional argument(s)")
+        }
+        return Parsed.Ok(
+            ReplayCommand.Options(
+                romPath = Paths.get(positional[0]),
+                moviePath = Paths.get(positional[1]),
+                pngPath = png,
+                frameLimit = frame,
+                expectState = expectState,
+                expectFrame = expectFrame,
+                verifyChecksum = verifyChecksum,
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/github/alondero/nestlin/cli/ReplayCommand.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cli/ReplayCommand.kt
@@ -1,0 +1,242 @@
+package com.github.alondero.nestlin.cli
+
+import com.github.alondero.nestlin.Nestlin
+import com.github.alondero.nestlin.file.load
+import com.github.alondero.nestlin.movie.Fm2Format
+import com.github.alondero.nestlin.movie.Movie
+import com.github.alondero.nestlin.movie.runOneFrame
+import com.github.alondero.nestlin.ppu.Frame
+import com.github.alondero.nestlin.ppu.RESOLUTION_HEIGHT
+import com.github.alondero.nestlin.ppu.RESOLUTION_WIDTH
+import com.github.alondero.nestlin.ui.FrameListener
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import javax.imageio.ImageIO
+
+/**
+ * Headless `replay` command: boot a ROM cold, replay an FM2 input log deterministically, and emit
+ * a reproducible fingerprint of the resulting machine state plus a PNG of the frame reached.
+ *
+ * This is the agentic core of issue #62 ("replay-as-test"). The whole point is that an agent — or
+ * CI — can run *one* command with a ROM and a shared `.fm2` and either:
+ *
+ *  - **record** the state the bug lands in (no `--expect-*`): prints the hashes and writes a PNG so
+ *    a human can confirm "yes, that's the freeze the user reported", then commits the hash; or
+ *  - **verify** against a previously-recorded hash (`--expect-state` / `--expect-frame`): exits 0 on
+ *    a byte-identical reproduction, 1 with a diff line otherwise — a regression gate.
+ *
+ * Determinism comes entirely from [MoviePlayer]/[runOneFrame]: throttling off, cold boot, input
+ * latched once per frame. No wall clock, no threads, no display — so the same (ROM, FM2) pair lands
+ * in byte-identical state on every machine, which is what makes the printed hash a durable contract.
+ */
+object ReplayCommand {
+
+    /** Exit codes are part of the CLI contract — CI and agents branch on them. */
+    const val EXIT_OK = 0
+    const val EXIT_MISMATCH = 1
+    const val EXIT_USAGE = 2
+    const val EXIT_ERROR = 3   // the emulator threw mid-replay (crash, unimplemented mapper, …)
+
+    data class Options(
+        val romPath: Path,
+        val moviePath: Path,
+        /** Where to write the captured frame. Null → `<movie>.png` beside the movie. */
+        val pngPath: Path?,
+        /** Replay only the first N input rows (capture a mid-movie frame). Null → whole movie. */
+        val frameLimit: Int?,
+        /** Expected `state=` hash; presence switches the command into verify mode. */
+        val expectState: String?,
+        /** Expected `frame=` hash; presence switches the command into verify mode. */
+        val expectFrame: String?,
+        /** Verify the ROM's FM2 checksum matches the movie's `romChecksum` before replaying. */
+        val verifyChecksum: Boolean,
+    )
+
+    data class Outcome(
+        val exitCode: Int,
+        val frames: Int,
+        val stateHash: String,
+        val frameHash: String,
+        val pngPath: Path,
+        /** null in record mode; true/false in verify mode. */
+        val matched: Boolean?,
+    )
+
+    /**
+     * Run the command, writing human-readable progress/result lines to [out]. Returns an [Outcome]
+     * carrying the exit code so the caller (`main`) can `System.exit` and tests can assert on it
+     * without parsing stdout.
+     */
+    fun run(opts: Options, out: Appendable): Outcome {
+        val movie = Fm2Format.read(Files.readString(opts.moviePath))
+
+        // Fail fast — and distinctly (EXIT_USAGE, not EXIT_MISMATCH) — if the ROM on disk isn't the
+        // one the movie was recorded against. Replaying the wrong ROM produces a meaningless hash.
+        if (opts.verifyChecksum && movie.romChecksum.isNotEmpty()) {
+            val image = opts.romPath.load() ?: return usage(out, "Could not load ROM: ${opts.romPath}")
+            val actual = Fm2Format.romChecksum(image)
+            if (actual != movie.romChecksum) {
+                return usage(
+                    out,
+                    "ROM checksum mismatch: movie expects ${movie.romChecksum}, " +
+                        "but ${opts.romPath} hashes to $actual",
+                )
+            }
+        }
+
+        val playedFrames = opts.frameLimit?.coerceAtMost(movie.length) ?: movie.length
+
+        // A throw here (unimplemented mapper, a crash partway through replay) is itself a
+        // reproduction signal — surface it as a clean EXIT_ERROR with a one-line message rather
+        // than letting a stack trace escape `main`. A *hang*, by contrast, does not throw: it
+        // replays to the end and lands in a frozen frame, which is a normal EXIT_OK whose PNG/hash
+        // reveal the bug. That asymmetry is intentional.
+        val frame: Frame
+        val stateHash: String
+        try {
+            frame = replay(opts, movie)
+            stateHash = stateHash(opts, movie)
+        } catch (t: Throwable) {
+            out.appendLine("ERROR: emulator threw while replaying ${opts.moviePath}: ${t.message ?: t.javaClass.simpleName}")
+            return Outcome(EXIT_ERROR, playedFrames, "", "", Path.of("."), null)
+        }
+
+        val pngPath = opts.pngPath ?: defaultPngPath(opts.moviePath)
+        writePng(frame, pngPath)
+        val frameHash = frameHash(frame)
+
+        out.appendLine("rom=${opts.romPath}")
+        out.appendLine("movie=${opts.moviePath}")
+        out.appendLine("frames=$playedFrames")
+        out.appendLine("state=$stateHash")
+        out.appendLine("frame=$frameHash")
+        out.appendLine("png=$pngPath")
+
+        val matched = verify(opts, stateHash, frameHash, out)
+        val exit = when (matched) {
+            null -> EXIT_OK
+            true -> EXIT_OK
+            false -> EXIT_MISMATCH
+        }
+        return Outcome(exit, playedFrames, stateHash, frameHash, pngPath, matched)
+    }
+
+    /**
+     * Boot cold and replay, returning the [Frame] reached. The frame object is mutated in place by
+     * the PPU and never reallocated, so holding the reference and reading it once replay has stopped
+     * yields the final frame's pixels. We re-derive the booted machine in [stateHash] rather than
+     * threading the [Nestlin] out, keeping this method's single responsibility "produce the frame".
+     */
+    private fun replay(opts: Options, movie: Movie): Frame {
+        val nestlin = boot(opts.romPath)
+        val captured = FrameCapture().also { nestlin.addFrameListener(it) }
+        replayInto(nestlin, movie, opts.frameLimit)
+        return captured.last ?: Frame() // a 0-frame movie yields a blank frame rather than crashing
+    }
+
+    /**
+     * Re-run the replay to serialise the final save state. A second cold boot is cheap relative to
+     * the clarity of not carrying mutable emulator state across the frame-capture and hashing steps;
+     * determinism guarantees both runs land identically.
+     */
+    private fun stateHash(opts: Options, movie: Movie): String {
+        val nestlin = boot(opts.romPath)
+        replayInto(nestlin, movie, opts.frameLimit)
+        val buf = ByteArrayOutputStream()
+        nestlin.saveState(buf)
+        return sha256Hex(buf.toByteArray())
+    }
+
+    private fun boot(romPath: Path): Nestlin = Nestlin().apply {
+        config.speedThrottlingEnabled = false
+        load(romPath)
+        powerReset()
+    }
+
+    /** Replay [movie], honouring an optional [frameLimit] (first N input rows). */
+    private fun replayInto(nestlin: Nestlin, movie: Movie, frameLimit: Int?) {
+        val rows = if (frameLimit != null) movie.inputs.take(frameLimit) else movie.inputs
+        for (input in rows) {
+            nestlin.getController1().setButtonBitmap(input.controller1)
+            nestlin.getController2().setButtonBitmap(input.controller2)
+            nestlin.runOneFrame()
+        }
+    }
+
+    /** Compare against the expected hashes; null when no expectation was supplied (record mode). */
+    private fun verify(opts: Options, stateHash: String, frameHash: String, out: Appendable): Boolean? {
+        if (opts.expectState == null && opts.expectFrame == null) return null
+        var ok = true
+        if (opts.expectState != null && opts.expectState != stateHash) {
+            out.appendLine("MISMATCH state: expected ${opts.expectState} got $stateHash")
+            ok = false
+        }
+        if (opts.expectFrame != null && opts.expectFrame != frameHash) {
+            out.appendLine("MISMATCH frame: expected ${opts.expectFrame} got $frameHash")
+            ok = false
+        }
+        if (ok) out.appendLine("OK: replay matches expected hashes")
+        return ok
+    }
+
+    private fun usage(out: Appendable, message: String): Outcome {
+        out.appendLine("ERROR: $message")
+        return Outcome(EXIT_USAGE, 0, "", "", Path.of("."), null)
+    }
+
+    private fun defaultPngPath(moviePath: Path): Path {
+        val name = moviePath.fileName.toString().substringBeforeLast('.')
+        val parent = moviePath.parent ?: Path.of(".")
+        return parent.resolve("$name.png")
+    }
+
+    /** Single-slot frame listener that keeps the most recently completed frame. */
+    private class FrameCapture : FrameListener {
+        var last: Frame? = null
+        override fun frameUpdated(frame: Frame) { last = frame }
+    }
+
+    private fun frameHash(frame: Frame): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        val row = ByteArray(RESOLUTION_WIDTH * 3)
+        for (y in 0 until RESOLUTION_HEIGHT) {
+            var i = 0
+            val line = frame.scanlines[y]
+            for (x in 0 until RESOLUTION_WIDTH) {
+                val rgb = line[x]
+                row[i++] = (rgb ushr 16).toByte()
+                row[i++] = (rgb ushr 8).toByte()
+                row[i++] = rgb.toByte()
+            }
+            md.update(row)
+        }
+        return md.digest().toHex()
+    }
+
+    private fun sha256Hex(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes).toHex()
+
+    private fun ByteArray.toHex(): String = buildString(size * 2) {
+        for (b in this@toHex) {
+            val v = b.toInt() and 0xFF
+            append(HEX[v ushr 4])
+            append(HEX[v and 0x0F])
+        }
+    }
+
+    private fun writePng(frame: Frame, path: Path) {
+        val image = BufferedImage(RESOLUTION_WIDTH, RESOLUTION_HEIGHT, BufferedImage.TYPE_INT_RGB)
+        for (y in 0 until RESOLUTION_HEIGHT) {
+            for (x in 0 until RESOLUTION_WIDTH) {
+                image.setRGB(x, y, frame.scanlines[y][x])
+            }
+        }
+        path.parent?.let { Files.createDirectories(it) }
+        ImageIO.write(image, "PNG", path.toFile())
+    }
+
+    private val HEX = "0123456789abcdef".toCharArray()
+}

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
@@ -47,6 +47,13 @@ import kotlin.concurrent.thread
 private const val BATTERY_FLUSH_INTERVAL_MS = 10_000L
 
 fun main(args: Array<String>) {
+    // Headless `replay` subcommand (issue #62): deterministically replay an FM2 against a ROM and
+    // emit a state/frame fingerprint + PNG. Dispatched before Application.launch so it never starts
+    // the JavaFX toolkit — it must run on a CI box or worktree with no display, and exit with a
+    // status code an agent can branch on.
+    if (args.isNotEmpty() && args[0] == "replay") {
+        kotlin.system.exitProcess(com.github.alondero.nestlin.cli.ReplayCli.main(args.drop(1)))
+    }
     Application.launch(NestlinApplication::class.java, *args)
 }
 

--- a/src/test/kotlin/com/github/alondero/nestlin/cli/ReplayCliTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cli/ReplayCliTest.kt
@@ -1,0 +1,79 @@
+package com.github.alondero.nestlin.cli
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.containsSubstring
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+import java.nio.file.Paths
+
+class ReplayCliTest {
+
+    private fun ok(args: List<String>): ReplayCommand.Options {
+        val parsed = ReplayCli.parse(args)
+        assertThat("expected Ok but got $parsed", parsed is ReplayCli.Parsed.Ok, equalTo(true))
+        return (parsed as ReplayCli.Parsed.Ok).options
+    }
+
+    private fun err(args: List<String>): String {
+        val parsed = ReplayCli.parse(args)
+        assertThat("expected Error but got $parsed", parsed is ReplayCli.Parsed.Error, equalTo(true))
+        return (parsed as ReplayCli.Parsed.Error).message
+    }
+
+    @Test
+    fun `parses the two positional paths and defaults`() {
+        val o = ok(listOf("rom.nes", "movie.fm2"))
+        assertThat(o.romPath, equalTo(Paths.get("rom.nes")))
+        assertThat(o.moviePath, equalTo(Paths.get("movie.fm2")))
+        assertThat(o.pngPath, equalTo<java.nio.file.Path?>(null))
+        assertThat(o.frameLimit, equalTo<Int?>(null))
+        assertThat(o.expectState, equalTo<String?>(null))
+        assertThat(o.verifyChecksum, equalTo(true))
+    }
+
+    @Test
+    fun `parses every option`() {
+        val o = ok(
+            listOf(
+                "rom.nes", "movie.fm2",
+                "--frame", "120",
+                "--png", "out.png",
+                "--expect-state", "abc",
+                "--expect-frame", "def",
+                "--no-verify-checksum",
+            ),
+        )
+        assertThat(o.frameLimit, equalTo<Int?>(120))
+        assertThat(o.pngPath, equalTo<java.nio.file.Path?>(Paths.get("out.png")))
+        assertThat(o.expectState, equalTo<String?>("abc"))
+        assertThat(o.expectFrame, equalTo<String?>("def"))
+        assertThat(o.verifyChecksum, equalTo(false))
+    }
+
+    @Test
+    fun `options before positionals also parse`() {
+        val o = ok(listOf("--frame", "5", "rom.nes", "movie.fm2"))
+        assertThat(o.frameLimit, equalTo<Int?>(5))
+        assertThat(o.romPath, equalTo(Paths.get("rom.nes")))
+    }
+
+    @Test
+    fun `missing movie path is an error`() {
+        assertThat(err(listOf("rom.nes")), containsSubstring("positional"))
+    }
+
+    @Test
+    fun `non-integer frame is an error`() {
+        assertThat(err(listOf("rom.nes", "movie.fm2", "--frame", "soon")), containsSubstring("integer"))
+    }
+
+    @Test
+    fun `unknown option is an error`() {
+        assertThat(err(listOf("rom.nes", "movie.fm2", "--turbo")), containsSubstring("unknown option"))
+    }
+
+    @Test
+    fun `dangling flag value is an error`() {
+        assertThat(err(listOf("rom.nes", "movie.fm2", "--expect-state")), containsSubstring("requires a value"))
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/cli/ReplayCommandTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cli/ReplayCommandTest.kt
@@ -1,0 +1,145 @@
+package com.github.alondero.nestlin.cli
+
+import com.github.alondero.nestlin.movie.Fm2Format
+import com.github.alondero.nestlin.movie.Movie
+import com.github.alondero.nestlin.movie.MovieInput
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.containsSubstring
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Exercises the headless `replay` command — the agentic "ROM + FM2 reproduces a bug" loop
+ * (issue #62). Uses the in-git `nestest.nes` so the test is self-contained: no external ROM,
+ * no Mesen2, no display. A synthetic all-buttons-released movie is enough to prove the
+ * record/verify contract; the determinism guarantee is the same one a real bug repro relies on.
+ */
+class ReplayCommandTest {
+
+    private val nestest: Path = Paths.get("testroms/nestest.nes")
+
+    /** Write a {@code frames}-long FM2 of empty input next to {@code dir}. */
+    private fun writeMovie(dir: Path, frames: Int, checksum: String = ""): Path {
+        val movie = Movie(
+            romFilename = "nestest.nes",
+            romChecksum = checksum,
+            inputs = (0 until frames).map { MovieInput(0, 0, 0) },
+        )
+        val path = dir.resolve("nestest.fm2")
+        Files.writeString(path, Fm2Format.write(movie))
+        return path
+    }
+
+    private fun options(
+        dir: Path,
+        moviePath: Path,
+        expectState: String? = null,
+        expectFrame: String? = null,
+    ) = ReplayCommand.Options(
+        romPath = nestest,
+        moviePath = moviePath,
+        pngPath = dir.resolve("out.png"),
+        frameLimit = null,
+        expectState = expectState,
+        expectFrame = expectFrame,
+        verifyChecksum = true,
+    )
+
+    @Test
+    fun `record mode is deterministic across runs`(@TempDir dir: Path) {
+        val movie = writeMovie(dir, 30)
+        val a = ReplayCommand.run(options(dir, movie), StringBuilder())
+        val b = ReplayCommand.run(options(dir, movie), StringBuilder())
+
+        assertThat(a.exitCode, equalTo(0))
+        assertThat(a.matched, equalTo<Boolean?>(null))          // record mode: nothing to match
+        assertThat(a.frames, equalTo(30))
+        assertThat(a.stateHash, equalTo(b.stateHash))
+        assertThat(a.frameHash, equalTo(b.frameHash))
+    }
+
+    @Test
+    fun `a PNG artefact is written for eyeballing`(@TempDir dir: Path) {
+        val movie = writeMovie(dir, 10)
+        val r = ReplayCommand.run(options(dir, movie), StringBuilder())
+        assertThat(Files.exists(r.pngPath), equalTo(true))
+    }
+
+    @Test
+    fun `verify mode exits 0 when the expected hashes match`(@TempDir dir: Path) {
+        val movie = writeMovie(dir, 20)
+        val recorded = ReplayCommand.run(options(dir, movie), StringBuilder())
+
+        val verify = ReplayCommand.run(
+            options(dir, movie, expectState = recorded.stateHash, expectFrame = recorded.frameHash),
+            StringBuilder(),
+        )
+        assertThat(verify.exitCode, equalTo(0))
+        assertThat(verify.matched, equalTo<Boolean?>(true))
+    }
+
+    @Test
+    fun `verify mode exits 1 and names the mismatch on a wrong hash`(@TempDir dir: Path) {
+        val movie = writeMovie(dir, 20)
+        val out = StringBuilder()
+        val verify = ReplayCommand.run(options(dir, movie, expectState = "deadbeef"), out)
+
+        assertThat(verify.exitCode, equalTo(1))
+        assertThat(verify.matched, equalTo<Boolean?>(false))
+        assertThat(out.toString(), containsSubstring("state"))
+    }
+
+    @Test
+    fun `frame limit captures a mid-movie frame`(@TempDir dir: Path) {
+        val movie = writeMovie(dir, 60)
+        val full = ReplayCommand.run(options(dir, movie), StringBuilder())
+        val early = ReplayCommand.run(
+            options(dir, movie).copy(frameLimit = 10),
+            StringBuilder(),
+        )
+        assertThat(early.frames, equalTo(10))
+        // Distinct execution points must hash differently, else the limit is being ignored.
+        assertThat(early.stateHash != full.stateHash, equalTo(true))
+    }
+
+    @Test
+    fun `an emulator throw becomes a clean EXIT_ERROR, not a stack trace`(@TempDir dir: Path) {
+        // A minimal but header-valid iNES whose mapper (238) is unimplemented: createMapper throws
+        // during powerReset. The command must catch it and exit cleanly — the same path a real
+        // crash-on-replay bug takes. (An unimplemented mapper IS how Akira/#141 presents on a branch
+        // without Mapper 33.)
+        val rom = ByteArray(16 + 16384).apply {
+            this[0] = 'N'.code.toByte(); this[1] = 'E'.code.toByte()
+            this[2] = 'S'.code.toByte(); this[3] = 0x1A
+            this[4] = 1            // 1 × 16KB PRG
+            this[5] = 0            // 0 CHR (CHR-RAM)
+            this[6] = 0xE0.toByte()  // mapper low nibble = E
+            this[7] = 0xE0.toByte()  // mapper high nibble = E  → mapper 238
+        }
+        val romPath = dir.resolve("unsupported.nes")
+        Files.write(romPath, rom)
+        val movie = writeMovie(dir, 1)
+
+        val out = StringBuilder()
+        val r = ReplayCommand.run(
+            options(dir, movie).copy(romPath = romPath),
+            out,
+        )
+        assertThat(r.exitCode, equalTo(3))
+        assertThat(out.toString(), containsSubstring("emulator threw"))
+    }
+
+    @Test
+    fun `a wrong ROM checksum fails fast before replaying`(@TempDir dir: Path) {
+        val movie = writeMovie(dir, 5, checksum = "base64:AAAAAAAAAAAAAAAAAAAAAA==")
+        val out = StringBuilder()
+        val r = ReplayCommand.run(options(dir, movie), out)
+
+        assertThat(r.exitCode, equalTo(2))                      // distinct from a verify failure (1)
+        assertThat(out.toString(), containsSubstring("checksum"))
+    }
+}


### PR DESCRIPTION
Closes #62 (core CLI scope).

## What

A headless `replay` subcommand that reproduces a reported game bug **deterministically** from a ROM + an FM2 input log — no GUI, machine-readable output, CI-friendly exit codes. This is the agentic core of issue #62 ("replay-as-test"): an agent (or CI) takes a ROM and a shared `.fm2` and lands the exact bug state on demand.

```bash
java -jar build/libs/nestlin-all.jar replay <rom.nes> <movie.fm2>     [--frame N] [--png PATH] [--expect-state <sha>] [--expect-frame <sha>] [--no-verify-checksum]
```

- **Record mode** (no `--expect-*`): prints `state=`/`frame=` SHA-256 fingerprints and writes a PNG of the frame reached.
- **Verify mode** (`--expect-*`): asserts a previously-recorded fingerprint — exit `0` match / `1` mismatch.

## How

- `cli/ReplayCli` (arg parse) → `cli/ReplayCommand` (boot + replay + hash + PNG). Dispatched from `Application.main` on the `replay` token **before** `Application.launch`, so JavaFX never starts.
- Determinism is inherited from the existing movie engine (`MoviePlayer`/`runOneFrame`): throttle off, cold boot, per-frame input latch → byte-identical state on every machine.
- Two fingerprints: `state=` over `SaveState` bytes (authoritative, pixel-independent) and `frame=` over the RGB framebuffer (pairs with the PNG). State-hash-first matches the project's state-diff-over-pixel-diff testing policy.

### Exit codes (the CI/agent contract)
| Code | Meaning |
|---|---|
| 0 | ran clean (record), or verify matched |
| 1 | verify mismatch (diff line names which hash differs) |
| 2 | usage error, or ROM↔movie checksum mismatch |
| 3 | emulator threw mid-replay (caught → clean failure, **not** a stack trace) |

A **hang does not throw** — it replays to the end and lands in a frozen frame (exit 0); the PNG/hash reveal the freeze. That asymmetry is intentional.

## Verified end-to-end against #141 (Akira, Mapper 33)

Replayed the FM2 attached to #141 against the real ROM. The title screen (frame 100) renders the Neo-Tokyo cityscape; from ~frame 333 the `frame=` hash **freezes** while the `state=` hash keeps **advancing** → the CPU is still executing while the display is stuck, i.e. **#141 is a render/blank bug, not a CPU lockup**. That's the first-divergence signal the issue asked for, from one command.

## Discoverability

Adds a git-tracked **`replay-bug`** project skill (alongside `mesen`/`nes-emulation-expert`) so a future agent handed a bug + `.fm2` is surfaced this workflow on intent, plus the command reference in `CLAUDE.md`.

## Tests (TDD — written first; full suite green)

- `ReplayCommandTest` — determinism across runs, PNG written, verify pass/fail, `--frame` mid-movie capture, crash→exit 3, checksum fail-fast.
- `ReplayCliTest` — arg-parsing happy paths + every error case.

## Scope / follow-up

Core CLI only, per agreed scope. **Deferred:** a committed replay-corpus dir + a Gradle/CI task that runs every bundle + the first real regression bundle (the Akira `.fm2` is the obvious candidate, skipping cleanly when the ROM is absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)