### PR TITLE
chore: remove dead code from Ppu.kt and Cpu.kt (#24)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/Cpu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/Cpu.kt
@@ -10,7 +10,6 @@ import java.io.File
 class Cpu(var memory: Memory)
 {
     var currentGame: GamePak? = null
-    var interrupt: Interrupt? = null
     var workCyclesLeft = 0
     // The 6502 services an NMI with ~1 instruction of latency: when the NMI line is
     // asserted (PPU vblank) the CPU finishes its current instruction (and often issues
@@ -247,7 +246,9 @@ class Cpu(var memory: Memory)
         out.writeBoolean(pageBoundaryFlag)
         out.writeBoolean(idle)
         out.writeBoolean(nmiArmed)
-        out.writeInt(interrupt?.ordinal ?: -1)
+        // Reserved: the old `Interrupt` enum (IRQ_BRK/NMI/RESET) was removed in issue #24.
+        // The 4-byte slot stays in the format so save files made by older builds still load.
+        out.writeInt(0)
     }
 
     fun loadState(input: DataInput) {
@@ -262,8 +263,8 @@ class Cpu(var memory: Memory)
         pageBoundaryFlag = input.readBoolean()
         idle = input.readBoolean()
         nmiArmed = input.readBoolean()
-        val interruptOrdinal = input.readInt()
-        interrupt = if (interruptOrdinal < 0) null else Interrupt.values()[interruptOrdinal]
+        // Reserved slot — see saveState.
+        input.readInt()
     }
 
     fun push(value: Byte) { memory[0x100 + ((registers.stackPointer--).toUnsignedInt())] = value }
@@ -276,13 +277,7 @@ class Cpu(var memory: Memory)
     private fun readyForNextInstruction() = workCyclesLeft <= 0
 }
 
-enum class Interrupt {
-    IRQ_BRK,
-    NMI,
-    RESET
-}
-
-data class Registers(
+class Registers(
         var stackPointer: Byte = 0,
         var accumulator: Byte = 0,
         var indexX: Byte = 0,
@@ -306,7 +301,7 @@ data class Registers(
 
 }
 
-data class ProcessorStatus(
+class ProcessorStatus(
         var carry: Boolean = false,
         var zero: Boolean = true,
         var interruptDisable: Boolean = true,

--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/Ppu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/Ppu.kt
@@ -8,7 +8,6 @@ import java.io.DataOutput
 const val RESOLUTION_WIDTH = 256
 const val RESOLUTION_HEIGHT = 240
 
-const val IDLE_SCANLINE = 0
 const val POST_RENDER_SCANLINE = 240
 
 class Ppu(var memory: Memory) {
@@ -180,18 +179,6 @@ class Ppu(var memory: Memory) {
         }
 
         //  Every cycle a bit is fetched from the 4 backgroundNametables shift registers in order to create a pixel on screen
-
-
-//        with(spriteNametables) {
-//            decrementCounters()
-//            getActiveSprites().forEach {
-//                // If the counter is zero, the sprite becomes "active", and the respective pair of shift registers for the sprite is shifted once every cycle.
-//                // This output accompanies the data in the sprite's latch, to form a pixel.
-//                it.shiftRegisters()
-//                // The current pixel for each "active" sprite is checked (from highest to lowest priority), and the first non-transparent pixel moves on to a multiplexer,
-//                // where it joins the BG pixel
-//            }
-//        }
 
 
         cycle++
@@ -847,7 +834,7 @@ data class SpriteData(
 /**
  * Sprite with fetched tile data, ready to render on current scanline.
  */
-data class ActiveSprite(
+class ActiveSprite(
     val data: SpriteData,
     val tileDataLow: Byte,    // Pattern table low byte (bit 0 plane)
     val tileDataHigh: Byte,   // Pattern table high byte (bit 1 plane)


### PR DESCRIPTION
Closes #24

Removes the dead-code items listed in issue #24:

- **`Ppu.kt`**: unused `IDLE_SCANLINE` constant
- **`Ppu.kt`**: 10-line commented-out `with(spriteNametables) {...}` block
  referencing a class that no longer exists (leftover from a prior
  sprite rendering approach)
- **`Cpu.kt`**: `enum class Interrupt { IRQ_BRK, NMI, RESET }` and the
  `cpu.interrupt: Interrupt?` field. The field was never assigned or
  read by emulation — it only round-tripped through save state. The
  4-byte save-state slot is preserved (`writeInt(0)` + `readInt()` to
  discard) so existing `.nstl` files still load without bumping
  `SaveState.VERSION`.
- **`Cpu.kt`**: `data class` → `class` for `Registers` and `ProcessorStatus`
- **`Ppu.kt`**: `data class` → `class` for `ActiveSprite`. The
  auto-generated `equals()` on a class with `var` fields that mutate
  in place was actively misleading.

### Issue line numbers vs. current code

The issue's line numbers reference an older Ppu.kt:
- `fetchSpriteTile()` is now a real implementation (not a stub).
- The dead commented-out block had moved to lines 185-194 — that's what
  this PR removes.

### Regression coverage

`SaveStateTest`'s byte-identical save/load round-trip is the gate for
the `Interrupt` removal. 476/476 unit tests pass, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
