### PR TITLE
Agent-effectiveness tooling: divergence localizer, TestRomBuilder + header lint, diagnostics, CI test gating

### DIFF
--- a/.claude/hooks/worktree-guard.ps1
+++ b/.claude/hooks/worktree-guard.ps1
@@ -1,0 +1,61 @@
+<#
+PreToolUse hook: block Write/Edit calls that escape a Claude Code worktree into the
+parent repository.
+
+Why: sessions running inside .claude/worktrees/<name>/ have twice written files into
+the parent repo (X:\src\nestlin\src\...) by using the parent's absolute path instead
+of the worktree's. The global instructions forbid it, but instructions are advisory —
+this hook makes it mechanical.
+
+Behavior:
+  - Not in a worktree session  -> exit 0 (allow, instantly)
+  - Target inside the worktree -> exit 0 (allow)
+  - Target inside the PARENT repo (the part of the path before \.claude\worktrees\)
+                               -> exit 2 (BLOCK; stderr tells the agent the corrected path)
+  - Target elsewhere (memory dir, temp, other drives) -> exit 0 (not this hook's business)
+
+Windows-first by design (this project's dev platform). On hosts without powershell the
+hook fails non-blocking and Claude Code proceeds.
+#>
+$ErrorActionPreference = 'Stop'
+
+try {
+    $payload = [Console]::In.ReadToEnd() | ConvertFrom-Json
+
+    $projectDir = $env:CLAUDE_PROJECT_DIR
+    if (-not $projectDir) { $projectDir = (Get-Location).Path }
+
+    # Only act when the session itself lives inside a worktree.
+    $marker = '\.claude\worktrees\'
+    $idx = $projectDir.ToLowerInvariant().IndexOf($marker.ToLowerInvariant())
+    if ($idx -lt 0) { exit 0 }
+    $parentRepo = $projectDir.Substring(0, $idx)
+
+    $target = $payload.tool_input.file_path
+    if (-not $target) { $target = $payload.tool_input.notebook_path }
+    if (-not $target) { exit 0 }
+
+    if (-not [System.IO.Path]::IsPathRooted($target)) {
+        $target = Join-Path $projectDir $target
+    }
+    $target = [System.IO.Path]::GetFullPath($target)
+
+    $t = $target.ToLowerInvariant()
+    $wt = ($projectDir.TrimEnd('\') + '\').ToLowerInvariant()
+    $pr = ($parentRepo.TrimEnd('\') + '\').ToLowerInvariant()
+
+    if ($t.StartsWith($wt)) { exit 0 }          # inside the worktree: fine
+    if ($t.StartsWith($pr)) {
+        $relative = $target.Substring($parentRepo.TrimEnd('\').Length).TrimStart('\')
+        [Console]::Error.WriteLine(
+            "BLOCKED: this session runs in the worktree '$projectDir' but the write targets the PARENT repo: $target. " +
+            "Use the worktree path instead: $(Join-Path $projectDir $relative)")
+        exit 2
+    }
+    exit 0
+}
+catch {
+    # A broken hook must never block legitimate work — fail open, but say why.
+    [Console]::Error.WriteLine("worktree-guard hook error (allowing call): $_")
+    exit 0
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/worktree-guard.ps1"
+          }
+        ]
+      }
+    ]
+  },
   "enabledPlugins": {
     "jdtls-lsp@claude-plugins-official": true,
     "context7@claude-plugins-official": true,

--- a/.claude/skills/mesen/SKILL.md
+++ b/.claude/skills/mesen/SKILL.md
@@ -11,16 +11,16 @@ Mesen is a cycle-accurate NES/Famicom emulator. Two distinct binaries ship on th
 
 | Capability | Mesen v1 (`tools/Mesen/Mesen.exe`) | Mesen v2 (`tools/Mesen2/Mesen.exe`) |
 |---|---|---|
-| Headless (`--testrunner`) | yes — true headless | no — requires display |
-| `emu.getState()` | yes | yes |
+| Headless (`--testRunner`) | yes — true headless | **yes** (verified 2026-06-08 on v2.1.1, incl. `emu.read` and memory callbacks) |
+| `emu.getState()` | yes | yes — returns a **FLAT dotted-key table** (`s["cpu.pc"]`), not nested |
 | `emu.takeScreenshot()` | yes | yes |
-| `emu.read()` | no — deadlocks in headless | yes — in GUI mode |
-| `emu.addMemoryCallback()` | limited | yes — full |
+| `emu.read()` | no — deadlocks in headless | yes — GUI **and** `--testRunner` |
+| `emu.addMemoryCallback()` | limited | yes — via **`emu.callbackType`** (see below) |
 | `emu.execute(count, type)` | yes | yes |
-| `emu.stop()` | yes | no — hangs; use `os.exit()` |
+| `emu.stop(code)` | yes | **yes** — exits cleanly with the code (earlier "use os.exit()" advice obsolete) |
 | Mapper introspection via `nesMapperRam` memType | partial | yes |
 
-**Rule of thumb:** for byte-level inspection of mapper behavior, use **v2 in GUI mode** with `--doNotSaveSettings`. For pure regression screenshots in CI, v1 headless is fine.
+**Rule of thumb:** use **v2 `--testRunner --doNotSaveSettings`** for everything scripted — it is headless-capable on this machine. Before writing fresh Lua, check `tools/mesen-trace/` — write-watch, interrupt-counter, ppuctrl-transitions, and chr-dump are already there, verified against the installed binary.
 
 ## Absolute paths (no relative path discipline survives worktrees)
 
@@ -54,7 +54,7 @@ Mesen.exe --testrunner <script.lua> <rom>
 
 | Call | Use |
 |---|---|
-| `emu.getState()` | Returns nested table: `state.cpu.{pc,a,x,y,sp,status,cycleCount,nmiFlag,irqFlag}`, `state.ppu.{cycle,scanline,frameCount,control,mask,status,state.{videoRamAddr,...}}`, `state.apu.{square1,square2,triangle,noise,dmc,frameCounter}`, `state.cart.{selectedChrPages[0..7],selectedPrgPages[0..3],chrRomSize,prgRomSize,prgPageCount,chrPageCount,chrPageSize,prgPageSize}`. |
+| `emu.getState()` | **v2.1.1 reality:** a FLAT table with dotted string keys — `s["cpu.pc"]`, `s["ppu.scanline"]`, `s["ppu.frameCount"]`, `s["cpu.cycleCount"]`, etc. (`state.cpu.pc` nested access throws nil-index.) **Inside event/memory callbacks** the table is PARTIAL: no `ppu.*`, no `cart.*` keys — an unguarded access silently aborts the rest of the callback. Count frames yourself via an `endFrame` callback instead of reading `ppu.frameCount` there. |
 | `emu.setState(state)` | Writes CPU/PPU back (NOT APU or cart). Useful for forcing a known state to repro. |
 | `emu.takeScreenshot()` | Returns raw PNG bytes — `io.open(path, "wb"); f:write(data); f:close()`. |
 | `emu.getRomInfo()` | Mapper number, PRG/CHR sizes, mirroring — surface what the ROM declares. |
@@ -66,7 +66,7 @@ Mesen.exe --testrunner <script.lua> <rom>
 | `emu.read(addr, memType, signed=false)` | One byte from any memory space. **v2 GUI only.** |
 | `emu.readWord(addr, memType, signed=false)` | Two bytes. |
 | `emu.write(addr, value, memType)` | Inject a value. Writes to `prgRom`/`chrRom` are reversible via `emu.revertPrgChrChanges()`. |
-| `emu.addMemoryCallback(fn, type, startAddr [, endAddr])` | Fire on every CPU read/write/exec or PPU read/write in a range. **This is how you watch mapper-register writes** — register for `cpuWrite` over `$8000..$FFFF` and log `address, value, state.cpu.cycleCount`. Returning a number from the callback rewrites the operation's value. |
+| `emu.addMemoryCallback(fn, type, startAddr [, endAddr])` | Fire on every access in a range. **v2.1.1: `type` comes from `emu.callbackType`, whose ONLY keys are `exec`, `read`, `write`** — `emu.memCallbackType` is nil and there is no `cpuWrite`/`ppuRead` variant. Watch mapper-register writes with `emu.addMemoryCallback(fn, emu.callbackType.write, 0x8000, 0xFFFF)`; the callback receives `(address, value)`. Do NOT call `emu.getState()` inside it for ppu/cart fields (they're absent there). Returning a number from the callback rewrites the operation's value. |
 | `emu.removeMemoryCallback(ref, type, ...)` | Unregister. |
 | `emu.getPrgRomOffset(cpuAddr)` | Maps a CPU address to a byte offset in the PRG ROM file — invaluable for reasoning about bank switching. |
 | `emu.getChrRomOffset(ppuAddr)` | Maps a PPU address to CHR ROM file offset. |
@@ -81,14 +81,13 @@ Mesen.exe --testrunner <script.lua> <rom>
 | `emu.resume()` | Continue after `breakExecution()`. |
 | `emu.reset()` | Soft reset. |
 | `emu.rewind(seconds)` | Only valid from `startFrame` callback. |
-| `emu.stop(exitCode)` | v1 only; in v2 use `os.exit()`. |
+| `emu.stop(exitCode)` | Works on BOTH v1 and v2.1.1 — exits `--testRunner` with the given code. (Old "v1 only, use os.exit()" advice was wrong for the installed v2.) |
 
 ### Event hooks
 
-`emu.addEventCallback(fn, eventType)` where eventType is:
-`reset, nmi, irq, startFrame, endFrame, codeBreak, stateLoaded, stateSaved, inputPolled, spriteZeroHit, scriptEnded`.
+`emu.addEventCallback(fn, eventType)` — v2.1.1 keys (dumped at runtime): `codeBreak, endFrame, inputPolled, irq, nmi, reset, scriptEnded, startFrame, stateLoaded, stateSaved`.
 
-Register callbacks **before** `emu.resume()`. The callback receives no args; query state via `emu.getState()` inside it.
+`emu.eventType.irq` **fires for mapper IRQs** and is reliable for counting fires per frame — increment a global, attribute to a frame via your own `endFrame` counter. This is the instrument that proved Mesen fires the RAMBO-1 IRQ once/frame vs Nestlin's twice. The callback receives no args; do NOT rely on `emu.getState()` ppu/cart fields inside it (absent — see above).
 
 ### Drawing overlays (debugging visualisation)
 
@@ -116,42 +115,30 @@ local oam = pick("nesSpriteRam", "spriteRam", "oam")
 
 ## Mapper-inspection recipe
 
-For obscure mappers, the question is usually "which $8000-region writes is the ROM making, and when?" — this is the canonical Lua to dump that, runnable via `Mesen2OamDumpRunner`-style harness:
+For obscure mappers, the question is usually "which $8000-region writes is the ROM making, and when?" — **do not write this from scratch: use `tools/mesen-trace/write-watch.lua`** (edit its CONFIG block). The companions cover the other recurring questions: `interrupt-counter.lua` (NMI/IRQ fires per frame — the instrument that cracked the Gimmick hang and the Klax double-IRQ), `ppuctrl-transitions.lua` (did rendering/NMI ever get enabled?), `chr-dump.lua` (which CHR bank is mapped at frame N?). All verified against the installed v2.1.1; see `tools/mesen-trace/README.md`.
+
+Key shape they all share (this is what a correct v2.1.1 trace looks like):
 
 ```lua
-local writes = {}
-local memTypes = {}
-for k, v in pairs(emu.memType) do memTypes[k] = v end
-
-local function onMapperWrite(address, value)
-    local s = emu.getState()
-    table.insert(writes, string.format(
-        "f=%d sl=%d cyc=%d cpu=%d addr=${'$'}%04X val=${'$'}%02X",
-        s.ppu.frameCount, s.ppu.scanline, s.ppu.cycle, s.cpu.cycleCount,
-        address, value))
-end
-
--- Watch the cartridge address space
-emu.addMemoryCallback(onMapperWrite, emu.memCallbackType.cpuWrite, 0x8000, 0xFFFF)
-
-local targetFrame = 600
+-- frame attribution: own counter, NOT getState() inside the callback
 local frame = 0
-function onEnd()
-    frame = frame + 1
-    if frame >= targetFrame then
-        local base = emu.getScriptDataFolder()
-        local last = string.sub(base, -1)
-        if last ~= "\\" and last ~= "/" then base = base .. "\\" end
-        local f = io.open(base .. "mapper-writes.txt", "w")
-        for _, line in ipairs(writes) do f:write(line .. "\n") end
-        f:close()
-        os.exit()
-    end
+local f = assert(io.open(emu.getScriptDataFolder() .. "/out.txt", "w"))
+
+local function onWrite(address, value)
+    f:write(string.format("frame=%d addr=%04X val=%02X\n", frame, address, value))
+    f:flush()  -- crash mid-run still leaves usable data
 end
-emu.addEventCallback(onEnd, emu.eventType.endFrame)
+
+local function onEndFrame()
+    frame = frame + 1
+    if frame >= 600 then f:close(); emu.stop(0) end
+end
+
+emu.addMemoryCallback(onWrite, emu.callbackType.write, 0x8000, 0xFFFF)
+emu.addEventCallback(onEndFrame, emu.eventType.endFrame)
 ```
 
-For PPU-side mapper triggers (MMC3 A12 IRQ), swap `cpuWrite` for `ppuRead` over `$0000..$1FFF` and log every read — then post-process to find rising A12 edges (low→high in address bit 12).
+For PPU-side mapper triggers (MMC3 A12 IRQ), use `emu.callbackType.read` over `$0000..$1FFF` and post-process for rising A12 edges (low→high in address bit 12).
 
 For PRG ROM offset tracking (which physical bank is mapped at the moment of the write), include `emu.getPrgRomOffset(address)` in the log line.
 

--- a/.claude/skills/new-mapper/SKILL.md
+++ b/.claude/skills/new-mapper/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: new-mapper
+description: Checklist-driven workflow for implementing a new NES mapper in Nestlin (or fixing a mapper that "works in unit tests but the game doesn't boot"). Invoke whenever adding mapper support for a new mapper number, implementing a board (MMC/VRC/FME/Namco/Bandai/etc.), or when a newly-merged mapper still fails in a real game. Encodes the oracle ordering and test requirements distilled from every past mapper implementation.
+---
+
+# New Mapper Implementation Checklist
+
+Five past mappers shipped with green test suites that asserted the bug (GxROM decode,
+RAMBO-1 ×2, Bandai EEPROM, NES 2.0 header split). Every one happened because the wrong
+source was treated as ground truth, or the test exercised registers the real game never
+touches. This checklist exists to make those failure modes impossible. Work through it
+in order; do not skip steps because the mapper "looks simple".
+
+## Step 0 — Identify the actual board (headers lie)
+
+- Decode the ROM's header yourself before trusting the issue title. Known traps:
+  - Every Namco 108/DxROM dump (Gauntlet, Ring King, RBI Baseball, Mappy-Land) is
+    labelled **mapper 4** in iNES bytes 6/7. Patch a *copy* for mapper-206 work:
+    byte6 `(b6 & 0x0F) | 0xE0`, byte7 `(b7 & 0x0F) | 0xC0`.
+  - Captain Tsubasa II is mapper 4, NOT 33. Alien Syndrome is 118, NOT 64.
+  - iNES 1.0 dumps omit the submapper the board may require (broke two Bandai games).
+- NES 2.0 decode: mapper = `(byte6>>4) | (byte7&0xF0) | (isNes20 ? (byte8&0x0F)<<8 : 0)`;
+  byte 7 **bit 4 is mapper bit D4**, not a flag; NES 2.0 = byte 7 bits 2-3 == 0b10;
+  submapper = byte 8 high nibble.
+
+## Step 1 — Oracle ordering (hard rule)
+
+1. **nesdev wiki page** for the mapper number — the spec.
+2. **Mesen2's mapper source** (`Core/NES/Mappers/<family>/<Board>.h` in the Mesen2 repo)
+   — the tiebreaker. When wiki prose and Mesen disagree, **Mesen wins** (proven twice:
+   VRC4 `$9002` bit layout, RAMBO-1 IRQ reload). When the GitHub **issue spec disagrees
+   with both, the issue is design *intent* only** — the RAMBO-1 issue's "no-IRQ/masked
+   bits" claims were simply wrong.
+3. Watch for family look-alikes that differ in one trap detail: RAMBO-1 is "MMC3-shaped"
+   but has 4-bit bank selects, K-bit 1KB CHR mode, R15, and `latch+2` IRQ reload;
+   TC0190 R0/R1 preserve the LSB unlike MMC3; mapper 25 swaps the low address bits.
+
+## Step 2 — Implementation conventions
+
+- Register decode masks: most boards alias addresses — decode via `addr & MASK` `when`
+  arms (see `Mapper33.kt` for `addr & 0xA003`, `Mapper113.kt` for a `$4100` window with
+  mask `0xE100`).
+- IRQ clocking: a mapper counts **either** A12 edges (MMC3 family) **or** CPU cycles
+  (FME-7, Bandai, via `Mapper.tickCpuCycle()`) — never both.
+- Reads the chip doesn't drive must return the **open-bus value** (`dataBus`), not 0 —
+  a 0 read decodes as BRK and derails boot (Mind Blower Pak).
+- Mappers with state: bump `saveStateVersion`, override `saveState`/`loadState`, call
+  `super` first.
+
+## Step 3 — Tests (all four kinds, in this order)
+
+1. **Unit tests with `testutil.TestRomBuilder`** — never hand-roll the 16-byte header
+   (7+ past incidents: missing magic, 16KB-vs-8KB unit confusion, submapper nibble).
+   Assert register decode, bank arithmetic, mirroring, IRQ enable/disable/ack.
+2. **Game-usage trace test** — run `tools/mesen-trace/write-watch.lua` against the real
+   ROM to record which registers/modes the game *actually* writes, then make a test
+   that drives exactly that sequence (the `Mapper64KlaxBankTraceTest` pattern). A suite
+   that only exercises registers the game never touches is how RAMBO-1 stayed "green"
+   through four broken versions.
+3. **Mesen2 regression test** — subclass `compare.MapperRegressionTestBase`
+   (~25 lines): bank-moves-during-boot guard + render-output (OAM/palette/PPUCTRL/
+   PPUMASK) byte-compare at frame N. Annotate `@RequiresMesen2`; add the class to the
+   `mesenTests` list in `build.gradle.kts`. Pick a **static-screen** capture frame —
+   animated screens swap CHR banks mid-frame and aren't phase-stable (GxROM lesson).
+   Note OAM can be legitimately incomparable when the game's NMI handler rewrites OAM
+   between the two capture points (Don Doko Don) — CHR byte-equality is the mapper's
+   proof in that case.
+4. **For scanline-IRQ mappers: assert WHEN the IRQ fires** — count + scanline vs
+   Mesen2 (`tools/mesen-trace/interrupt-counter.lua` vs Nestlin's `Cpu.nmiCount`/
+   `irqCount`), not end-of-frame CHR bytes. An end-of-frame compare cannot see a
+   mid-frame double-fire (the RAMBO-1 v6 trap: "CHR matched byte-for-byte" while the
+   IRQ fired twice per frame).
+
+## Step 4 — Boot verification against the real game
+
+- Run the game; if it doesn't boot, run `./gradlew diverge -Prom=<rom> -Pframe=60`
+  FIRST — the DivergenceLocalizer's classification table maps the divergence shape to
+  the likely subsystem before you form a hypothesis. Do not start from a guess.
+- Update `MAPPER_SUPPORT.md` (games tested, quirks) and close out with the regression
+  suite green: `./gradlew test` and `./gradlew testMesenComparison`.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v3
+      # Mesen2-dependent comparison tests are excluded from `test` by build.gradle.kts;
+      # they run locally via `./gradlew testMesenComparison`.
+      - run: ./gradlew test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,20 @@ Personal learning project. 6502 CPU + 2C02 PPU + 2A03 APU. JavaFX 21 UI, Mesen2 
 # Run the Mesen2-comparison suite (needs Mesen2 on disk — see CLAUDE.local.md)
 ./gradlew testMesenComparison
 
+# Diagnose "game renders wrong / doesn't boot": side-by-side Nestlin-vs-Mesen2 state
+# at frame N (PPUCTRL/MASK, NMI+IRQ per frame, banks, OAM/palette/CHR/RAM diffs)
+# plus automated LIKELY-CAUSE classification. Run this BEFORE forming a hypothesis.
+./gradlew diverge -Prom=X:/src/nestlin/testroms/kirby.nes -Pframe=120
+
+# Print test-environment diagnostics (MESEN2_PATH resolution, ROM availability,
+# strict-mode flag) — run when a comparison test reports SKIPPED unexpectedly
+./gradlew verifyTestEnv
+
+# Run ONE test class/method and print only its output (no Gradle noise, cache defeated,
+# failure messages + system-out extracted from the result XML). Use for diagnostic loops.
+tools/run-diag.ps1 -TestClass GoldenLogTest            # or tools/run-diag.sh from bash
+tools/run-diag.ps1 -TestClass Mapper10RegressionTest -Mesen
+
 # Run the emulator UI
 ./gradlew run --args="path/to/rom.nes"
 
@@ -89,7 +103,13 @@ testroms/                    # nestest.nes is the only ROM in git
 
 ## Testing Strategy (one-paragraph version)
 
-Read `docs/TESTING_STRATEGY.md` before adding tests. The pyramid, top to bottom:
+Read `docs/TESTING_STRATEGY.md` before adding tests. Test-fixture rules:
+
+- **Never hand-roll a 16-byte iNES header** — use `testutil.TestRomBuilder` (`testRom { mapper = 33; prgKb = 128; ... }`). `HeaderConstructionLintTest` fails the build for new raw `ByteArray(16)` headers (grandfathered files are baselined; the list only shrinks).
+- **New mapper regression tests subclass `compare.MapperRegressionTestBase`** (~25 lines: bank-moves-during-boot guard + render-output compare vs Mesen2) and annotate `@RequiresMesen2` (loud skip naming the resolved path; set `NESTLIN_REQUIRE_MESEN2` to turn skips into failures, e.g. on a runner that must have Mesen2).
+- **New mapper work follows the `new-mapper` skill checklist** (oracle ordering: nesdev wiki → Mesen2 source → issue spec is intent only; game-usage trace test; IRQ fire-count assertions for scanline mappers).
+
+The pyramid, top to bottom:
 
 1. **Structured state diff** against Mesen2 — `Mesen2StateCapturer` → JSON of CPU/PPU/RAM/OAM/palette; byte-compare with `StateComparator`. This is the workhorse. `Mapper10RegressionTest` is the worked example.
 2. **Hook-based behaviour assertions** — `emu.addMemoryCallback` for cycle-sensitive bugs (MMC3 A12, NMI counts, `$2002` polling).
@@ -102,6 +122,8 @@ Read `docs/TESTING_STRATEGY.md` before adding tests. The pyramid, top to bottom:
 - `docs/TESTING_STRATEGY.md` — the test pyramid and how to add a regression test. Actively maintained.
 - `README.md` — build/test/run entry points and the full tooling list.
 - `tools/dump_analyzer.py` — parse 64KB CPU memory dumps (`.dmp`) from debug sessions and query them by region, register, or address. Useful for post-mortem debugging.
+- `tools/mesen-trace/` — checked-in, v2.1.1-verified Mesen2 Lua instruments (mapper write-watch, NMI/IRQ-per-frame counter, PPUCTRL transition log, CHR dump). Use these instead of writing fresh Lua; see its README for the invocation and the installed binary's API quirks.
+- `tools/run-diag.ps1` — single-test diagnostic runner (see Build/Test/Run above).
 
 `docs/` also contains older design notes (`PPU_RENDERING_PLAN.md`, `DONKEY_KONG_RENDERING_PLAN.md`) that describe specific milestones. They're kept for context but not actively maintained — reference them from commit messages or PR descriptions when relevant, not from this file.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -157,9 +157,69 @@ tasks.register<Test>("testMesenComparison") {
     if (donDokoDonRom != null) {
         environment("NESTLIN_DON_DOKO_DON_ROM", donDokoDonRom)
     }
+    // Strict mode for @RequiresMesen2: when set, a missing Mesen2 hard-fails the
+    // comparison tests instead of skipping them (guards against a broken
+    // MESEN2_PATH silently false-greening the suite).
+    val requireMesen2 = System.getenv("NESTLIN_REQUIRE_MESEN2")
+    if (requireMesen2 != null) {
+        environment("NESTLIN_REQUIRE_MESEN2", requireMesen2)
+    }
     // Show stdout/stderr from tests (e.g. the diff% println) so we can see results.
     testLogging {
         events("passed", "failed", "skipped", "standard_out", "standard_error")
         showStandardStreams = true
+    }
+}
+
+// Divergence localizer: capture Nestlin + Mesen2 at a frame, print a side-by-side
+// table of render-output state and "LIKELY CAUSE" classifications.
+// Usage: ./gradlew diverge -Prom=X:/src/nestlin/testroms/kirby.nes -Pframe=120 [-Pout=DIR]
+tasks.register<JavaExec>("diverge") {
+    group = "verification"
+    description = "Runs the DivergenceLocalizer against a ROM (use -Prom=, optional -Pframe=, -Pout=)"
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("com.github.alondero.nestlin.compare.DivergeMainKt")
+
+    val rom = project.findProperty("rom") as String?
+    val frame = project.findProperty("frame") as String?
+    val out = project.findProperty("out") as String?
+    doFirst {
+        if (rom == null) {
+            throw GradleException("Missing -Prom=<path-to-rom>. Usage: ./gradlew diverge -Prom=rom.nes [-Pframe=120] [-Pout=DIR]")
+        }
+    }
+    args = buildList {
+        if (rom != null) add(rom)
+        if (frame != null) { add("--frame"); add(frame) }
+        if (out != null) { add("--out"); add(out) }
+    }
+    // Forward MESEN2_PATH like testMesenComparison does (the Gradle daemon may not
+    // inherit shell env vars cleanly between invocations).
+    val mesen2Path = System.getenv("MESEN2_PATH")
+    if (mesen2Path != null) {
+        environment("MESEN2_PATH", mesen2Path)
+    }
+}
+
+// Sanity-check the local test environment (Mesen2, ROMs, strict mode) before
+// chasing phantom SKIPPED/green results.
+tasks.register("verifyTestEnv") {
+    group = "verification"
+    description = "Prints the resolved Mesen2 path, test ROM availability, and related env vars"
+    doLast {
+        val mesen2Env = System.getenv("MESEN2_PATH")
+        val mesen2Prop = System.getProperty("mesen2.path")
+        val resolved = mesen2Env ?: mesen2Prop ?: "tools/Mesen2/Mesen.exe"
+        val resolvedFile = file(resolved)
+        println("MESEN2_PATH env:            ${mesen2Env ?: "(not set)"}")
+        println("mesen2.path property:       ${mesen2Prop ?: "(not set)"}")
+        println("Resolved Mesen2 path:       ${resolvedFile.absolutePath}")
+        println("Mesen2 exists:              ${resolvedFile.exists()}")
+        println("testroms/nestest.nes:       ${file("testroms/nestest.nes").exists()}")
+        println("Parent testroms dir:        ${file("X:/src/nestlin/testroms").exists()} (X:/src/nestlin/testroms)")
+        println("NESTLIN_REQUIRE_MESEN2 set: ${!System.getenv("NESTLIN_REQUIRE_MESEN2").isNullOrBlank()}")
+        println()
+        println("Reminder: the Gradle daemon may hold STALE env vars from a previous shell.")
+        println("If a value above looks wrong or a test SKIPs unexpectedly: ./gradlew --stop, then re-run.")
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/Cpu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/Cpu.kt
@@ -20,6 +20,13 @@ class Cpu(var memory: Memory)
     // the latch, suppressing the NMI for that frame. Camerica/Codemasters titles (Big
     // Nose, Micro Machines) hang without it. See BigNoseHangTest.
     var nmiArmed = false
+    // Diagnostic counters: incremented exactly once per *dispatched* interrupt (the
+    // point the vector is taken, not when armed/pending). Deliberately NOT part of
+    // save-state serialisation — these are debugging telemetry, not emulation state.
+    // The compare/DivergenceLocalizer harness reads per-frame deltas of these to
+    // compare NMI/IRQ-per-frame against Mesen2's event counts.
+    var nmiCount = 0
+    var irqCount = 0
     var pageBoundaryFlag = false
     var registers = Registers()
     var processorStatus = ProcessorStatus()
@@ -42,6 +49,8 @@ class Cpu(var memory: Memory)
         registers.reset()
         workCyclesLeft = 0
         nmiArmed = false
+        nmiCount = 0
+        irqCount = 0
         currentGame?.let {
             memory.readCartridge(it)
             registers.initialise(memory)
@@ -200,6 +209,8 @@ class Cpu(var memory: Memory)
         // NMI takes 7 cycles
         workCyclesLeft = 7
 
+        nmiCount++
+
         return true
     }
 
@@ -234,6 +245,8 @@ class Cpu(var memory: Memory)
 
         // Acknowledge IRQ from mapper (APU IRQ is cleared elsewhere by the APU)
         memory.mapper?.acknowledgeIrq()
+
+        irqCount++
 
         return true
     }

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/DivergeMain.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/DivergeMain.kt
@@ -1,0 +1,65 @@
+package com.github.alondero.nestlin.compare
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.system.exitProcess
+
+/**
+ * CLI entry point for the DivergenceLocalizer.
+ *
+ * Usage: DivergeMainKt <rom> [--frame N] [--out DIR]
+ *   --frame defaults to 120
+ *   --out   defaults to build/reports/divergence/<romname>-frame-N
+ *
+ * Invoked via the `diverge` Gradle task:
+ *   ./gradlew diverge -Prom=X:/src/nestlin/testroms/kirby.nes -Pframe=120
+ */
+fun main(args: Array<String>) {
+    if (args.isEmpty()) {
+        System.err.println("Usage: diverge <rom> [--frame N] [--out DIR]")
+        exitProcess(2)
+    }
+
+    val romPath = Paths.get(args[0])
+    var frame = 120
+    var outDir: Path? = null
+
+    var i = 1
+    while (i < args.size) {
+        when (args[i]) {
+            "--frame" -> {
+                frame = args.getOrNull(i + 1)?.toIntOrNull()
+                    ?: run { System.err.println("--frame requires an integer"); exitProcess(2) }
+                i += 2
+            }
+            "--out" -> {
+                outDir = args.getOrNull(i + 1)?.let { Paths.get(it) }
+                    ?: run { System.err.println("--out requires a directory"); exitProcess(2) }
+                i += 2
+            }
+            else -> {
+                System.err.println("Unknown argument: ${args[i]}")
+                exitProcess(2)
+            }
+        }
+    }
+
+    if (!Files.exists(romPath)) {
+        System.err.println("ROM not found: $romPath")
+        exitProcess(2)
+    }
+
+    val romName = romPath.fileName.toString().substringBeforeLast('.')
+    val reportDir = outDir ?: Paths.get("build/reports/divergence/$romName-frame-$frame")
+
+    if (!Mesen2StateCapturer.isMesen2Available()) {
+        println("NOTE: Mesen2 not found at ${Mesen2StateCapturer.getMesen2Path().toAbsolutePath()} — " +
+                "Nestlin-only capture; classification needs Mesen2 (set MESEN2_PATH).")
+    }
+
+    val report = DivergenceLocalizer.localize(romPath, frame, reportDir)
+
+    println(report.table)
+    println("Reports written to: ${reportDir.toAbsolutePath()}")
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/DivergenceLocalizer.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/DivergenceLocalizer.kt
@@ -1,0 +1,268 @@
+package com.github.alondero.nestlin.compare
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Localizes WHERE Nestlin diverges from the Mesen2 oracle for a given ROM + frame,
+ * and classifies the LIKELY CAUSE using a decision tree distilled from nine past
+ * debugging sessions (Gimmick NMI latch, Akira OAM DMA, RAMBO-1 double-fire,
+ * Mind Blower Pak open-bus, Don Doko Don OAM phase, Micro Machines forced blank,
+ * Big Nose NMI latency, Mapper 66 CHR decode, OAM DMA halt cycles).
+ *
+ * Output: a side-by-side table over the *render-output* state (the fields that are
+ * stable across the Mesen2-scanline-240 / Nestlin-scanline-261 capture offset) plus
+ * per-frame NMI/IRQ dispatch counts, with zero or more "LIKELY CAUSE" lines ordered
+ * most -> least specific. PC and PPUSTATUS are shown but informational only — the
+ * capture offset makes them inherently non-comparable.
+ */
+object DivergenceLocalizer {
+
+    data class DivergenceReport(
+        val nestlin: EmulatorStateSnapshot,
+        val mesen2: EmulatorStateSnapshot?,   // null when Mesen2 is unavailable
+        val table: String,                    // the full divergence-report.txt contents
+        val classifications: List<String>,    // the LIKELY CAUSE lines (empty when Mesen2 absent)
+        val reportDir: Path
+    ) {
+        val mesen2Available: Boolean get() = mesen2 != null
+    }
+
+    /**
+     * Captures both emulators at [frame] for [romPath], writes
+     * nestlin-state.json / mesen2-state.json / divergence-report.txt into
+     * [reportDir], and returns the parsed report.
+     *
+     * When Mesen2 is not available the Nestlin-side table is still produced,
+     * with a note that classification needs Mesen2.
+     */
+    fun localize(romPath: Path, frame: Int, reportDir: Path): DivergenceReport {
+        val nestlin = NestlinStateCapturer.captureState(romPath, frame)
+        val mesen2 = if (Mesen2StateCapturer.isMesen2Available()) {
+            Mesen2StateCapturer.captureState(romPath, frame)
+        } else null
+        return report(nestlin, mesen2, reportDir)
+    }
+
+    /**
+     * Builds + writes the report from snapshots captured elsewhere (so callers that
+     * already paid for the captures — e.g. MapperRegressionTestBase — don't re-run
+     * both emulators).
+     */
+    fun report(nestlin: EmulatorStateSnapshot, mesen2: EmulatorStateSnapshot?, reportDir: Path): DivergenceReport {
+        Files.createDirectories(reportDir)
+        Files.writeString(reportDir.resolve("nestlin-state.json"), nestlin.toJson())
+        if (mesen2 != null) {
+            Files.writeString(reportDir.resolve("mesen2-state.json"), mesen2.toJson())
+        }
+
+        val classifications = if (mesen2 != null) classify(nestlin, mesen2) else emptyList()
+        val table = buildTable(nestlin, mesen2, classifications)
+        Files.writeString(reportDir.resolve("divergence-report.txt"), table)
+
+        return DivergenceReport(nestlin, mesen2, table, classifications, reportDir)
+    }
+
+    // ------------------------------------------------------------------ table
+
+    private fun buildTable(
+        nestlin: EmulatorStateSnapshot,
+        mesen2: EmulatorStateSnapshot?,
+        classifications: List<String>
+    ): String {
+        val sb = StringBuilder()
+        sb.appendLine("Divergence Report — ${nestlin.romName} @ frame ${nestlin.frameNumber}")
+        sb.appendLine("=".repeat(70))
+        sb.appendLine("Capture offset: Mesen2 endFrame fires at scanline 240 (pre-NMI),")
+        sb.appendLine("Nestlin's frame callback at scanline 261 (post-NMI). CPU registers and")
+        sb.appendLine("cycle counts are therefore NON-comparable; PC and PPUSTATUS below are")
+        sb.appendLine("informational only. Render outputs (OAM, palette, CHR, PPUCTRL, PPUMASK)")
+        sb.appendLine("reflect the completed frame and ARE comparable.")
+        sb.appendLine()
+
+        fun fmtCount(v: Int) = if (v < 0) "?" else v.toString()
+        fun row(label: String, n: String, m: String, note: String = "") {
+            val diff = if (mesen2 == null) "" else if (n == m) "" else "  <-- DIFFERS"
+            sb.appendLine("%-22s %-18s %-18s%s%s".format(label, n, m, diff, note))
+        }
+
+        sb.appendLine("%-22s %-18s %-18s".format("Field", "Nestlin", if (mesen2 != null) "Mesen2" else "Mesen2 (N/A)"))
+        sb.appendLine("-".repeat(70))
+        row("PC (informational)", "0x%04X".format(nestlin.cpu.pc), mesen2?.let { "0x%04X".format(it.cpu.pc) } ?: "-")
+        row("PPUCTRL", "0x%02X".format(nestlin.ppuRegisters.controller), mesen2?.let { "0x%02X".format(it.ppuRegisters.controller) } ?: "-")
+        row("PPUMASK", "0x%02X".format(nestlin.ppuRegisters.mask), mesen2?.let { "0x%02X".format(it.ppuRegisters.mask) } ?: "-")
+        // PPUSTATUS vblank bit is phase-dependent across the capture offset — informational.
+        sb.appendLine("%-22s %-18s %-18s".format(
+            "PPUSTATUS (info)",
+            "0x%02X".format(nestlin.ppuRegisters.status),
+            mesen2?.let { "0x%02X".format(it.ppuRegisters.status) } ?: "-"))
+        row("NMI/frame", fmtCount(nestlin.nmiCountLastFrame), mesen2?.let { fmtCount(it.nmiCountLastFrame) } ?: "-")
+        row("IRQ/frame", fmtCount(nestlin.irqCountLastFrame), mesen2?.let { fmtCount(it.irqCountLastFrame) } ?: "-")
+        sb.appendLine()
+
+        // Mapper banks (Nestlin side only — Mesen2 captures don't decompose the mapper).
+        sb.appendLine("Mapper banks (Nestlin):")
+        val mapper = nestlin.mapper
+        if (mapper != null) {
+            sb.appendLine("  type=${mapper.type} (mapper ${mapper.mapperId})")
+            if (mapper.banks.isEmpty()) {
+                sb.appendLine("  (no banks reported)")
+            } else {
+                mapper.banks.forEach { (k, v) -> sb.appendLine("  %-20s %d (0x%02X)".format(k, v, v)) }
+            }
+        } else {
+            sb.appendLine("  (mapper snapshot not available)")
+        }
+        sb.appendLine()
+
+        if (mesen2 == null) {
+            sb.appendLine("Mesen2 NOT AVAILABLE — no oracle to diff against, so memory diffs and")
+            sb.appendLine("classification are skipped. Set MESEN2_PATH (or mesen2.path) to enable.")
+            return sb.toString()
+        }
+
+        // Memory diffs.
+        sb.appendLine("Memory diffs (Nestlin vs Mesen2):")
+        appendArrayDiff(sb, "OAM", nestlin.oam, mesen2.oam, sampleCount = 8)
+        appendArrayDiff(sb, "paletteRam", nestlin.paletteRam, mesen2.paletteRam, sampleCount = 8)
+        appendArrayDiff(sb, "CHR", nestlin.chr, mesen2.chr, sampleCount = 0)
+        appendArrayDiff(sb, "cpuRam", nestlin.cpuRam, mesen2.cpuRam, sampleCount = 1)
+        sb.appendLine()
+
+        if (classifications.isEmpty()) {
+            sb.appendLine("LIKELY CAUSE: (none classified)")
+        } else {
+            classifications.forEach { sb.appendLine("LIKELY CAUSE: $it") }
+        }
+        return sb.toString()
+    }
+
+    private fun appendArrayDiff(sb: StringBuilder, name: String, a: IntArray, b: IntArray, sampleCount: Int) {
+        if (a.size != b.size) {
+            sb.appendLine("  %-12s size mismatch: ${a.size} vs ${b.size}".format(name))
+            return
+        }
+        val diffs = a.indices.filter { a[it] != b[it] }
+        if (diffs.isEmpty()) {
+            sb.appendLine("  %-12s match (${a.size} bytes)".format(name))
+        } else {
+            val sample = if (sampleCount > 0) {
+                " — first ${minOf(sampleCount, diffs.size)}: " + diffs.take(sampleCount).joinToString(", ") {
+                    "[0x%03X] N=0x%02X M=0x%02X".format(it, a[it], b[it])
+                }
+            } else ""
+            sb.appendLine("  %-12s ${diffs.size}/${a.size} byte(s) differ$sample".format(name))
+        }
+    }
+
+    // --------------------------------------------------------------- classify
+
+    /**
+     * The decision tree. Multiple rules can fire; output is ordered most -> least
+     * specific. Distilled from past sessions — each rule names the historical bug
+     * that taught it.
+     */
+    internal fun classify(n: EmulatorStateSnapshot, m: EmulatorStateSnapshot): List<String> {
+        val causes = mutableListOf<String>()
+
+        val oamDiffers = !sameArray(n.oam, m.oam)
+        val chrDiffers = !sameArray(n.chr, m.chr)
+        val paletteDiffers = !sameArray(n.paletteRam, m.paletteRam)
+        val cpuRamDiffers = !sameArray(n.cpuRam, m.cpuRam)
+        val maskDiffers = n.ppuRegisters.mask != m.ppuRegisters.mask
+        val ctrlDiffers = n.ppuRegisters.controller != m.ppuRegisters.controller
+        val nmiKnown = n.nmiCountLastFrame >= 0 && m.nmiCountLastFrame >= 0
+        val irqKnown = n.irqCountLastFrame >= 0 && m.irqCountLastFrame >= 0
+        val nmiDiffers = nmiKnown && n.nmiCountLastFrame != m.nmiCountLastFrame
+        val irqDiffers = irqKnown && n.irqCountLastFrame != m.irqCountLastFrame
+
+        // 1. Boot stall.
+        if (n.ppuRegisters.mask == 0 && m.ppuRegisters.mask != 0) {
+            causes += "Boot stall: Nestlin never enabled rendering — game is stuck pre-init. " +
+                "Compare PC: if Nestlin PC sits in a small loop, find what flag/interrupt it is " +
+                "waiting on. Past causes: NMI latch not cleared at pre-render (Gimmick), " +
+                "open-bus reads decoding as BRK (Mind Blower Pak)."
+        }
+
+        // 2. NMI/frame differs.
+        if (nmiDiffers) {
+            causes += "NMI dispatch divergence (Nestlin=${n.nmiCountLastFrame}/frame, " +
+                "Mesen2=${m.nmiCountLastFrame}/frame) — check vblank latch, \$2002 read " +
+                "suppression, NMI 1-instruction latency."
+        }
+
+        // 3. IRQ/frame differs.
+        if (irqDiffers) {
+            causes += "Mapper IRQ timing divergence (Nestlin=${n.irqCountLastFrame}/frame, " +
+                "Mesen2=${m.irqCountLastFrame}/frame) — check fire condition placement " +
+                "(decrement-to-zero vs reload-to-zero, RAMBO-1 trap), A12 edge counting vs " +
+                "CPU-cycle counting."
+        }
+
+        // 4/5. OAM rules.
+        if (oamDiffers) {
+            val shift = detectOamShift(n.oam, m.oam)
+            if (shift != null) {
+                causes += "OAM uniformly shifted by $shift — OAM DMA target/oamAddress bug " +
+                    "(\$4014 must reset oamAddress to 0; Akira #141)."
+            } else {
+                causes += "CPU-side divergence upstream of sprite setup (OAM is CPU-written) — " +
+                    "likely CPU/DMA/timing, NOT the PPU. Note: if the game's NMI handler " +
+                    "rewrites OAM, the capture offset makes OAM incomparable (Don Doko Don) — " +
+                    "verify with a static screen."
+            }
+        }
+
+        // 6. OAM matches but CHR differs.
+        if (!oamDiffers && chrDiffers) {
+            causes += "Mapper CHR banking/fetch bug — wrong bank mapped at capture. Check " +
+                "register decode and bank-window arithmetic."
+        }
+
+        // 7. Palette differs while OAM + CHR match.
+        if (paletteDiffers && !oamDiffers && !chrDiffers) {
+            causes += "Palette write path or VRAM address increment bug."
+        }
+
+        // 8. Only cpuRam differs.
+        val anyRenderDiff = oamDiffers || chrDiffers || paletteDiffers || maskDiffers ||
+            ctrlDiffers || nmiDiffers || irqDiffers
+        if (cpuRamDiffers && !anyRenderDiff) {
+            causes += "RAM divergence without render impact yet — bisect earlier frames to " +
+                "find first divergent frame."
+        }
+
+        // 9. Everything compared matches.
+        if (!anyRenderDiff && !cpuRamDiffers) {
+            causes += "No divergence at frame ${n.frameNumber} — diverges later; re-run at a " +
+                "later frame, or the bug is timing-only (use replay CLI fingerprints to bisect)."
+        }
+
+        return causes
+    }
+
+    private fun sameArray(a: IntArray, b: IntArray): Boolean =
+        a.size == b.size && a.indices.all { a[it] == b[it] }
+
+    /**
+     * Detects whether [nestlin] is the same OAM byte stream as [mesen2] but
+     * uniformly rotated by k positions (k in 1..8, either direction) — the
+     * signature of an OAM DMA writing to the wrong starting oamAddress
+     * (Akira #141: 4 manual writes before the DMA shifted every byte by 4).
+     * Returns the shift k, or null if no uniform shift matches. All-equal
+     * arrays return null (that is a match, not a shift); degenerate constant
+     * arrays would match trivially, so a shift is only reported when the
+     * arrays actually differ unrotated.
+     */
+    internal fun detectOamShift(nestlin: IntArray, mesen2: IntArray): Int? {
+        if (nestlin.size != mesen2.size || nestlin.size == 0) return null
+        if (sameArray(nestlin, mesen2)) return null
+        val size = nestlin.size
+        for (k in 1..8) {
+            // Nestlin's byte i landed where mesen2 has i+k (or i-k) — check both directions.
+            if (nestlin.indices.all { nestlin[(it + k) % size] == mesen2[it] }) return k
+            if (nestlin.indices.all { nestlin[it] == mesen2[(it + k) % size] }) return k
+        }
+        return null
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/EmulatorStateSnapshot.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/EmulatorStateSnapshot.kt
@@ -24,7 +24,12 @@ data class EmulatorStateSnapshot(
     // (Mesen2 captures don't decompose the mapper that way). Tests that want
     // to assert Nestlin's bank state without going through Mesen2 read this
     // directly.
-    val mapper: com.github.alondero.nestlin.gamepak.MapperStateSnapshot? = null
+    val mapper: com.github.alondero.nestlin.gamepak.MapperStateSnapshot? = null,
+    // Interrupts dispatched during the LAST FULL FRAME before this capture
+    // (frame N-1 -> N delta on Nestlin; per-endFrame event counts on Mesen2).
+    // -1 = unknown / not captured, so older snapshots and tests are unaffected.
+    val nmiCountLastFrame: Int = -1,
+    val irqCountLastFrame: Int = -1
 ) {
     fun toJson(): String = gson.toJson(this)
 

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper10RegressionTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper10RegressionTest.kt
@@ -1,138 +1,32 @@
 package com.github.alondero.nestlin.compare
 
 import com.github.alondero.nestlin.gamepak.Mapper10
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
-import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
 
 /**
- * Structured-state regression test for issue #49 (Mapper 10 / MMC4).
- *
- * Per docs/TESTING_STRATEGY.md, this is a byte-level state comparison against the
- * Mesen2 oracle at a frame boundary — NOT a pixel diff. It asserts two things for
- * Fire Emblem Gaiden:
- *   1. The ROM is actually a Mapper10 and the MMC4 PRG bank moved off its reset
- *      value during boot (proves the bank-select register is wired, the cheap
- *      "did the mapper do anything" guard from the Star Soldier recipe).
- *   2. Nestlin's CPU/PPU/RAM/OAM/palette snapshot matches Mesen2's at frame N.
- *
- * The ROM lives only in the NO-INTRO library (not in git). Override its location
- * with NESTLIN_FIRE_EMBLEM_ROM; otherwise we fall back to the canonical path on
- * Adam's machine. Skipped (not failed) when neither the ROM nor Mesen2 is present,
- * since CI runners won't have either.
+ * Structured-state regression test for issue #49 (Mapper 10 / MMC4), against the
+ * Fire Emblem Gaiden ROM (NO-INTRO library only — override with
+ * NESTLIN_FIRE_EMBLEM_ROM). See MapperRegressionTestBase for the pattern and for
+ * WHY only render outputs are compared against Mesen2.
  */
-class Mapper10RegressionTest {
+class Mapper10RegressionTest : MapperRegressionTestBase() {
 
     private val frameNumber = 120
 
-    private fun fireEmblemRom(): Path {
-        val override = System.getenv("NESTLIN_FIRE_EMBLEM_ROM")
-        if (override != null && override.isNotBlank()) return Paths.get(override)
-        return Paths.get("S:/Media/Nintendo NES/Games/Fire Emblem Gaiden (Japan) (Translated En).nes")
-    }
+    private fun fireEmblemRom(): Path = resolveRom(
+        "NESTLIN_FIRE_EMBLEM_ROM",
+        "S:/Media/Nintendo NES/Games/Fire Emblem Gaiden (Japan) (Translated En).nes"
+    )
 
     @Test
     fun `mmc4 prg bank switches during fire emblem gaiden boot`() {
-        val rom = fireEmblemRom()
-        assumeTrue(Files.exists(rom), "Fire Emblem Gaiden ROM not found at $rom")
-
-        val nestlin = com.github.alondero.nestlin.Nestlin().apply {
-            config.speedThrottlingEnabled = false
-            load(rom)
-        }
-        nestlin.powerReset()
-        val mapper = nestlin.memory.mapper as? Mapper10
-            ?: error("Expected Mapper10 for Fire Emblem Gaiden; got ${nestlin.memory.mapper?.javaClass?.simpleName}")
-
-        val banksSeen = linkedSetOf<Int>()
-        var frameCount = 0
-        nestlin.addFrameListener(object : com.github.alondero.nestlin.ui.FrameListener {
-            override fun frameUpdated(frame: com.github.alondero.nestlin.ppu.Frame) {
-                banksSeen.add(mapper.snapshot().banks["prgBank"] ?: -1)
-                if (++frameCount >= frameNumber) nestlin.stop()
-            }
-        })
-        nestlin.start()
-
-        // A 256KB game cannot run from a single 16KB bank — it must page $8000.
-        Assertions.assertTrue(banksSeen.size > 1
-        , "MMC4 PRG bank never changed during boot (banks seen: $banksSeen) — " +
-                "the \$A000 bank-select register may not be wired.")
+        assertBankSwitchesDuringBoot(fireEmblemRom(), frameNumber, "prgBank", Mapper10::class.java)
     }
 
-    /**
-     * Compares the *render-output* state (OAM, palette, PPUCTRL, PPUMASK) between
-     * Nestlin and Mesen2 for the same displayed frame.
-     *
-     * Why this subset rather than StateComparator's full snapshot equality? The two
-     * emulators expose only one capture hook each, and they fire at different points
-     * in the frame: Mesen2's endFrame at scanline 240 (pre-NMI), Nestlin's frame
-     * callback at scanline 261 (post-NMI). That sub-frame offset makes the CPU
-     * registers, PPU scanline/cycle, and cycleCount (which Nestlin reports as an
-     * instruction count, not a cycle count) inherently non-comparable across the two
-     * — chasing cycle-exact cross-emulator equality is the brittleness docs/TESTING_STRATEGY.md
-     * explicitly steers away from.
-     *
-     * The render outputs, by contrast, reflect the *completed* frame and are stable
-     * across that offset. They're also exactly what an MMC4 banking bug corrupts: wrong
-     * CHR banks fetch wrong tiles (sprite/palette setup diverges), and wrong PRG banks
-     * derail the code that populates OAM. Byte-equality here is strong, low-noise
-     * evidence the mapper is right. The full snapshot + diff are still written to disk
-     * for inspection.
-     */
     @Test
+    @RequiresMesen2
     fun `fire emblem gaiden render output matches mesen2 at frame N`() {
-        val rom = fireEmblemRom()
-        assumeTrue(Files.exists(rom), "Fire Emblem Gaiden ROM not found at $rom")
-        assumeTrue(Mesen2StateCapturer.isMesen2Available(), "Mesen2 not available")
-
-        val reportsDir = Paths.get("build/reports/state-diffs/fire-emblem-gaiden-frame-$frameNumber")
-
-        val nestlinState = NestlinStateCapturer.captureState(rom, frameNumber)
-        val mesen2State = Mesen2StateCapturer.captureState(rom, frameNumber)
-
-        // Persist the full snapshots and StateComparator report for human inspection.
-        Files.createDirectories(reportsDir)
-        Files.writeString(reportsDir.resolve("nestlin-state.json"), nestlinState.toJson())
-        Files.writeString(reportsDir.resolve("mesen2-state.json"), mesen2State.toJson())
-        val fullDiff = StateComparator.compare(nestlinState, mesen2State)
-        StateComparator.writeReport(fullDiff, nestlinState, mesen2State, reportsDir.resolve("diff-report.txt"))
-
-        val problems = mutableListOf<String>()
-        fun cmpArray(name: String, a: IntArray, b: IntArray) {
-            if (a.size != b.size) { problems += "$name size ${a.size} != ${b.size}"; return }
-            val diffs = (a.indices).filter { a[it] != b[it] }
-            if (diffs.isNotEmpty()) {
-                val sample = diffs.take(8).joinToString(", ") {
-                    "[$it] N=0x%02X M=0x%02X".format(a[it], b[it])
-                }
-                problems += "$name differs in ${diffs.size} byte(s): $sample"
-            }
-        }
-        fun cmpReg(name: String, n: Int, m: Int) {
-            if (n != m) problems += "$name: Nestlin=0x%02X Mesen2=0x%02X".format(n, m)
-        }
-
-        cmpArray("OAM", nestlinState.oam, mesen2State.oam)
-        cmpArray("paletteRam", nestlinState.paletteRam, mesen2State.paletteRam)
-        cmpReg("PPUCTRL", nestlinState.ppuRegisters.controller, mesen2State.ppuRegisters.controller)
-        cmpReg("PPUMASK", nestlinState.ppuRegisters.mask, mesen2State.ppuRegisters.mask)
-
-        println("Fire Emblem Gaiden frame $frameNumber render-output: ${if (problems.isEmpty()) "MATCH" else "MISMATCH"}")
-        if (problems.isNotEmpty()) {
-            // Extract the message to a String-typed local var to disambiguate
-            // JUnit 5's fail(Supplier<String>) overload (which has a phantom
-            // <V> type variable the Kotlin compiler cannot infer when the
-            // argument is a multi-line string concat). Then bypass fail()
-            // entirely and throw AssertionFailedError directly — that's what
-            // fail(String) does internally anyway.
-            val failMessage = "Render output diverged from Mesen2 oracle:\n  " +
-                problems.joinToString("\n  ") +
-                "\nSee: ${reportsDir.resolve("diff-report.txt")}"
-            throw org.opentest4j.AssertionFailedError(failMessage)
-        }
+        assertRenderOutputMatchesMesen2(fireEmblemRom(), frameNumber, "fire-emblem-gaiden")
     }
 }

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/MapperRegressionTestBase.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/MapperRegressionTestBase.kt
@@ -1,0 +1,149 @@
+package com.github.alondero.nestlin.compare
+
+import com.github.alondero.nestlin.Nestlin
+import com.github.alondero.nestlin.ppu.Frame
+import com.github.alondero.nestlin.ui.FrameListener
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Base class for per-mapper Mesen2-oracle regression tests (the
+ * Mapper10RegressionTest pattern from docs/TESTING_STRATEGY.md, extracted).
+ *
+ * A typical subclass is ~25 lines: one test calling [assertBankSwitchesDuringBoot]
+ * (the cheap "did the mapper do anything" guard) and one @[RequiresMesen2] test
+ * calling [assertRenderOutputMatchesMesen2].
+ *
+ * ## Why only render outputs are compared against Mesen2
+ *
+ * The two emulators expose only one capture hook each, and they fire at different
+ * points in the frame: Mesen2's endFrame at scanline 240 (pre-NMI), Nestlin's frame
+ * callback at scanline 261 (post-NMI). That sub-frame offset makes the CPU
+ * registers, PPU scanline/cycle, and cycleCount (which Nestlin reports as an
+ * instruction count, not a cycle count) inherently non-comparable across the two —
+ * chasing cycle-exact cross-emulator equality is the brittleness
+ * docs/TESTING_STRATEGY.md explicitly steers away from.
+ *
+ * The render outputs (OAM, palette, PPUCTRL, PPUMASK), by contrast, reflect the
+ * *completed* frame and are stable across that offset. They're also exactly what a
+ * mapper banking bug corrupts: wrong CHR banks fetch wrong tiles (sprite/palette
+ * setup diverges), and wrong PRG banks derail the code that populates OAM.
+ * Byte-equality here is strong, low-noise evidence the mapper is right. The full
+ * snapshots, the StateComparator diff, and the DivergenceLocalizer table are still
+ * written to disk for inspection.
+ */
+abstract class MapperRegressionTestBase {
+
+    /**
+     * Resolves a test ROM: [envVar] override first, falling back to [defaultPath]
+     * (typically an absolute path into the NO-INTRO library on Adam's machine).
+     * Skips (assumption failure, not a test failure) when the ROM is absent, since
+     * CI runners won't have the ROM library.
+     */
+    protected fun resolveRom(envVar: String, defaultPath: String): Path {
+        val override = System.getenv(envVar)
+        val rom = if (!override.isNullOrBlank()) Paths.get(override) else Paths.get(defaultPath)
+        assumeTrue(Files.exists(rom), "ROM not found at $rom (override with $envVar)")
+        return rom
+    }
+
+    /**
+     * The cheap "did the mapper do anything" guard from the Star Soldier recipe:
+     * asserts the ROM loads with a mapper of [mapperClass] and that the bank under
+     * [bankKey] (a key of `MapperStateSnapshot.banks`) takes more than one value
+     * during the first [frames] frames of boot — i.e. the bank-select register is
+     * actually wired. A multi-bank game cannot run from a single fixed bank.
+     */
+    protected fun assertBankSwitchesDuringBoot(rom: Path, frames: Int, bankKey: String, mapperClass: Class<*>) {
+        val nestlin = Nestlin().apply {
+            config.speedThrottlingEnabled = false
+            load(rom)
+        }
+        nestlin.powerReset()
+        val mapper = nestlin.memory.mapper
+        if (!mapperClass.isInstance(mapper)) {
+            error("Expected ${mapperClass.simpleName} for $rom; got ${mapper?.javaClass?.simpleName}")
+        }
+
+        val banksSeen = linkedSetOf<Int>()
+        var frameCount = 0
+        nestlin.addFrameListener(object : FrameListener {
+            override fun frameUpdated(frame: Frame) {
+                banksSeen.add(mapper!!.snapshot()?.banks?.get(bankKey) ?: -1)
+                if (++frameCount >= frames) nestlin.stop()
+            }
+        })
+        nestlin.start()
+
+        Assertions.assertTrue(
+            banksSeen.size > 1,
+            "${mapperClass.simpleName} bank '$bankKey' never changed during boot " +
+                "(banks seen: $banksSeen) — the bank-select register may not be wired."
+        )
+    }
+
+    /**
+     * Captures BOTH emulators at [frame], writes the full report set under
+     * `build/reports/state-diffs/<reportName>-frame-<frame>/` (nestlin-state.json,
+     * mesen2-state.json, diff-report.txt via StateComparator, and the
+     * DivergenceLocalizer table + classifications in divergence-report.txt), then
+     * byte-compares the render outputs — OAM, palette RAM, PPUCTRL, PPUMASK — and
+     * throws AssertionFailedError on any mismatch. See the class KDoc for why only
+     * this subset is compared.
+     *
+     * Callers should be annotated @[RequiresMesen2]; this helper assumes Mesen2 is
+     * present and will fail (not skip) if it is missing.
+     */
+    protected fun assertRenderOutputMatchesMesen2(rom: Path, frame: Int, reportName: String) {
+        val reportsDir = Paths.get("build/reports/state-diffs/$reportName-frame-$frame")
+
+        val nestlinState = NestlinStateCapturer.captureState(rom, frame)
+        val mesen2State = Mesen2StateCapturer.captureState(rom, frame)
+
+        // Persist the full snapshots, the StateComparator report, and the
+        // DivergenceLocalizer table (which also rewrites the snapshot JSONs —
+        // harmless, same content) for human inspection.
+        Files.createDirectories(reportsDir)
+        val fullDiff = StateComparator.compare(nestlinState, mesen2State)
+        StateComparator.writeReport(fullDiff, nestlinState, mesen2State, reportsDir.resolve("diff-report.txt"))
+        val divergence = DivergenceLocalizer.report(nestlinState, mesen2State, reportsDir)
+
+        val problems = mutableListOf<String>()
+        fun cmpArray(name: String, a: IntArray, b: IntArray) {
+            if (a.size != b.size) { problems += "$name size ${a.size} != ${b.size}"; return }
+            val diffs = a.indices.filter { a[it] != b[it] }
+            if (diffs.isNotEmpty()) {
+                val sample = diffs.take(8).joinToString(", ") {
+                    "[$it] N=0x%02X M=0x%02X".format(a[it], b[it])
+                }
+                problems += "$name differs in ${diffs.size} byte(s): $sample"
+            }
+        }
+        fun cmpReg(name: String, n: Int, m: Int) {
+            if (n != m) problems += "$name: Nestlin=0x%02X Mesen2=0x%02X".format(n, m)
+        }
+
+        cmpArray("OAM", nestlinState.oam, mesen2State.oam)
+        cmpArray("paletteRam", nestlinState.paletteRam, mesen2State.paletteRam)
+        cmpReg("PPUCTRL", nestlinState.ppuRegisters.controller, mesen2State.ppuRegisters.controller)
+        cmpReg("PPUMASK", nestlinState.ppuRegisters.mask, mesen2State.ppuRegisters.mask)
+
+        println("$reportName frame $frame render-output: ${if (problems.isEmpty()) "MATCH" else "MISMATCH"}")
+        if (problems.isNotEmpty()) {
+            // JUnit 5's fail(Supplier<String>) overload has a phantom <V> type
+            // variable Kotlin cannot infer for a multi-line string concat — bypass
+            // fail() and throw AssertionFailedError directly (that's what
+            // fail(String) does internally anyway).
+            val failMessage = "Render output diverged from Mesen2 oracle:\n  " +
+                problems.joinToString("\n  ") +
+                (if (divergence.classifications.isNotEmpty())
+                    "\nLIKELY CAUSE:\n  " + divergence.classifications.joinToString("\n  ")
+                 else "") +
+                "\nSee: ${reportsDir.resolve("divergence-report.txt")}"
+            throw org.opentest4j.AssertionFailedError(failMessage)
+        }
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2StateCapturer.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2StateCapturer.kt
@@ -79,6 +79,20 @@ object Mesen2StateCapturer {
 local targetFrame = $targetFrame
 local frame = 0
 
+-- Interrupt counters, reset at every endFrame, so at capture time they hold the
+-- number of NMI/IRQ dispatches during the FINAL FULL FRAME. emu.eventType.irq
+-- fires for mapper IRQs too (verified on v2.1.1) and is reliable for counting.
+local nmiThisFrame = 0
+local irqThisFrame = 0
+
+local function onNmi()
+    nmiThisFrame = nmiThisFrame + 1
+end
+
+local function onIrq()
+    irqThisFrame = irqThisFrame + 1
+end
+
 local function writeState()
     local s = emu.getState()
 
@@ -135,6 +149,8 @@ local function writeState()
         "\"control\":" .. control .. "," ..
         "\"mask\":" .. mask .. "," ..
         "\"ppuStatus\":" .. ppuStatus .. "," ..
+        "\"nmiCountLastFrame\":" .. nmiThisFrame .. "," ..
+        "\"irqCountLastFrame\":" .. irqThisFrame .. "," ..
         "\"cpuRam\":" .. dumpMem(emu.memType.nesInternalRam, 2048) .. "," ..
         "\"oam\":" .. dumpMem(emu.memType.nesSpriteRam, 256) .. "," ..
         "\"chr\":" .. dumpMem(emu.memType.nesPpuMemory, 8192) .. "," ..
@@ -149,6 +165,8 @@ end
 function onEndFrame()
     frame = frame + 1
     if frame == targetFrame then
+        -- nmiThisFrame/irqThisFrame still hold the counts since the PREVIOUS
+        -- endFrame, i.e. the dispatches during the last full frame.
         local ok, err = pcall(writeState)
         if not ok then
             print("state capture error: " .. tostring(err))
@@ -157,8 +175,13 @@ function onEndFrame()
             emu.stop(0)
         end
     end
+    -- Reset per-frame interrupt counters for the next frame window.
+    nmiThisFrame = 0
+    irqThisFrame = 0
 end
 
+emu.addEventCallback(onNmi, emu.eventType.nmi)
+emu.addEventCallback(onIrq, emu.eventType.irq)
 emu.addEventCallback(onEndFrame, emu.eventType.endFrame)
 """.trimIndent()
         return luaScript
@@ -185,8 +208,15 @@ emu.addEventCallback(onEndFrame, emu.eventType.endFrame)
             oam = parseIntArray(json, "oam", 256),
             paletteRam = parseIntArray(json, "paletteRam", 32),
             timestamp = System.currentTimeMillis(),
-            chr = parseIntArray(json, "chr", 8192)
+            chr = parseIntArray(json, "chr", 8192),
+            nmiCountLastFrame = parseIntOrDefault(json, "nmiCountLastFrame", -1),
+            irqCountLastFrame = parseIntOrDefault(json, "irqCountLastFrame", -1)
         )
+    }
+
+    private fun parseIntOrDefault(json: String, key: String, default: Int): Int {
+        val match = Regex("\"$key\":(-?\\d+)").find(json) ?: return default
+        return match.groupValues[1].toIntOrNull() ?: default
     }
 
     private data class Mesen2CartState(

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/NestlinStateCapturer.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/NestlinStateCapturer.kt
@@ -27,12 +27,25 @@ object NestlinStateCapturer {
 
         var captured: EmulatorStateSnapshot? = null
         var frameCount = 0
+        // Interrupt-counter baselines at frame N-1, so the snapshot can report how
+        // many NMIs/IRQs were dispatched during the LAST FULL FRAME (N-1 -> N).
+        // For frameNumber == 1 the baseline is power-on (0), i.e. "since boot".
+        var nmiBaseline = 0
+        var irqBaseline = 0
 
         nestlin.addFrameListener(object : FrameListener {
             override fun frameUpdated(frame: com.github.alondero.nestlin.ppu.Frame) {
                 frameCount++
+                if (frameCount == frameNumber - 1) {
+                    nmiBaseline = nestlin.cpu.nmiCount
+                    irqBaseline = nestlin.cpu.irqCount
+                }
                 if (frameCount == frameNumber) {
-                    captured = captureCurrentState(nestlin, romPath.fileName.toString(), frameNumber)
+                    captured = captureCurrentState(
+                        nestlin, romPath.fileName.toString(), frameNumber,
+                        nmiLastFrame = nestlin.cpu.nmiCount - nmiBaseline,
+                        irqLastFrame = nestlin.cpu.irqCount - irqBaseline
+                    )
                     nestlin.stop()
                 }
             }
@@ -44,7 +57,13 @@ object NestlinStateCapturer {
         return captured ?: throw IllegalStateException("Failed to capture state at frame $frameNumber")
     }
 
-    private fun captureCurrentState(nestlin: Nestlin, romName: String, frameNumber: Int): EmulatorStateSnapshot {
+    private fun captureCurrentState(
+        nestlin: Nestlin,
+        romName: String,
+        frameNumber: Int,
+        nmiLastFrame: Int = -1,
+        irqLastFrame: Int = -1
+    ): EmulatorStateSnapshot {
         val cpu = nestlin.cpu
         val ppu = nestlin.ppu
         val memory = nestlin.memory
@@ -101,7 +120,9 @@ object NestlinStateCapturer {
             paletteRam = paletteRam,
             timestamp = System.currentTimeMillis(),
             chr = chr,
-            mapper = memory.mapper?.snapshot()
+            mapper = memory.mapper?.snapshot(),
+            nmiCountLastFrame = nmiLastFrame,
+            irqCountLastFrame = irqLastFrame
         )
     }
 

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/RequiresMesen2.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/RequiresMesen2.kt
@@ -1,0 +1,47 @@
+package com.github.alondero.nestlin.compare
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult
+import org.junit.jupiter.api.extension.ExecutionCondition
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * Marks a test (or test class) as requiring the Mesen2 reference emulator.
+ *
+ * Default behaviour when Mesen2 is absent: the test is DISABLED with a loud
+ * reason naming the resolved path — never a silent green (the anti-pattern from
+ * docs/TESTING_STRATEGY.md).
+ *
+ * Strict mode: set the env var NESTLIN_REQUIRE_MESEN2 (to any non-blank value)
+ * and a missing Mesen2 becomes a hard FAILURE instead of a skip. Use this on
+ * machines/CI lanes where Mesen2 is supposed to exist, so a broken MESEN2_PATH
+ * cannot false-green the comparison suite. Forwarded by the testMesenComparison
+ * Gradle task.
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@ExtendWith(RequiresMesen2Condition::class)
+annotation class RequiresMesen2
+
+class RequiresMesen2Condition : ExecutionCondition {
+    override fun evaluateExecutionCondition(context: ExtensionContext): ConditionEvaluationResult {
+        if (Mesen2StateCapturer.isMesen2Available()) {
+            return ConditionEvaluationResult.enabled("Mesen2 found at ${Mesen2StateCapturer.getMesen2Path()}")
+        }
+
+        val resolvedPath = Mesen2StateCapturer.getMesen2Path().toAbsolutePath()
+        val strict = System.getenv("NESTLIN_REQUIRE_MESEN2")
+        if (!strict.isNullOrBlank()) {
+            throw IllegalStateException(
+                "Mesen2 required but not found at $resolvedPath (NESTLIN_REQUIRE_MESEN2 strict mode)"
+            )
+        }
+
+        return ConditionEvaluationResult.disabled(
+            "MESEN2 NOT AVAILABLE: resolved path $resolvedPath does not exist. " +
+                "Set MESEN2_PATH (or -Dmesen2.path) to your Mesen2 executable, or set " +
+                "NESTLIN_REQUIRE_MESEN2=1 to make this a hard failure instead of a skip. " +
+                "Remember the Gradle daemon may hold stale env: ./gradlew --stop, then re-run."
+        )
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/cpu/InterruptCounterTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cpu/InterruptCounterTest.kt
@@ -1,0 +1,87 @@
+package com.github.alondero.nestlin.cpu
+
+import com.github.alondero.nestlin.Memory
+import com.github.alondero.nestlin.gamepak.GamePak
+import com.github.alondero.nestlin.testutil.testRom
+import com.github.alondero.nestlin.toSignedByte
+import com.github.alondero.nestlin.toSignedShort
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * The diagnostic counters `Cpu.nmiCount` / `Cpu.irqCount` increment exactly once
+ * per *dispatched* interrupt — at the point the vector is taken, not when the NMI
+ * is merely armed/pending. The compare/DivergenceLocalizer harness relies on
+ * per-frame deltas of these to compare NMI/IRQ-per-frame against Mesen2.
+ */
+class InterruptCounterTest {
+
+    @Test
+    fun nmiCountIncrementsOncePerDispatchedNmi() {
+        val cpu = Cpu(Memory()).apply {
+            currentGame = GamePak(spinLoopRom())
+            reset()
+        }
+        assertThat(cpu.nmiCount, equalTo(0))
+        assertThat(cpu.irqCount, equalTo(0))
+
+        // Reset vector points at the JMP-to-self spin loop at $C000; park there.
+        repeat(6) { cpu.tick() }
+
+        // Arm an NMI: enable NMI generation (PPUCTRL bit 7) and flag vblank.
+        cpu.memory[0x2000] = 0x80.toSignedByte()
+        cpu.memory.ppuAddressedMemory.nmiOccurred = true
+
+        cpu.tick() // dispatches (idle park skips the 1-instruction latency)
+
+        assertThat(cpu.nmiCount, equalTo(1))
+        assertThat(cpu.irqCount, equalTo(0))
+        assertThat(cpu.registers.programCounter, equalTo(0xC010.toSignedShort()))
+
+        // The vector was taken once; ticking through the 7 interrupt cycles (and the
+        // handler) must not bump the counter again while no new NMI is pending.
+        repeat(20) { cpu.tick() }
+        assertThat(cpu.nmiCount, equalTo(1))
+    }
+
+    @Test
+    fun armedButSuppressedNmiDoesNotCount() {
+        val cpu = Cpu(Memory()).apply {
+            reset()
+            registers.programCounter = 0x0000.toSignedShort()
+            // A run of NOPs so there is always an in-flight instruction (no idle park),
+            // which means the NMI is armed first and dispatches one instruction later.
+            for (addr in 0x0000..0x000F) memory[addr] = 0xEA.toSignedByte()
+        }
+
+        // Make an NMI pending: it gets ARMED at the next instruction boundary...
+        cpu.memory[0x2000] = 0x80.toSignedByte()
+        cpu.memory.ppuAddressedMemory.nmiOccurred = true
+        cpu.tick() // boundary: arms the NMI, executes one more instruction
+        assertThat(cpu.nmiArmed, equalTo(true))
+        assertThat(cpu.nmiCount, equalTo(0))
+
+        // ...but the latch is cleared within the latency window (as a $2002 vblank
+        // poll would do), so the NMI is suppressed and must never be counted.
+        cpu.memory.ppuAddressedMemory.nmiOccurred = false
+        repeat(10) { cpu.tick() }
+        assertThat(cpu.nmiCount, equalTo(0))
+    }
+
+    /**
+     * Minimal 16KB NROM: JMP-to-self at $C000, RTI at $C010,
+     * reset vector -> $C000, NMI vector -> $C010. (Same shape as IdleLoopTest.)
+     */
+    private fun spinLoopRom(): ByteArray = testRom {
+        prgKb = 16
+        chrKb = 0
+        prg[0x0000] = 0x4C.toByte() // JMP $C000
+        prg[0x0001] = 0x00.toByte()
+        prg[0x0002] = 0xC0.toByte()
+        prg[0x0010] = 0x40.toByte() // RTI
+        prg[0x3FFA] = 0x10.toByte() // NMI vector -> $C010
+        prg[0x3FFB] = 0xC0.toByte()
+        resetVector(0xC000)
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/testutil/HeaderConstructionLintTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/testutil/HeaderConstructionLintTest.kt
@@ -1,0 +1,107 @@
+package com.github.alondero.nestlin.testutil
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.extension
+import kotlin.io.path.readText
+
+/**
+ * Lint-as-test: forbids NEW hand-built 16-byte iNES headers in test fixtures.
+ *
+ * Hand-rolled headers have caused 7+ bug incidents (missing 4-byte magic,
+ * 16KB-PRG vs 8KB-CHR unit confusion, NES 2.0 submapper nibble mistakes,
+ * signed-byte multiplies). [TestRomBuilder] owns those encodings now; any test
+ * that needs a ROM image should use it.
+ *
+ * Existing offenders are grandfathered in [BASELINE]. The baseline must only
+ * SHRINK: migrate a file to TestRomBuilder, then delete its entry here.
+ */
+class HeaderConstructionLintTest {
+
+    @Test
+    fun `no new raw iNES header construction outside the baseline`() {
+        val root = Paths.get("src/test/kotlin")
+        assertTrue(Files.isDirectory(root), "expected to run from the project root; missing $root")
+
+        val offenders = Files.walk(root).use { stream ->
+            stream.filter { Files.isRegularFile(it) && it.extension == "kt" }
+                .toList()
+        }
+            .map { it to relativePath(root, it) }
+            .filter { (_, rel) -> rel !in EXCLUDED }
+            .filter { (file, _) -> RAW_HEADER_PATTERNS.any { it.containsMatchIn(file.readText()) } }
+            .map { (_, rel) -> rel }
+            .sorted()
+
+        val newOffenders = offenders.filter { it !in BASELINE }
+        assertTrue(
+            newOffenders.isEmpty(),
+            "Build test ROMs with testutil.TestRomBuilder instead of raw ByteArray(16) headers — " +
+                "see TestRomBuilder.kt. If migrating an old file, remove it from the baseline. " +
+                "New offender(s): $newOffenders"
+        )
+
+        // The baseline may only shrink: a baselined file that no longer exists or no
+        // longer matches has been migrated — delete its entry to lock in the progress.
+        val stale = BASELINE.filter { it !in offenders }
+        assertTrue(
+            stale.isEmpty(),
+            "Baseline entries no longer match raw-header patterns — remove them from " +
+                "HeaderConstructionLintTest.BASELINE so the list only shrinks: $stale"
+        )
+    }
+
+    private fun relativePath(root: Path, file: Path): String =
+        root.relativize(file).toString().replace('\\', '/')
+
+    companion object {
+        /**
+         * Signatures of hand-built iNES headers, tuned against the existing corpus:
+         * a bare 16-byte array allocation, and byte-wise writing of the "NES" magic.
+         */
+        private val RAW_HEADER_PATTERNS = listOf(
+            Regex("""ByteArray\(16\)"""),
+            Regex("""'N'\.code\.toByte\(\)"""),
+        )
+
+        /** This builder and this lint legitimately mention the patterns. */
+        private val EXCLUDED = setOf(
+            "com/github/alondero/nestlin/testutil/TestRomBuilder.kt",
+            "com/github/alondero/nestlin/testutil/HeaderConstructionLintTest.kt",
+        )
+
+        /**
+         * Grandfathered files that pre-date TestRomBuilder (snapshot 2026-06-11).
+         * This list must ONLY SHRINK — never add to it. Migrate a file to
+         * TestRomBuilder and delete its entry.
+         */
+        private val BASELINE = setOf(
+            "com/github/alondero/nestlin/SaveRamTest.kt",
+            "com/github/alondero/nestlin/cli/ReplayCommandTest.kt",
+            "com/github/alondero/nestlin/cpu/IdleLoopTest.kt",
+            "com/github/alondero/nestlin/movie/MovieRoundTripTest.kt",
+            "com/github/alondero/nestlin/gamepak/GamePakTest.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper10Test.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper153Test.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper16Test.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper1Test.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper206Test.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper33Test.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper3Test.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper4ChrBankingTest.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper4IrqTest.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper64IrqDisarmTest.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper64Test.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper66Test.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper69Test.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper71Test.kt",
+            "com/github/alondero/nestlin/gamepak/Mapper9Test.kt",
+            "com/github/alondero/nestlin/gamepak/RegionDetectionTest.kt",
+            "com/github/alondero/nestlin/gamepak/Vrc4Test.kt",
+            "com/github/alondero/nestlin/gamepak/Vrc4VariantDecodeTest.kt",
+        )
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/testutil/TestRomBuilder.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/testutil/TestRomBuilder.kt
@@ -1,0 +1,170 @@
+package com.github.alondero.nestlin.testutil
+
+import com.github.alondero.nestlin.gamepak.GamePak
+
+/**
+ * Fluent builder for in-memory iNES / NES 2.0 test ROMs.
+ *
+ * Hand-built 16-byte headers in test fixtures have caused a recurring class of
+ * bugs in this project. This builder owns every encoding decision so individual
+ * tests can't get them wrong:
+ *
+ *  - **4-byte magic** `"NES\x1A"` — several test helpers historically wrote only
+ *    3 bytes (or none), producing `BadHeaderException` once `GamePak` started
+ *    validating (GH #16).
+ *  - **Unit conversion** — header byte 4 counts *16KB* PRG units and byte 5
+ *    counts *8KB* CHR units. Tests that stamp 8KB PRG banks or 1KB CHR pages
+ *    repeatedly mixed these up. Here you give sizes in KB ([prgKb]/[chrKb]) and
+ *    the builder divides; it refuses sizes that aren't a whole number of units.
+ *  - **Mapper nibble split** — mapper bits 0-3 live in byte 6 bits 4-7, bits 4-7
+ *    in byte 7 bits 4-7. Byte 7 bit 4 IS mapper bit D4 (NOT a "title present"
+ *    flag — that misreading broke all NES 2.0 mapper-16+ ROM loading in PR #117).
+ *  - **NES 2.0 encoding** — setting [submapper] (or a mapper number above 255)
+ *    forces NES 2.0: byte 7 bits 2-3 = `0b10`, byte 8 = `(submapper shl 4) or
+ *    ((mapper shr 8) and 0x0F)`. The submapper is the HIGH nibble; the LOW
+ *    nibble is mapper bits 8-11. Getting these swapped decodes as a completely
+ *    different mapper.
+ *  - **Signed-byte hazard** — Kotlin header bytes are signed; the builder only
+ *    ever converts *to* bytes (masking with `and 0xFF`), and round-trip tests go
+ *    through the real `Header` decode which widens with `toUnsignedInt()`.
+ *
+ * Usage:
+ * ```kotlin
+ * val rom: ByteArray = testRom {
+ *     mapper = 33
+ *     prgKb = 128
+ *     chrKb = 32
+ *     stampPrgBanks(windowKb = 8)
+ *     stampChrBanks(windowKb = 1)
+ *     resetVector(0x8000)
+ * }
+ * // or, when a GamePak is wanted directly:
+ * val pak: GamePak = testGamePak { mapper = 4; prgKb = 32; chrKb = 8 }
+ * ```
+ */
+class TestRomBuilder {
+
+    /** iNES mapper number, 0..4095. Values above 255 force NES 2.0 encoding. */
+    var mapper: Int = 0
+
+    /**
+     * Submapper (NES 2.0 byte 8 high nibble), 0..15. Setting this to any
+     * non-null value forces NES 2.0 encoding even for submapper 0, because a
+     * test that *names* the submapper wants the NES 2.0 byte-8 path exercised.
+     */
+    var submapper: Int? = null
+
+    /** Battery-backed PRG-RAM flag — byte 6 bit 1. */
+    var battery: Boolean = false
+
+    /** Mirroring — byte 6 bit 0 (0 = horizontal, 1 = vertical). */
+    var verticalMirroring: Boolean = false
+
+    /**
+     * PRG ROM size in KB. Must be a multiple of 16 (the iNES PRG unit).
+     * Re-assigning replaces [prg] with a fresh zeroed array of the new size.
+     */
+    var prgKb: Int = 16
+        set(value) {
+            require(value > 0 && value % 16 == 0) {
+                "prgKb must be a positive multiple of 16 (iNES byte 4 counts 16KB units), got $value"
+            }
+            require(value / 16 <= 0xFF) { "prgKb/16 must fit one header byte, got ${value / 16} units" }
+            field = value
+            prg = ByteArray(value * 1024)
+        }
+
+    /**
+     * CHR ROM size in KB. Must be a multiple of 8 (the iNES CHR unit); 0 means
+     * CHR-RAM (no CHR data in the file). Re-assigning replaces [chr].
+     */
+    var chrKb: Int = 8
+        set(value) {
+            require(value >= 0 && value % 8 == 0) {
+                "chrKb must be a non-negative multiple of 8 (iNES byte 5 counts 8KB units), got $value"
+            }
+            require(value / 8 <= 0xFF) { "chrKb/8 must fit one header byte, got ${value / 8} units" }
+            field = value
+            chr = ByteArray(value * 1024)
+        }
+
+    /** Raw PRG data (size = prgKb * 1024) — mutate in place for custom stamping. */
+    var prg: ByteArray = ByteArray(prgKb * 1024)
+        private set
+
+    /** Raw CHR data (size = chrKb * 1024) — mutate in place for custom stamping. */
+    var chr: ByteArray = ByteArray(chrKb * 1024)
+        private set
+
+    /**
+     * Stamps the first byte of every [windowKb]-sized PRG bank with that bank's
+     * index (masked to 8 bits), so a mapper test can read the first byte of a
+     * CPU window and assert exactly which bank is mapped there.
+     */
+    fun stampPrgBanks(windowKb: Int) = stampBanks(prg, windowKb, "PRG")
+
+    /** As [stampPrgBanks] but for CHR banks. */
+    fun stampChrBanks(windowKb: Int) = stampBanks(chr, windowKb, "CHR")
+
+    private fun stampBanks(data: ByteArray, windowKb: Int, label: String) {
+        require(windowKb > 0) { "windowKb must be positive" }
+        val windowBytes = windowKb * 1024
+        require(data.isNotEmpty()) { "$label is empty — set ${label.lowercase()}Kb before stamping" }
+        require(data.size % windowBytes == 0) {
+            "$label size ${data.size} is not a multiple of the ${windowKb}KB stamp window"
+        }
+        for (bank in 0 until data.size / windowBytes) {
+            data[bank * windowBytes] = (bank and 0xFF).toByte()
+        }
+    }
+
+    /**
+     * Writes [address] little-endian at the file positions that the LAST 16KB
+     * PRG bank exposes as the 6502 reset vector ($FFFC/$FFFD) — i.e. the last
+     * 4th- and 3rd-from-end bytes of PRG. Most mappers fix the last bank at
+     * $C000-$FFFF on power-up, so this is where a real ROM's reset vector lives.
+     */
+    fun resetVector(address: Int) {
+        require(address in 0..0xFFFF) { "reset vector must be a 16-bit address, got $address" }
+        prg[prg.size - 4] = (address and 0xFF).toByte()
+        prg[prg.size - 3] = ((address shr 8) and 0xFF).toByte()
+    }
+
+    /** Assembles header + PRG + CHR into a complete iNES file image. */
+    fun build(): ByteArray {
+        require(mapper in 0..0xFFF) { "mapper must be 0..4095, got $mapper" }
+        submapper?.let { require(it in 0..15) { "submapper must be 0..15, got $it" } }
+        // Mapper numbers above 255 need byte 8 bits 0-3, which only exists in NES 2.0.
+        val nes20 = submapper != null || mapper > 0xFF
+
+        val header = ByteArray(16)
+        // The full 4-byte magic. Helpers that set only "NES" (or nothing) were a
+        // recurring source of BadHeaderException after GH #16.
+        header[0] = 'N'.code.toByte()
+        header[1] = 'E'.code.toByte()
+        header[2] = 'S'.code.toByte()
+        header[3] = 0x1A
+        header[4] = (prgKb / 16).toByte()  // 16KB PRG units
+        header[5] = (chrKb / 8).toByte()   // 8KB CHR units (0 = CHR-RAM)
+        header[6] = (((mapper and 0x0F) shl 4) or
+            (if (battery) 0x02 else 0x00) or
+            (if (verticalMirroring) 0x01 else 0x00)).toByte()
+        // Byte 7 bits 4-7 are mapper bits D4-D7 — bit 4 included (it is NOT a flag).
+        // Bits 2-3 = 0b10 marks NES 2.0.
+        header[7] = ((mapper and 0xF0) or (if (nes20) 0x08 else 0x00)).toByte()
+        if (nes20) {
+            // NES 2.0 byte 8: high nibble = submapper, low nibble = mapper bits 8-11.
+            header[8] = ((((submapper ?: 0) and 0x0F) shl 4) or ((mapper shr 8) and 0x0F)).toByte()
+        }
+        return header + prg + chr
+    }
+
+    /** Builds the ROM image and loads it through the real [GamePak] constructor. */
+    fun buildGamePak(displayName: String = "testrom.nes"): GamePak = GamePak(build(), displayName)
+}
+
+/** Builds a complete iNES file image. See [TestRomBuilder]. */
+fun testRom(block: TestRomBuilder.() -> Unit): ByteArray = TestRomBuilder().apply(block).build()
+
+/** Builds a [GamePak] directly. See [TestRomBuilder]. */
+fun testGamePak(block: TestRomBuilder.() -> Unit): GamePak = TestRomBuilder().apply(block).buildGamePak()

--- a/src/test/kotlin/com/github/alondero/nestlin/testutil/TestRomBuilderTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/testutil/TestRomBuilderTest.kt
@@ -1,0 +1,181 @@
+package com.github.alondero.nestlin.testutil
+
+import com.github.alondero.nestlin.gamepak.GamePak
+import com.github.alondero.nestlin.gamepak.Header
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Round-trip tests for [TestRomBuilder]: every assertion goes THROUGH the real
+ * [Header]/[GamePak] decode rather than poking at raw bytes, so the builder is
+ * proven against the authoritative decoder, not against a re-statement of the
+ * same encoding assumptions.
+ */
+class TestRomBuilderTest {
+
+    private fun headerOf(rom: ByteArray) = Header(rom.copyOfRange(0, 16))
+
+    @Test
+    fun `mapper 0 defaults decode as plain iNES`() {
+        val header = headerOf(testRom { mapper = 0 })
+        assertThat(header.mapper, equalTo(0))
+        assertFalse(header.isNes20)
+        assertThat(header.submapper, equalTo(0))
+        assertThat(header.mirroring, equalTo(Header.Mirroring.HORIZONTAL))
+        assertFalse(header.hasBattery)
+    }
+
+    @Test
+    fun `mapper 4 decodes from byte 6 high nibble`() {
+        assertThat(headerOf(testRom { mapper = 4 }).mapper, equalTo(4))
+    }
+
+    @Test
+    fun `mapper 33 splits across bytes 6 and 7`() {
+        // 33 = 0x21: low nibble 1 -> byte 6 bits 4-7, high nibble 2 -> byte 7 bits 4-7
+        assertThat(headerOf(testRom { mapper = 33 }).mapper, equalTo(33))
+    }
+
+    @Test
+    fun `mapper 113 uses byte 7 bit 4 as mapper bit D4 not a flag`() {
+        // 113 = 0x71: byte 7 high nibble = 0x7, which has bit 4 set. The PR #117
+        // regression treated that bit as a "title present" flag and decoded a
+        // bogus mapper number. The real Header decode must see 113.
+        assertThat(headerOf(testRom { mapper = 113 }).mapper, equalTo(113))
+    }
+
+    @Test
+    fun `mapper 206 with both high nibbles populated`() {
+        // 206 = 0xCE — exercises bits in both byte 6 and byte 7 nibbles at once.
+        assertThat(headerOf(testRom { mapper = 206 }).mapper, equalTo(206))
+    }
+
+    @Test
+    fun `setting submapper forces NES 2 dot 0 and decodes mapper 16 submapper 5`() {
+        val header = headerOf(testRom {
+            mapper = 16
+            submapper = 5
+        })
+        assertTrue(header.isNes20, "submapper must force the NES 2.0 signature (byte 7 bits 2-3 = 0b10)")
+        assertThat(header.mapper, equalTo(16))
+        assertThat(header.submapper, equalTo(5))
+    }
+
+    @Test
+    fun `mapper above 255 forces NES 2 dot 0 and uses byte 8 low nibble`() {
+        // 277 = 0x115: bits 8-11 = 1 (byte 8 low nibble), must not leak into submapper.
+        val header = headerOf(testRom { mapper = 277 })
+        assertTrue(header.isNes20)
+        assertThat(header.mapper, equalTo(277))
+        assertThat(header.submapper, equalTo(0))
+    }
+
+    @Test
+    fun `prg and chr sizes decode through GamePak including the signed-byte hazard`() {
+        // prgKb = 2048 -> header byte 4 = 128 = 0x80, which is NEGATIVE as a Kotlin
+        // Byte. GamePak must still slice 2MB of PRG (it widens with toUnsignedInt;
+        // a signed multiply would produce a negative bound and throw).
+        val pak = testGamePak {
+            prgKb = 2048
+            chrKb = 32
+        }
+        assertThat(pak.programRom.size, equalTo(2048 * 1024))
+        assertThat(pak.chrRom.size, equalTo(32 * 1024))
+    }
+
+    @Test
+    fun `chrKb zero means CHR-RAM and an empty chrRom`() {
+        val pak = testGamePak { chrKb = 0 }
+        assertThat(pak.chrRom.size, equalTo(0))
+    }
+
+    @Test
+    fun `battery and vertical mirroring bits decode`() {
+        val header = headerOf(testRom {
+            battery = true
+            verticalMirroring = true
+        })
+        assertTrue(header.hasBattery)
+        assertThat(header.mirroring, equalTo(Header.Mirroring.VERTICAL))
+    }
+
+    @Test
+    fun `stamped prg banks land at the right file offsets`() {
+        val rom = testRom {
+            prgKb = 32
+            chrKb = 8
+            stampPrgBanks(windowKb = 8)
+        }
+        val pak = GamePak(rom, "stamp-test.nes")
+        // 32KB PRG / 8KB windows = banks 0..3 stamped at the start of each window.
+        for (bank in 0..3) {
+            assertThat(pak.programRom[bank * 8 * 1024].toInt(), equalTo(bank))
+        }
+        // And at the raw file offsets (16-byte header first).
+        assertThat(rom[16 + 8 * 1024].toInt(), equalTo(1))
+    }
+
+    @Test
+    fun `stamped chr banks land at the right file offsets`() {
+        val rom = testRom {
+            prgKb = 16
+            chrKb = 32
+            stampChrBanks(windowKb = 1)
+        }
+        val pak = GamePak(rom, "stamp-test.nes")
+        for (page in 0 until 32) {
+            assertThat(pak.chrRom[page * 1024].toInt(), equalTo(page))
+        }
+        // Raw offset: header (16) + full PRG comes before CHR.
+        assertThat(rom[16 + 16 * 1024 + 2 * 1024].toInt(), equalTo(2))
+    }
+
+    @Test
+    fun `reset vector lands at header plus prgSize minus 4`() {
+        val rom = testRom {
+            prgKb = 128
+            chrKb = 8
+            resetVector(0x8000)
+        }
+        val prgBytes = 128 * 1024
+        assertThat(rom[16 + prgBytes - 4].toInt() and 0xFF, equalTo(0x00))
+        assertThat(rom[16 + prgBytes - 3].toInt() and 0xFF, equalTo(0x80))
+        // The decoded PRG slice agrees.
+        val pak = GamePak(rom, "vector-test.nes")
+        assertThat(pak.programRom[prgBytes - 3].toInt() and 0xFF, equalTo(0x80))
+    }
+
+    @Test
+    fun `buildGamePak loads through the real constructor and validation`() {
+        val pak = testGamePak {
+            mapper = 33
+            prgKb = 128
+            chrKb = 32
+        }
+        assertThat(pak.header.mapper, equalTo(33))
+        assertThat(pak.programRom.size, equalTo(128 * 1024))
+        assertThat(pak.chrRom.size, equalTo(32 * 1024))
+    }
+
+    @Test
+    fun `non-unit sizes are rejected up front`() {
+        val prgMessage = try {
+            testRom { prgKb = 8 }
+            ""
+        } catch (e: IllegalArgumentException) {
+            e.message ?: ""
+        }
+        assertTrue(prgMessage.contains("multiple of 16"), "expected PRG unit guidance, got: $prgMessage")
+
+        val chrMessage = try {
+            testRom { chrKb = 4 }
+            ""
+        } catch (e: IllegalArgumentException) {
+            e.message ?: ""
+        }
+        assertTrue(chrMessage.contains("multiple of 8"), "expected CHR unit guidance, got: $chrMessage")
+    }
+}

--- a/tools/mesen-trace/README.md
+++ b/tools/mesen-trace/README.md
@@ -1,0 +1,49 @@
+# mesen-trace — reusable Mesen2 Lua instruments
+
+Checked-in versions of the four instruments that have historically cracked Nestlin's
+hardest bugs, so they never have to be rebuilt from scratch mid-debugging-session.
+All are verified against the installed **Mesen2 v2.1.1** (`X:\src\nestlin\tools\Mesen2\Mesen.exe`),
+whose Lua API differs from the upstream docs — see "API reality" below.
+
+## Invocation (headless, no display needed)
+
+```
+X:\src\nestlin\tools\Mesen2\Mesen.exe --testRunner --doNotSaveSettings <script.lua> <absolute-rom-path.nes>
+```
+
+- ROM path **must be absolute** (Mesen's cwd is its install dir; relative paths silently fail to load — symptom: wall time > 10s).
+- Output lands in `<MesenDir>\LuaScriptData\<script-base-name>\` — e.g. `write-watch.lua` → `LuaScriptData\write-watch\writes.txt`.
+- Exit code 0 = clean run (`emu.stop(0)`), 2 = the script's own failure path.
+- Edit the `==== CONFIG ====` block at the top of each script (target frame, watch range) before running; copy to a temp dir first if you don't want to dirty the checkout.
+
+## The instruments
+
+| Script | Question it answers | Output |
+|---|---|---|
+| `write-watch.lua` | Which mapper registers does this game actually write, and when? | `writes.txt`: `frame=N addr=$XXXX val=$YY` |
+| `interrupt-counter.lua` | How many NMIs/IRQs fire per frame? (Compare vs Nestlin's `Cpu.nmiCount`/`irqCount`.) | `interrupts.txt`: `frame=N nmi=X irq=Y` |
+| `ppuctrl-transitions.lua` | Did the game ever enable rendering/NMI? When did PPUCTRL/PPUMASK change? | `ppuctrl.txt`: `frame=N PPUCTRL=$XX` |
+| `chr-dump.lua` | Which CHR data is mapped at frame N? (Byte-diff vs Nestlin's CHR window.) | `chr.txt`: `OOOO:VV` per byte |
+
+Typical divergence workflow: run `./gradlew diverge -Prom=<rom> -Pframe=<n>` first (it
+compares full state automatically); reach for these scripts when you need the
+*time-series* view (when did X first happen?) rather than the frame-N snapshot.
+
+## API reality on the installed v2.1.1 (differs from mesen.ca docs)
+
+- Memory callbacks: **`emu.callbackType`** with keys `exec`/`read`/`write`.
+  `emu.memCallbackType` is **nil**; there is no `cpuWrite`/`ppuRead` variant.
+- `emu.getState()` **inside** an event or memory callback has **no `.ppu` and no `.cart`**
+  (and at top level it returns a FLAT dotted-key table: `s["cpu.pc"]`, not `s.cpu.pc`).
+  An unguarded nil index silently aborts the rest of the callback — wrap in `pcall`
+  or, better, don't call `getState()` in callbacks at all (these scripts don't).
+- Frame attribution in callbacks: count `emu.eventType.endFrame` yourself.
+- `emu.eventType.irq` fires for mapper IRQs — reliable for counting.
+- `--testRunner` headless works, including `emu.read`; `emu.stop(code)` exits cleanly.
+- `emu.getScriptDataFolder()` has no trailing separator — append one.
+- I/O access must have been enabled once in the GUI (Script → Settings → Restrictions →
+  Allow access to I/O and OS functions); it's persisted in settings.json and
+  `--doNotSaveSettings` won't unset it.
+
+When embedding any of this in Kotlin `"""..."""` strings: `$` interpolates — use `${'$'}`
+for literal `$`, **including inside Lua comments**.

--- a/tools/mesen-trace/chr-dump.lua
+++ b/tools/mesen-trace/chr-dump.lua
@@ -1,0 +1,44 @@
+-- chr-dump.lua — dump the active 8KB PPU pattern data ($0000-$1FFF) at a target frame.
+-- Byte-compare this against Nestlin's CHR window (NestlinStateCapturer captures the
+-- same region through the mapper) to prove or disprove a CHR-banking bug: if OAM
+-- matches but CHR differs, the mapper has the wrong bank mapped — see the
+-- DivergenceLocalizer classification table.
+--
+-- emu.read works in --testRunner mode on the installed Mesen2 v2.1.1. Reads happen
+-- in the endFrame callback (NOT inside a memory callback, where getState/reads are
+-- restricted).
+--
+-- Output: <MesenDir>/LuaScriptData/chr-dump/chr.txt — one "offset:value" pair per
+-- line in hex, trivially diffable.
+
+-- ==== CONFIG ====
+local TARGET_FRAME = 120
+-- ================
+
+local frame = 0
+
+local function dump()
+    local base = emu.getScriptDataFolder()
+    local last = string.sub(base, -1)
+    if last ~= "\\" and last ~= "/" then base = base .. "/" end
+    local f = assert(io.open(base .. "chr.txt", "w"))
+    for i = 0, 0x1FFF do
+        f:write(string.format("%04X:%02X\n", i, emu.read(i, emu.memType.nesPpuMemory)))
+    end
+    f:close()
+end
+
+local function onEndFrame()
+    frame = frame + 1
+    if frame >= TARGET_FRAME then
+        local ok, err = pcall(dump)
+        if not ok then
+            print("chr-dump failed: " .. tostring(err))
+            emu.stop(2)
+        else
+            emu.stop(0)
+        end
+    end
+end
+
+emu.addEventCallback(onEndFrame, emu.eventType.endFrame)

--- a/tools/mesen-trace/interrupt-counter.lua
+++ b/tools/mesen-trace/interrupt-counter.lua
@@ -1,0 +1,49 @@
+-- interrupt-counter.lua — count NMI and IRQ fires per frame.
+-- The instrument that cracked the Gimmick boot hang (NMI fired once total vs once
+-- per frame) and the Klax RAMBO-1 double-IRQ (2/frame vs Mesen's 1/frame).
+-- Compare its output against Nestlin's Cpu.nmiCount/irqCount diagnostics or the
+-- DivergenceLocalizer's per-frame counts.
+--
+-- Verified against installed Mesen2 v2.1.1: emu.eventType.irq fires for mapper IRQs
+-- and is reliable for COUNTING. Do not call emu.getState() inside the nmi/irq
+-- callbacks expecting .ppu/.cart — those fields are nil there; frame attribution
+-- uses our own endFrame counter.
+--
+-- Output: <MesenDir>/LuaScriptData/interrupt-counter/interrupts.txt
+-- one line per frame: "frame=N nmi=X irq=Y" (only frames with activity, plus a summary).
+
+-- ==== CONFIG ====
+local TARGET_FRAME = 600
+-- ================
+
+local frame = 0
+local nmiThisFrame, irqThisFrame = 0, 0
+local totalNmi, totalIrq = 0, 0
+
+local base = emu.getScriptDataFolder()
+local last = string.sub(base, -1)
+if last ~= "\\" and last ~= "/" then base = base .. "/" end
+local f = assert(io.open(base .. "interrupts.txt", "w"))
+
+local function onNmi() nmiThisFrame = nmiThisFrame + 1 end
+local function onIrq() irqThisFrame = irqThisFrame + 1 end
+
+local function onEndFrame()
+    frame = frame + 1
+    if nmiThisFrame > 0 or irqThisFrame > 0 then
+        f:write(string.format("frame=%d nmi=%d irq=%d\n", frame, nmiThisFrame, irqThisFrame))
+        f:flush()
+    end
+    totalNmi = totalNmi + nmiThisFrame
+    totalIrq = totalIrq + irqThisFrame
+    nmiThisFrame, irqThisFrame = 0, 0
+    if frame >= TARGET_FRAME then
+        f:write(string.format("-- summary: %d frames, %d NMIs, %d IRQs\n", frame, totalNmi, totalIrq))
+        f:close()
+        emu.stop(0)
+    end
+end
+
+emu.addEventCallback(onNmi, emu.eventType.nmi)
+emu.addEventCallback(onIrq, emu.eventType.irq)
+emu.addEventCallback(onEndFrame, emu.eventType.endFrame)

--- a/tools/mesen-trace/ppuctrl-transitions.lua
+++ b/tools/mesen-trace/ppuctrl-transitions.lua
@@ -1,0 +1,46 @@
+-- ppuctrl-transitions.lua — log every write to PPUCTRL ($2000) and PPUMASK ($2001),
+-- including their $2008-$3FFF mirrors, tagged with frame number.
+-- The "did the game ever enable rendering / NMI, and when?" instrument: a boot-stall
+-- investigation starts by checking whether PPUMASK ever gets bits 3/4 set and whether
+-- PPUCTRL bit 7 (NMI enable) toggles at the expected cadence.
+--
+-- Verified against installed Mesen2 v2.1.1 (emu.callbackType, own frame counter —
+-- see write-watch.lua header for the API caveats).
+--
+-- Output: <MesenDir>/LuaScriptData/ppuctrl-transitions/ppuctrl.txt
+
+-- ==== CONFIG ====
+local TARGET_FRAME = 600
+-- ================
+
+local frame = 0
+
+local base = emu.getScriptDataFolder()
+local last = string.sub(base, -1)
+if last ~= "\\" and last ~= "/" then base = base .. "/" end
+local f = assert(io.open(base .. "ppuctrl.txt", "w"))
+
+local lastVal = { [0] = -1, [1] = -1 }  -- de-dupe repeated identical writes per register
+
+local function onWrite(address, value)
+    local reg = address % 8
+    if reg > 1 then return end  -- only $2000/$2001 (and mirrors)
+    if lastVal[reg] == value then return end
+    lastVal[reg] = value
+    local name = (reg == 0) and "PPUCTRL" or "PPUMASK"
+    f:write(string.format("frame=%d %s=$%02X\n", frame, name, value))
+    f:flush()
+end
+
+local function onEndFrame()
+    frame = frame + 1
+    if frame >= TARGET_FRAME then
+        f:write(string.format("-- done at frame %d. PPUCTRL=$%02X PPUMASK=$%02X\n",
+            frame, lastVal[0], lastVal[1]))
+        f:close()
+        emu.stop(0)
+    end
+end
+
+emu.addMemoryCallback(onWrite, emu.callbackType.write, 0x2000, 0x3FFF)
+emu.addEventCallback(onEndFrame, emu.eventType.endFrame)

--- a/tools/mesen-trace/write-watch.lua
+++ b/tools/mesen-trace/write-watch.lua
@@ -1,0 +1,45 @@
+-- write-watch.lua — log every CPU write in an address range, tagged with frame number.
+-- The canonical "which mapper registers does this game actually touch?" instrument.
+--
+-- Verified against the installed Mesen2 v2.1.1 (NOT the upstream docs):
+--   * memory callbacks use emu.callbackType (exec/read/write); emu.memCallbackType is nil
+--   * emu.getState() inside a callback has NO .ppu and NO .cart — do not touch them here;
+--     frame number comes from our own endFrame counter instead
+--   * runs headless: Mesen.exe --testRunner --doNotSaveSettings write-watch.lua rom.nes
+--
+-- Output: <MesenDir>/LuaScriptData/write-watch/writes.txt (flushed per line, so a
+-- crash mid-run still leaves usable data).
+
+-- ==== CONFIG ====
+local WATCH_START  = 0x8000   -- watch range start (mapper register space by default)
+local WATCH_END    = 0xFFFF   -- watch range end
+local TARGET_FRAME = 600      -- stop after this many frames
+local MAX_LINES    = 20000    -- safety valve so a write-happy game can't fill the disk
+-- ================
+
+local frame = 0
+local lines = 0
+
+local base = emu.getScriptDataFolder()
+local last = string.sub(base, -1)
+if last ~= "\\" and last ~= "/" then base = base .. "/" end
+local f = assert(io.open(base .. "writes.txt", "w"))
+
+local function onWrite(address, value)
+    if lines >= MAX_LINES then return end
+    lines = lines + 1
+    f:write(string.format("frame=%d addr=$%04X val=$%02X\n", frame, address, value))
+    f:flush()
+end
+
+local function onEndFrame()
+    frame = frame + 1
+    if frame >= TARGET_FRAME then
+        f:write(string.format("-- done: %d frames, %d writes logged\n", frame, lines))
+        f:close()
+        emu.stop(0)
+    end
+end
+
+emu.addMemoryCallback(onWrite, emu.callbackType.write, WATCH_START, WATCH_END)
+emu.addEventCallback(onEndFrame, emu.eventType.endFrame)

--- a/tools/run-diag.ps1
+++ b/tools/run-diag.ps1
@@ -1,0 +1,82 @@
+<#
+.SYNOPSIS
+Run a single JUnit test class (or method) and print ONLY its output — no Gradle noise.
+
+.DESCRIPTION
+Exists because the obvious ways to see println output from a diagnostic test all fail:
+  - `gradlew test --tests X --info` emits null bytes that break text pipelines
+  - Gradle's UP-TO-DATE check silently skips a cached test (no output, looks green)
+  - the real output lands in build/test-results/<task>/TEST-*.xml, wrapped in XML escaping
+
+This script runs the test with --rerun-tasks (defeats the cache), then extracts the
+<system-out>/<system-err> and failure details straight from the result XML.
+
+.EXAMPLE
+  .\tools\run-diag.ps1 -TestClass GoldenLogTest
+  .\tools\run-diag.ps1 -TestClass com.github.alondero.nestlin.compare.Mapper10RegressionTest -Mesen
+  .\tools\run-diag.ps1 -TestClass Mapper64Test -Method "irq fires once per frame"
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$TestClass,
+    [string]$Method,
+    [switch]$Mesen   # run via the testMesenComparison task (Mesen2-dependent tests are excluded from plain `test`)
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$task = if ($Mesen) { 'testMesenComparison' } else { 'test' }
+$filter = if ($Method) { "$TestClass.$Method" } else { "*$TestClass*" }
+
+Push-Location $repoRoot
+try {
+    # cmd /c so stderr merges without PowerShell 5.1 wrapping it in ErrorRecords.
+    $gradleOut = & cmd /c "gradlew.bat $task --tests `"$filter`" --rerun-tasks -q 2>&1"
+    $gradleExit = $LASTEXITCODE
+
+    $resultsDir = Join-Path $repoRoot "build\test-results\$task"
+    $xmlFiles = @()
+    if (Test-Path $resultsDir) {
+        $xmlFiles = Get-ChildItem $resultsDir -Filter 'TEST-*.xml' |
+            Where-Object { $_.BaseName -like "*$TestClass*" }
+    }
+
+    if ($xmlFiles.Count -eq 0) {
+        # No results = the test never ran (compile error, bad filter, wrong task).
+        # This is the one case where Gradle's own output is the diagnostic.
+        Write-Output "No test results found for '$TestClass' under $resultsDir. Gradle output:"
+        # Strip null bytes — Gradle's rich console injects them and they break text tools.
+        Write-Output (($gradleOut | Out-String) -replace "`0", '')
+        exit ($(if ($gradleExit -ne 0) { $gradleExit } else { 1 }))
+    }
+
+    foreach ($file in $xmlFiles) {
+        [xml]$xml = (Get-Content $file.FullName -Raw) -replace "`0", ''
+        $suite = $xml.testsuite
+        Write-Output ("=" * 70)
+        Write-Output "$($suite.name): $($suite.tests) test(s), $($suite.failures) failure(s), $($suite.errors) error(s), $($suite.skipped) skipped"
+        foreach ($case in $suite.testcase) {
+            $status = 'PASS'
+            $detail = $null
+            foreach ($kind in @('failure', 'error')) {
+                $node = $case.SelectSingleNode($kind)
+                if ($node) { $status = $kind.ToUpper(); $detail = $node.InnerText }
+            }
+            if ($case.SelectSingleNode('skipped')) { $status = 'SKIPPED'; $detail = $case.SelectSingleNode('skipped').message }
+            Write-Output "  [$status] $($case.name)"
+            if ($detail) {
+                ($detail -split "`n" | Select-Object -First 40) | ForEach-Object { Write-Output "    $_" }
+            }
+        }
+        foreach ($stream in @('system-out', 'system-err')) {
+            $node = $suite.SelectSingleNode($stream)
+            if ($node -and $node.InnerText.Trim()) {
+                Write-Output "--- $stream ---"
+                Write-Output $node.InnerText.TrimEnd()
+            }
+        }
+    }
+    exit $gradleExit
+}
+finally {
+    Pop-Location
+}

--- a/tools/run-diag.sh
+++ b/tools/run-diag.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Thin wrapper so the diagnostic loop works from bash too.
+# All logic lives in run-diag.ps1 — see its header for why this exists.
+# Usage: tools/run-diag.sh <TestClass> [MethodName] [--mesen]
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARGS=(-TestClass "$1")
+shift || true
+for a in "$@"; do
+  if [ "$a" = "--mesen" ]; then ARGS+=(-Mesen); else ARGS+=(-Method "$a"); fi
+done
+exec powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$SCRIPT_DIR/run-diag.ps1" "${ARGS[@]}"


### PR DESCRIPTION
﻿## What

Permanent tooling for the friction classes that a review of two months of session history showed kept recurring — so future (and less capable) agent sessions ship fewer bugs, stay focused, and burn fewer tokens. Nine past misdiagnosis loops were each eventually cracked by the same improvised instrument (a Nestlin-vs-Mesen2 differential), then the instrument was thrown away; hand-rolled iNES headers caused 7+ test-fixture bugs; getting println output from one diagnostic test took 13 gradle invocations; the `mesen` skill taught an API the installed binary rejects.

## Changes

**Diagnosis**
- `DivergenceLocalizer` + `./gradlew diverge -Prom=<rom> -Pframe=N` — side-by-side Nestlin/Mesen2 state at a frame: PPUCTRL/MASK/STATUS, **NMI + IRQ per frame** (new `Cpu.nmiCount`/`irqCount` diagnostic counters on the Nestlin side, `emu.eventType.nmi/irq` Lua counting on the Mesen2 side), mapper banks, OAM/palette/CHR/RAM diff counts — plus automated **LIKELY CAUSE** classification (9 rules distilled from past sessions: boot-stall, NMI-latch, mapper-IRQ-timing, OAM-shift/DMA-target, CPU-side-upstream, CHR-banking, palette, RAM-only, no-divergence-yet).
- `tools/mesen-trace/` — four v2.1.1-verified Lua instruments (write-watch, interrupt-counter, ppuctrl-transitions, chr-dump), flush-per-line so crashed runs still leave evidence.
- `tools/run-diag.ps1`/`.sh` — run one test class/method, defeat UP-TO-DATE caching, print failures + system-out extracted from the result XML. One command instead of thirteen.
- `./gradlew verifyTestEnv` — env diagnostics for "why is this SKIPPED" (MESEN2_PATH resolution, ROM availability, daemon-env reminder).

**Bug prevention**
- `testutil.TestRomBuilder` — fluent iNES/NES 2.0 test-ROM builder owning the magic bytes, 16KB/8KB unit conversions, mapper nibble split (byte 7 bit 4 = mapper bit D4), submapper encoding, bank stamping, reset vector. 14 round-trip tests through the real `Header`/`GamePak` decode.
- `HeaderConstructionLintTest` — fails the build on new raw `ByteArray(16)` headers in test sources (23 legacy files baselined; the list may only shrink — already shrunk by one in this PR).
- `MapperRegressionTestBase` — `Mapper10RegressionTest` collapsed 139 → 33 lines; capture-offset rationale and the JUnit `fail()` workaround live once. Verified green against the real Fire Emblem ROM + Mesen2 (both tests ran, 0 skipped).
- `@RequiresMesen2` — loud skip naming the resolved path; `NESTLIN_REQUIRE_MESEN2` strict mode turns skips into failures (anti-false-green).
- `.github/workflows/test.yml` — CI previously ran **no tests at all** (release workflow only); PRs and master pushes now gate on `./gradlew test`.

**Agent guidance**
- `mesen` skill corrected to match the installed v2.1.1 binary (`emu.callbackType` not `emu.memCallbackType`, flat dotted `getState()` keys, partial state in callbacks, v2 headless works, `emu.stop(code)` works).
- New `new-mapper` skill — the implementation checklist: header-identity traps, oracle ordering (nesdev wiki → Mesen2 source → issue spec is intent only), game-usage trace tests, IRQ fire-count assertions for scanline mappers.
- `.claude/hooks/worktree-guard.ps1` — PreToolUse hook blocking Write/Edit calls that escape a worktree into the parent repo (has happened twice), with the corrected path in the block message.
- CLAUDE.md documents all of the above.

## Verification

- Full `./gradlew build` green (compile + entire unit suite + jar), 3m07s.
- `diverge` run end-to-end against kirby.nes with Mesen2 launching headless: interrupt counts agree across emulators (1 NMI / 0 IRQ per frame); classifier output sane for an animated title.
- `testMesenComparison --tests Mapper10RegressionTest`: 2/2 **passed, not skipped** (real ROM + Mesen2).
- Worktree-guard hook exercised with 5 simulated payloads (parent-repo writes blocked, worktree/external writes allowed, fails open on script error).
- `run-diag` exercised against `FrameDifferTest` (clean per-test output, zero Gradle noise).

Note: this PR is the first to exercise the new CI workflow on ubuntu runners — if a Windows-path assumption lurks in a non-excluded test, this run will surface it.

## Follow-ups

#152 (`tools/rom_info.py`), #153 (`tools/sync-master.ps1`), #154 (`TestAsserts.kt` + lints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
