### PR TITLE
Fix NES 2.0 mapper decode regression from #117 (Issue #118)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
@@ -17,27 +17,17 @@ class GamePak(data: ByteArray, displayName: String = "") {
         // corrupt or truncated ROM throws a descriptive BadHeaderException
         // instead of leaking ArrayIndexOutOfBoundsException from copyOfRange.
         // Order matters: length first (otherwise reading data[3] is unsafe),
-        // then the 4-byte magic ("NES\x1A"), then the declared PRG/CHR sizes.
+        // then the 4-byte magic ("NES"), then the declared PRG/CHR sizes.
         requireValidHeader(data)
     }
 
     val header = Header(data.copyOfRange(0, INES_HEADER_SIZE))
-    val name: String = when {
-        // NES 2.0 bit 4 (in header byte 7) marks the optional 128-byte title at
-        // 0x10..0x90. The spec only guarantees ASCII, but Famicom dumps routinely
-        // put Shift-JIS or Latin-1 bytes here. `String(bytes)` would fall back to
-        // the JVM platform charset (windows-1252 on Western Windows), which
-        // corrupts non-ASCII titles and surfaces as mojibake in the window title.
-        // Latin-1 is a 1:1 byte->codepoint mapping for 0x00..0xFF, so it preserves
-        // the original bytes without substitution; callers who know the real
-        // encoding (e.g. Shift-JIS) can re-decode.
-        data.size >= 144 && data[7].toUnsignedInt() and 0x10 != 0 -> {
-            String(data.copyOfRange(0x10, 0x10 + 128), Charsets.ISO_8859_1)
-                .trim().replace('\u0000', ' ').trim()
-        }
-        displayName.isNotEmpty() -> displayName
-        else -> ""
-    }
+    // The display name comes from the filename. There is NO in-ROM title field at
+    // offset 0x10 in iNES / NES 2.0 — that is the start of PRG ROM. Reading it as a
+    // title (gated on byte 7 bit 4, which is actually mapper bit D4) rendered PRG
+    // opcodes as text and surfaced as a "question mark" titlebar for mapper-16 games
+    // like Crayon Shin-chan. See GH #118.
+    val name: String = displayName
     val programRom: ByteArray
     val chrRom: ByteArray
     val crc: CRC32
@@ -169,19 +159,16 @@ class Header(headerData: ByteArray) {
     /** True when bits 2-3 of byte 7 are `10`, marking this as a NES 2.0 header. */
     val isNes20: Boolean = (headerData[7].toUnsignedInt() and 0x0C) == 0x08
 
-    // In plain iNES, byte 7 bits 4-7 are the mapper high nibble (4 bits).
-    // In NES 2.0, bit 4 of byte 7 is the title-present flag, NOT a mapper bit --
-    // so the mapper high bits come from byte 7 bits 5-7 (3 bits, giving mapper
-    // bits 4-6) plus byte 8 for the extended mapper bits 8-15. Without this split,
-    // any NES 2.0 dump with a title (basically every modern Famicom dump) is
-    // misread with mapper 16 too high.
-    val mapper: Int = if (isNes20) {
-        (headerData[6].toUnsignedInt() shr 4) or
-        ((headerData[7].toUnsignedInt() and 0xE0) ushr 1) or
-        ((headerData[8].toUnsignedInt() and 0xFF) shl 8)
-    } else {
-        headerData[6].toUnsignedInt() shr(4) or (headerData[7].toUnsignedInt() and 0xF0)
-    }
+    // Mapper number (NESdev iNES / NES 2.0):
+    //   bits 0-3  = byte 6 bits 4-7
+    //   bits 4-7  = byte 7 bits 4-7  (bit 4 IS mapper bit D4 in both iNES and
+    //               NES 2.0 — there is no "title-present" flag here)
+    //   bits 8-11 = byte 8 bits 0-3  (NES 2.0 only; byte 8 bits 4-7 are the
+    //               submapper and must NOT leak into the mapper number)
+    // In plain iNES, byte 8 is the PRG-RAM size, so it is excluded.
+    val mapper: Int = (headerData[6].toUnsignedInt() ushr 4) or
+        (headerData[7].toUnsignedInt() and 0xF0) or
+        (if (isNes20) ((headerData[8].toUnsignedInt() and 0x0F) shl 8) else 0)
     val mirroring: Mirroring = if (headerData[6].toUnsignedInt() and 0x01 == 0) Mirroring.HORIZONTAL else Mirroring.VERTICAL
     val hasBattery: Boolean = headerData[6].toUnsignedInt() and 0x02 != 0
 

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/GamePakTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/GamePakTest.kt
@@ -37,93 +37,72 @@ class GamePakTest {
     }
 
     /**
-     * Regression: the in-ROM title field (bytes 0x10-0x8F, when NES 2.0 byte 7 bit 4
-     * is set) used to be decoded via `String(bytes)`, which falls back to the JVM's
-     * platform default charset. On Western Windows that maps 0x80 to U+20AC (euro)
-     * and 0x99 to U+2122 (trademark) -- corrupting any non-ASCII title (Famicom dumps
-     * routinely store Shift-JIS or Latin-1 bytes here). The titlebar would then show
-     * this mojibake via `currentGameName()`.
-     *
-     * The fix decodes with Charsets.ISO_8859_1 -- a 1:1 byte->codepoint mapping that
-     * never substitutes, so the original bytes survive (and a downstream caller who
-     * knows the source encoding can re-decode). For these two test bytes that means
-     * U+0080 and U+0099 (Latin-1 control chars), NOT the Windows-1252 reinterpretation.
+     * Regression for GH #118 / the #117 misdiagnosis: in BOTH iNES and NES 2.0,
+     * byte 7 bit 4 is mapper number bit D4 (NESdev: byte 7 D7..D4 = mapper D7..D4).
+     * It is NOT a "title-present" flag. PR #117 treated it as a title flag and
+     * dropped it from the mapper number, which misread every Bandai FCG (mapper 16)
+     * and similar title — e.g. Rokudenashi Blues decoded as mapper 0x5000.
      */
     @Test
-    fun inRomTitleWithNes20HeaderIsDecodedWithoutCharsetSubstitution() {
-        // 0x80 and 0x99 are the most visible Latin-1 vs Windows-1252 deltas:
-        //   Latin-1 0x80 -> U+0080 (control); Windows-1252 0x80 -> U+20AC (euro)
-        //   Latin-1 0x99 -> U+0099 (control); Windows-1252 0x99 -> U+2122 (trademark)
-        // After trim() (which strips <= U+0020), both interpretations survive -- making
-        // the charset difference directly observable in the resulting `name`.
-        val titleBytes = byteArrayOf(0x80.toByte(), 0x99.toByte())
-        // PRG=1 (16KB) + CHR=1 (8KB) + 16-byte header = 24592 bytes minimum.
-        val data = ByteArray(24592)
-        // NES magic.
-        data[0] = 0x4E; data[1] = 0x45; data[2] = 0x53; data[3] = 0x1A.toByte()
-        // PRG=1 bank, CHR=1 bank, mapper 0, vertical mirroring.
-        data[4] = 0x01
-        data[5] = 0x01
-        // NES 2.0 marker in bits 2-3 of byte 7 (0b0000_1000), bit 4 set = title present.
-        data[7] = 0x18.toByte()
-        // Fill the 128-byte title field at 0x10..0x90 with our non-ASCII bytes,
-        // padded with zeros (which get replaced with spaces then trimmed).
-        titleBytes.copyInto(data, destinationOffset = 0x10)
-        // Ensure the rest of the 128-byte field is null-terminated.
-        for (i in 0x10 + titleBytes.size until 0x10 + 128) data[i] = 0
-
-        val gamePak = GamePak(data)
-
-        // Latin-1 decode preserves byte values: 0x80 -> U+0080, 0x99 -> U+0099.
-        // Windows-1252 (the old behaviour) would have produced U+20AC and U+2122.
-        // Build the expected value from codepoints to keep the source pure ASCII
-        // (the U+0080 control char would otherwise get mangled by the editor).
-        val expected = String(CharArray(2) { i -> if (i == 0) 0x80.toChar() else 0x99.toChar() })
-        assertThat(gamePak.name, equalTo(expected))
+    fun nes20Byte7Bit4IsMapperBitNotTitleFlag() {
+        // Rokudenashi Blues header bytes: byte6=0x02, byte7=0x18, byte8=0x50.
+        // NES 2.0 (byte7 bits 2-3 = 10). mapper = 0 | (0x18 & 0xF0)=0x10 | 0 = 16.
+        val header = ByteArray(16)
+        header[0] = 0x4E; header[1] = 0x45; header[2] = 0x53; header[3] = 0x1A
+        header[6] = 0x02
+        header[7] = 0x18.toByte()
+        header[8] = 0x50.toByte()
+        val h = Header(header)
+        assertThat(h.isNes20, equalTo(true))
+        assertThat(h.mapper, equalTo(16))
+        // The byte-8 high nibble is the submapper, and must NOT leak into the mapper.
+        assertThat(h.submapper, equalTo(5))
     }
 
-    /**
-     * Regression: Header.mapper used to decode as `(byte6 >> 4) | (byte7 & 0xF0)`
-     * unconditionally, which in NES 2.0 -- where bit 4 of byte 7 is the title flag
-     * (not a mapper bit) -- wrongly added 16 to every mapper number for any dump
-     * with a title (basically every modern Famicom dump). So mapper 0 + NES 2.0 +
-     * title got misread as mapper 16, crashing on `Mapper 16 not implemented`.
-     *
-     * The fix splits the decode by `isNes20`: in NES 2.0, mapper bits 4-6 come from
-     * byte 7 bits 5-7, and bits 8-15 come from byte 8. Without title (bit 4 clear),
-     * the old plain-iNES decode is preserved.
-     */
     @Test
-    fun nes20MapperWithTitleBitIsNotInflatedBySixteen() {
-        // NES 2.0 + title + mapper 0. The old decoder returned 16; the fix returns 0.
+    fun plainInesByte7Bit4IsMapperBit() {
+        // Crayon Shin-chan - Ora to Poi Poi (Japan): plain iNES (byte7 bits 2-3 = 00),
+        // byte6=0x00, byte7=0x10 -> mapper = 0 | 0x10 = 16 (Bandai FCG).
         val header = ByteArray(16)
-        header[0] = 0x4E; header[1] = 0x45; header[2] = 0x53
-        header[4] = 0x01; header[5] = 0x01
-        // byte 6 high nibble = 0 (mapper low). byte 7 = 0b0001_1000:
-        //   bits 5-7 = 000 (mapper high); bit 4 = 1 (title); bits 2-3 = 10 (NES 2.0)
-        header[7] = 0x18.toByte()
-        assertThat(Header(header).mapper, equalTo(0))
+        header[0] = 0x4E; header[1] = 0x45; header[2] = 0x53; header[3] = 0x1A
+        header[6] = 0x00
+        header[7] = 0x10.toByte()
+        val h = Header(header)
+        assertThat(h.isNes20, equalTo(false))
+        assertThat(h.mapper, equalTo(16))
     }
 
     @Test
     fun nes20MapperFromByte8WorksForExtendedMappers() {
-        // NES 2.0 + mapper 256: byte 6 high nibble = 0, byte 7 bits 5-7 = 0,
-        // byte 8 = 0x01 (mapper bits 8-15 = 1 -> mapper 256).
+        // NES 2.0 + mapper 256: byte 6 high nibble = 0, byte 7 bits 4-7 = 0,
+        // byte 8 low nibble = 0x01 (mapper bits 8-11 = 1 -> mapper 256).
         val header = ByteArray(16)
-        header[0] = 0x4E; header[1] = 0x45; header[2] = 0x53
-        header[7] = 0x08.toByte()  // NES 2.0 marker, no title
+        header[0] = 0x4E; header[1] = 0x45; header[2] = 0x53; header[3] = 0x1A
+        header[7] = 0x08.toByte()  // NES 2.0 marker
         header[8] = 0x01
         assertThat(Header(header).mapper, equalTo(256))
     }
 
     @Test
-    fun plainInesMapperDecodeIsUnchangedByNes20Fix() {
-        // Plain iNES (byte 7 bits 2-3 = 00, NOT 10): the old decode is still used.
-        // byte 6 = 0x21 (mapper low = 2, vertical mirroring, battery);
-        // byte 7 = 0x10 (mapper high = 1) -> mapper 0x12 = 18. The Mapper1Test
-        // helper uses this exact pattern; we assert it still parses the same way.
+    fun nes20SubmapperNibbleDoesNotLeakIntoMapper() {
+        // byte 8 = 0x51: low nibble 1 -> mapper bits 8-11; high nibble 5 -> submapper.
+        // mapper must be 0x100 (256), NOT 0x5100 — i.e. the submapper stays out of it.
         val header = ByteArray(16)
-        header[0] = 0x4E; header[1] = 0x45; header[2] = 0x53
+        header[0] = 0x4E; header[1] = 0x45; header[2] = 0x53; header[3] = 0x1A
+        header[7] = 0x08.toByte()  // NES 2.0 marker
+        header[8] = 0x51.toByte()
+        val h = Header(header)
+        assertThat(h.mapper, equalTo(256))
+        assertThat(h.submapper, equalTo(5))
+    }
+
+    @Test
+    fun plainInesMapperDecodeIsUnchanged() {
+        // Plain iNES (byte 7 bits 2-3 = 00): byte 6 = 0x21 (mapper low = 2),
+        // byte 7 = 0x10 (mapper high = 1) -> mapper 0x12 = 18. The Mapper1Test helper
+        // uses this exact pattern; we assert it still parses the same way.
+        val header = ByteArray(16)
+        header[0] = 0x4E; header[1] = 0x45; header[2] = 0x53; header[3] = 0x1A
         header[6] = 0x21.toByte()
         header[7] = 0x10.toByte()
         val h = Header(header)
@@ -222,5 +201,26 @@ class GamePakTest {
         // Should construct cleanly: validator passes, slice uses unsigned.
         val gp = GamePak(data)
         assertThat(gp.programRom.size, equalTo(16384 * 255))
+    }
+
+    /**
+     * Regression for the Crayon Shin-chan "question mark titlebar": there is no
+     * in-ROM title field at offset 0x10 (that is the start of PRG ROM). A ROM with
+     * byte 7 bit 4 set (a mapper-16 game) must NOT have its PRG bytes rendered as a
+     * name — the display name (filename) is used instead.
+     */
+    @Test
+    fun nameFallsBackToDisplayNameAndNeverReadsPrgAsTitle() {
+        // PRG=1 (16KB) + CHR=1 (8KB) + 16-byte header.
+        val data = ByteArray(16 + 16384 + 8192)
+        data[0] = 0x4E; data[1] = 0x45; data[2] = 0x53; data[3] = 0x1A
+        data[4] = 0x01   // PRG banks
+        data[5] = 0x01   // CHR banks
+        data[7] = 0x10.toByte()  // mapper bit D4 set (mapper 16); used to be misread as "title present"
+        // Put non-ASCII bytes where the old code read a "title" — these are PRG ROM.
+        data[0x10] = 0x80.toByte(); data[0x11] = 0x99.toByte()
+
+        val gamePak = GamePak(data, "Crayon Shin-chan - Ora to Poi Poi (Japan)")
+        assertThat(gamePak.name, equalTo("Crayon Shin-chan - Ora to Poi Poi (Japan)"))
     }
 }


### PR DESCRIPTION
## Summary

PR #117 ("Fix titlebar corruption", `ce3bddc`) rewrote `Header.mapper` on an incorrect premise — that NES 2.0 byte 7 bit 4 is a "title-present flag, not a mapper bit". Per the NES 2.0 spec, **byte 7 bits 4-7 are mapper bits D4-D7** (bit 4 *is* mapper bit D4), and **byte 8's high nibble is the submapper**, not part of the mapper number.

The #117 decode `(byte7 & 0xE0) ushr 1 | (byte8 & 0xFF) shl 8` therefore dropped mapper bit D4 and folded the submapper nibble into the mapper number. Rokudenashi Blues (`byte6=02 byte7=18 byte8=50`) decoded as mapper `0x5000` → `Mapper 20480 not implemented`, and **every NES 2.0 ROM with mapper bit 4 set** (mappers 16–19, incl. Dragon Ball / all Bandai FCG) failed to load. The plain-iNES decode `(byte6>>4)|(byte7&0xF0)` was correct all along.

## Changes

- **`Header.mapper`** — unified, spec-correct decode:
  ```
  (byte6 ushr 4) | (byte7 and 0xF0) | (if (isNes20) (byte8 and 0x0F) shl 8 else 0)
  ```
- **`GamePak.name`** — removed the bogus "in-ROM title at offset 0x10" feature #117 added. Offset 0x10 is the start of PRG ROM; there is no title field there. Reading it rendered PRG opcodes as text and was the actual cause of the "question mark titlebar" for Crayon Shin-chan (a plain-iNES mapper-16 game whose byte 7 bit 4 is set because it *is* mapper 16). The name now falls back to the filename.
- **`GamePakTest`** — replaced the three cases that pinned the wrong behaviour with spec-correct regressions:
  - `nes20Byte7Bit4IsMapperBitNotTitleFlag` (Rokudenashi header → mapper 16, submapper 5)
  - `plainInesByte7Bit4IsMapperBit` (Crayon Shin-chan header → mapper 16)
  - `nes20SubmapperNibbleDoesNotLeakIntoMapper`
  - `nameFallsBackToDisplayNameAndNeverReadsPrgAsTitle`
  - plus the existing extended-mapper and plain-iNES cases (kept)

## Testing

- `./gradlew test` — full unit suite green.

## Scope

This restores loading for Issue #118 (and all NES 2.0 mapper-16+ ROMs). The separate white-screen boot stall in Rokudenashi remains open — see the [investigation comment on #118](https://github.com/alondero/nestlin/issues/118#issuecomment-4643641071).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
