### PR TITLE
Buffer undocumented-opcode log writes; flush once at shutdown (issue #29)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/Cpu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/Cpu.kt
@@ -32,6 +32,9 @@ class Cpu(var memory: Memory)
     // TODO: Development-only feature - Remove undocumented opcode logging once emulator stability is proven
     // This allows us to identify missing opcodes without crashing, useful for game compatibility debugging
     private val undocumentedOpcodes = mutableSetOf<Int>()
+    // Buffered log lines; flushed in one write at shutdown. Avoids per-cycle
+    // disk I/O on the hot tick() path. See issue #29.
+    private val undocumentedLogBuffer = mutableListOf<String>()
     private val UNDOCUMENTED_LOG_FILE = "undocumented_opcodes.txt"
 
     fun reset() {
@@ -138,18 +141,20 @@ class Cpu(var memory: Memory)
 
     private fun logUndocumentedOpcode(opcodeVal: Int, pc: Short) {
         if (undocumentedOpcodes.add(opcodeVal)) {
-            // First time seeing this opcode, log it
+            // First time seeing this opcode; buffer the entry for a single bulk
+            // write at shutdown. Avoids per-cycle disk I/O on the hot tick() path.
+            // See issue #29.
             val logEntry = "PC: ${"%04X".format(pc.toUnsignedInt())} - Undocumented opcode: 0x${"%02X".format(opcodeVal)} (treating as NOP)\n"
-            File(UNDOCUMENTED_LOG_FILE).appendText(logEntry)
+            undocumentedLogBuffer.add(logEntry)
         }
     }
 
-    fun dumpUndocumentedOpcodes() {
-        if (undocumentedOpcodes.isNotEmpty()) {
-            val summary = "Found ${undocumentedOpcodes.size} unique undocumented opcodes: " +
-                    undocumentedOpcodes.sorted().joinToString(", ") { "0x${"%02X".format(it)}" }
-            File(UNDOCUMENTED_LOG_FILE).appendText("\n$summary\n")
-        }
+    fun dumpUndocumentedOpcodes(file: File = File(UNDOCUMENTED_LOG_FILE)) {
+        if (undocumentedOpcodes.isEmpty()) return
+        val perOpcodeText = undocumentedLogBuffer.joinToString("")
+        val summary = "\nFound ${undocumentedOpcodes.size} unique undocumented opcodes: " +
+                undocumentedOpcodes.sorted().joinToString(", ") { "0x${"%02X".format(it)}" }
+        file.writeText(perOpcodeText + summary + "\n")
     }
 
     private fun checkAndHandleNmi(): Boolean {

--- a/src/test/kotlin/com/github/alondero/nestlin/cpu/CpuTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cpu/CpuTest.kt
@@ -5,9 +5,13 @@ import com.github.alondero.nestlin.gamepak.GamePak
 import com.github.alondero.nestlin.toSignedByte
 import com.github.alondero.nestlin.toSignedShort
 import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.containsSubstring
 import com.natpryce.hamkrest.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 
 class CpuTest {
@@ -22,6 +26,49 @@ class CpuTest {
         }
 
         assertThat(cpu.registers.programCounter, equalTo(0xC000.toSignedShort()))
+    }
+
+    @Test
+    fun `tick on undocumented opcode does not write to disk but dumpUndocumentedOpcodes does`(
+        @TempDir tempDir: Path
+    ) {
+        // Snapshot the CWD log file's existence so the test is hermetic against
+        // a stray undocumented_opcodes.txt from a prior run or dev session.
+        val cwdFile = File("undocumented_opcodes.txt")
+        val existedBefore = cwdFile.exists()
+
+        // Arrange: Cpu with no currentGame (so the test-ROM guard is off and the
+        // logUndocumentedOpcode branch fires), PC=0, opcode 0xCB at address 0.
+        // 0xCB is one of only 6 bytes absent from the Opcodes map (250 of 256
+        // mapped), so it triggers the `?: run { logUndocumentedOpcode(...) }`
+        // branch in tick(). Set the byte AFTER reset() because reset() calls
+        // memory.clear() which would wipe it.
+        val cpu = Cpu(Memory()).apply {
+            reset()
+            this.memory[0] = 0xCB.toSignedByte()
+        }
+        val dumpFile = tempDir.resolve("undocumented_opcodes.txt").toFile()
+
+        // Sanity: the test-ROM guard is the off-ramp for the logging path.
+        assertThat(cpu.currentGame?.isTestRom() ?: false, equalTo(false))
+
+        // Act 1: tick the CPU through the undocumented opcode. Must NOT touch disk.
+        repeat(10) { cpu.tick() }
+        assertThat(
+            "tick() must not create a file in the working directory",
+            cwdFile.exists() && !existedBefore,
+            equalTo(false)
+        )
+        assertThat("dump target must not exist before dump()", dumpFile.exists(), equalTo(false))
+
+        // Act 2: dump should write the expected content to the explicit path.
+        cpu.dumpUndocumentedOpcodes(dumpFile)
+
+        // Assert: file exists, has both the per-opcode line and the summary line.
+        assertThat(dumpFile.exists(), equalTo(true))
+        val content = dumpFile.readText()
+        assertThat(content, containsSubstring("Undocumented opcode: 0xCB"))
+        assertThat(content, containsSubstring("Found 1 unique undocumented opcodes"))
     }
 
 }


### PR DESCRIPTION
@fixes #29

logUndocumentedOpcode was calling `File(UNDOCUMENTED_LOG_FILE).appendText(logEntry)` from inside the per-cycle CPU `tick()`. That is a blocking system call on the real-time hot path — every cycle that hits an undocumented opcode stalled on disk I/O.

The fix is to buffer per-opcode lines to an in-memory list and write the file in a single `writeText()` call from `dumpUndocumentedOpcodes()` (already invoked from the `finally` block in `Nestlin.run()` at shutdown).

**Changes**
- `Cpu.kt`: add `private val undocumentedLogBuffer: MutableList<String>`; `logUndocumentedOpcode` now appends to the buffer; `dumpUndocumentedOpcodes(file: File = File(UNDOCUMENTED_LOG_FILE))` does one `writeText` of the buffered per-opcode lines + summary. The default arg keeps the `Nestlin.kt:184` call site unchanged. The `.gitignore` already covered the output file (line 98), so no `.gitignore` change was needed.
- `CpuTest.kt`: new regression test (`tick on undocumented opcode does not write to disk but dumpUndocumentedOpcodes does`) using `@TempDir`. Asserts (a) `tick()` does NOT create the log file in the CWD (snapshot-based, hermetic against pre-existing files), and (b) `dumpUndocumentedOpcodes(tempFile)` writes the per-opcode line and summary to the explicit path.

**TDD evidence**
- Red: with the bug in place, the new test fails at the CWD-assertion: *"tick() must not create a file in the working directory: expected: a value that is equal to false but was: true"*. The 55-byte CWD file was created and contained `PC: 0000 - Undocumented opcode: 0xCB (treating as NOP)`.
- Green: after the buffer refactor, the test passes; the CWD file is absent after a successful run.

**Test count:** 477 tests, 0 failures, 9 ignored (Mesen2-oracle tests that skip when the binary is absent — unchanged).

**Trigger byte for the test:** `0xCB`. Research found the `Opcodes` map actually has 250 entries (not the "151" mentioned in the `Cpu.kt:34` comment), with only 6 truly-undocumented bytes: `0x0B`, `0x2B`, `0x8B`, `0x9C`, `0x9E`, `0xCB`. That stale comment is left alone here — out of scope for this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)@