### PR TITLE
Remove mandatory ROM argument requirement

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
@@ -639,14 +639,23 @@ class NestlinApplication : FrameListener, Application() {
                         else -> null
                     }
                 }
-                // Take only the first non-flag parameter as the ROM path (rest are other arguments)
-                val romPath = nonFlagParams.firstOrNull() ?: throw IllegalStateException("No ROM file provided")
-                currentRomPath = Paths.get(romPath)
-                load(currentRomPath!!)
-                powerReset()
-                loadBatteryRam(currentRomPath!!)
+                // Take only the first non-flag parameter as the ROM path (rest are other arguments).
+                // A ROM is optional at launch: the user can now start the emulator with no game
+                // and use File → Load Game... (or Load Recent) once the UI is up. We still spin
+                // up the emulation thread so the canvas/UI stay responsive while idle, and the
+                // pre-existing null-safety in cpu.reset() / loadBatteryRam() / nestlin.start()
+                // means no special-casing is needed in the engine.
+                val romPathArg = nonFlagParams.firstOrNull()
+                if (romPathArg != null) {
+                    currentRomPath = Paths.get(romPathArg)
+                    load(currentRomPath!!)
+                    powerReset()
+                    loadBatteryRam(currentRomPath!!)
+                }
                 // Both calls mutate JavaFX UI nodes, so they need to hop back
-                // to the JavaFX thread (we're inside a `thread { ... }` here).
+                // to the JavaFX thread (we're inside a `thread { ... }` here). When no
+                // ROM is loaded, updateTitle() shows "Nestlin - No Game Loaded" and
+                // updateSlotMenu() disables every slot with a "(no ROM loaded)" label.
                 Platform.runLater {
                     updateTitle()
                     updateSlotMenu()


### PR DESCRIPTION
## Summary

Nestlin now launches with no ROM. The `IllegalStateException("No ROM file provided")` guard in `NestlinApplication.start()` is gone — the user can boot the emulator and pick a game via `File → Load Game…` (or `Load Recent`) once the UI is up.

## Why

The File menu has had a working `Load Game…` action for a while. The launch-time gate was a redundant policy check, not an engine requirement.

The engine was already null-safe for the no-cartridge case:
- `Cpu.reset()` wraps `currentGame?.let { ... }` (no reset-vector lookup, no PRG-RAM read)
- `Nestlin.loadBatteryRam()` early-returns on null `currentGame` / `mapper`
- Battery-flush timer, `handleExit()`, `stop()` all use `currentRomPath?.let { ... }`
- `updateTitle()` falls through to `"Nestlin - No Game Loaded"`
- `updateSlotMenu()` has a `currentRomPath == null` branch that disables every slot with a "(no ROM loaded)" label

Audited all 22 callsites of `currentRomPath` / `currentGame` in `Application.kt` and the engine — every one is null-safe. Feature handlers that genuinely require a cartridge (save/load state, record/play movie, hard reset) keep their existing `"No ROM Loaded"` error dialogs unchanged.

## Diff

`src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt` — 1 file, +16 / -7. Just the guard removal in the startup thread.

## Verification

- `./gradlew build` — `BUILD SUCCESSFUL` (includes `:test`)
- `./gradlew test` — `BUILD SUCCESSFUL`
- No new lint warnings

## Usage

```bash
# Either of these now works — UI launches, use File → Load Game to pick a ROM:
./gradlew run
java -jar build/libs/nestlin-all.jar

# This still works exactly as before:
./gradlew run --args="rom.nes"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)