### PR TITLE
Add tools/rom_info.py: iNES header decoder + library utilities (issue #152)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,32 @@ java -jar build/libs/nestlin-all.jar replay rom.nes bug.fm2 \
 
 **Requirements:** JDK 21 (Gradle toolchain pinned in `build.gradle.kts`), Kotlin 1.9.22, JavaFX 21.0.1.
 
+## Step 0 of any mapper task — `tools/rom_info.py`
+
+Before writing a single line of mapper code, run the header decoder against your target ROM. Five known-broken conventions are encoded as warnings:
+
+```bash
+# What mapper is this, really?
+python tools/rom_info.py info path/to/rom.nes
+
+# Walk the dev library, filtered to a single mapper number
+python tools/rom_info.py scan S:\\Media\\Nintendo\\NES\\Games --mapper 33
+
+# NO-INTRO Namco 108 dumps are mislabelled as mapper 4; this emits a sibling COPY
+# with the byte6/byte7 patch applied (never touches the source).
+python tools/rom_info.py patch-namco108 path/to/gauntlet.nes
+
+# Read NMI/RESET/IRQ from the fixed last bank
+python tools/rom_info.py vectors path/to/rom.nes
+
+# CPU addr <-> file offset math + hexdump (for disassembly / reading NMI handlers)
+python tools/rom_info.py addr path/to/rom.nes --cpu-addr 0xEA40 --bank last
+```
+
+`info` warns about NO-INTRO header mislabels (Namco 108 / DxROM is the canonical one; the patch recipe lives in the tool's `--help` and the test suite). Library path defaults to `S:\Media\Nintendo NES\Games` (override with `ROMS_PATH` or `--library`).
+
+Run `python tools/test_rom_info.py` to exercise the decoder; the test suite cross-checks the byte equations against `Header.kt` and the in-repo `nestest.nes`.
+
 ## File Layout
 
 ```

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The CPU has a single gold-standard regression: **`GoldenLogTest`** runs `nestest
 | `src/test/kotlin/.../compare/` | Mesen2 oracle tests (state diff, not pixels). |
 | `docs/` | Strategy + historical design notes. |
 | `testroms/` | `nestest.nes` (the only ROM in git). |
-| `tools/` | Local-only emulators (not in git; see `CLAUDE.local.md`). |
+| `tools/` | Local-only emulators (not in git; see `CLAUDE.local.md`) + `rom_info.py` / `dump_analyzer.py` Python utilities. |
 
 ---
 
@@ -177,6 +177,7 @@ The CPU has a single gold-standard regression: **`GoldenLogTest`** runs `nestest
 
 - **[`MAPPER_SUPPORT.md`](MAPPER_SUPPORT.md)** — which mappers are working, what games are known to play, and what each one's quirks are.
 - **[`docs/TESTING_STRATEGY.md`](docs/TESTING_STRATEGY.md)** — the test pyramid and how to add a new regression test the right way.
+- **[`tools/rom_info.py`](tools/rom_info.py)** — decode a ROM header, scan a library, patch a NO-INTRO Namco 108 mislabel, read vectors, do CPU-addr ↔ file-offset math. **Step 0 of any new-mapper task** — before writing a single line of Kotlin, run `python tools/rom_info.py info <rom.nes>` to confirm the mapper / submapper / region you're about to target.
 - **[`tools/dump_analyzer.py`](tools/dump_analyzer.py)** — parse 64KB CPU memory dumps (`.dmp`) from debug sessions and query them by region, register, or address. Useful for post-mortem debugging.
 
 ---

--- a/tools/rom_info.py
+++ b/tools/rom_info.py
@@ -1,0 +1,771 @@
+#!/usr/bin/env python3
+"""
+NES ROM Header Decoder + Library Utilities
+
+Sibling of dump_analyzer.py. The single source of truth for iNES / NES 2.0
+header decoding in Nestlin lives in src/main/kotlin/.../gamepak/GamePak.kt
+(Header class). This tool mirrors that decoder byte-for-byte so an agent
+working outside the emulator core can answer "what is this ROM" without
+hand-decoding 16 bytes.
+
+Subcommands:
+    info         <rom.nes>            decode header: mapper, submapper, NES 2.0?,
+                                       PRG/CHR sizes, battery, mirroring, region
+                                       (header + filename), CRC32
+    scan         <dir> [--mapper N]   walk a ROM library, list titles by mapper
+    patch-namco108 <rom.nes>          emit a sibling COPY with the NO-INTRO
+                                       Namco 108 header patch applied
+                                       (mapper 4 -> mapper 206)
+    vectors      <rom.nes>            NMI / RESET / IRQ vectors from the
+                                       fixed last bank
+    addr         <rom.nes> --cpu-addr 0xXXXX [--bank N|last]
+                                       CPU addr <-> file offset math + hexdump
+
+The library path defaults to the dev machine's NO-INTRO library
+(S:\\Media\\Nintendo NES\\Games, override with --library or ROMS_PATH env var).
+
+Usage:
+    python rom_info.py info path/to/rom.nes
+    python rom_info.py scan S:\\Media\\Nintendo\\NES\\Games --mapper 33
+    python rom_info.py patch-namco108 game.nes
+    python rom_info.py vectors game.nes
+    python rom_info.py addr game.nes --cpu-addr 0xEA40 --bank last
+
+Exit codes: 0 OK · 1 usage / argument error · 2 ROM file unreadable or
+not a valid iNES file.
+"""
+
+import argparse
+import os
+import shutil
+import struct
+import sys
+import zlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+# =============================================================================
+# iNES constants (mirror src/main/kotlin/.../gamepak/GamePak.kt)
+# =============================================================================
+
+INES_MAGIC = b"NES\x1A"            # bytes 0..3
+INES_HEADER_SIZE = 16
+PRG_BANK_BYTES = 16 * 1024         # 16 KB
+CHR_BANK_BYTES = 8 * 1024          # 8 KB
+VECTOR_NMI = 0xFFFA
+VECTOR_RESET = 0xFFFC
+VECTOR_IRQ = 0xFFFE
+
+# Default library path on the dev machine. Can be overridden via the ROMS_PATH
+# environment variable or the --library CLI flag. S:\\Media\\Nintendo NES\\Games
+# is the canonical NO-INTRO archive per CLAUDE.local.md.
+DEFAULT_LIBRARY = r"S:\Media\Nintendo NES\Games"
+
+# NO-INTRO region markers copied verbatim from GamePak.kt (lines 138-149). The
+# PAL list wins ties (a ROM tagged both, e.g. multi-region, is treated as PAL).
+# Keeping this in lockstep with the Kotlin side means an agent running
+# `rom_info.py info` will infer the same region Nestlin uses at boot.
+NTSC_MARKERS = ("(usa", "(u)", "(japan", "(j)", "(jp", "(world", "(ntsc", "(brazil)")
+PAL_MARKERS = (
+    "(europe", "(e)", "(eur", "(pal", "(australia", "(france", "(germany",
+    "(italy", "(spain", "(sweden", "(netherlands", "(uk", "(scandinavia",
+)
+
+# Mapper families that are *occasionally* mislabeled by NO-INTRO dumpers.
+# The warning is a verification prompt, not a mislabel assertion: most ROMs
+# with these iNES mapper numbers are correctly labeled. The user should
+# cross-reference the title against the known-game list and only patch
+# when the title is on it. (See memory file
+# 'namco-108-ines-mapper-4-convention-2026-06-01.md' for the original
+# investigation of the Namco 108 case.)
+#
+# Adding a new family: also add the patch recipe to `patch_namco108`-style
+# helpers, or document the manual byte edits in the warning text.
+KNOWN_MISLABEL_FAMILIES = {
+    4: [
+        {
+            "actual_mapper": 206,
+            "family": "Namco 108 / DxROM",
+            "known_titles": "Gauntlet, Ring King, RBI Baseball, Mappy-Land",
+            "patch_recipe": "byte6 = (b6 & 0x0F) | 0xE0; byte7 = (b7 & 0x0F) | 0xC0",
+        },
+    ],
+}
+
+
+# =============================================================================
+# Header decode (mirror of Header.kt — see that file for the source equations
+# and the regression tests in GamePakTest.kt that lock the rules in place).
+# =============================================================================
+
+@dataclass
+class RomHeader:
+    """Decoded iNES / NES 2.0 header. Field semantics match Header.kt."""
+    path: str
+    raw: bytes                       # first 16 bytes of the ROM file
+
+    # Decoded fields
+    is_nes20: bool = False
+    mapper: int = 0
+    submapper: int = 0
+    prg_banks: int = 0
+    chr_banks: int = 0
+    prg_bytes: int = 0
+    chr_bytes: int = 0
+    mirroring: str = "?"              # "horizontal" or "vertical"
+    has_battery: bool = False
+    region_from_header: Optional[str] = None   # "NTSC" / "PAL" / None
+    region_from_name: Optional[str] = None
+    region_effective: str = "NTSC"             # header > name > NTSC
+    crc32: int = 0
+    file_size: int = 0
+    mislabel_warnings: list = field(default_factory=list)
+
+    @property
+    def is_chr_ram(self) -> bool:
+        """True when the game uses CHR-RAM (byte 5 = 0, no CHR ROM)."""
+        return self.chr_banks == 0
+
+    def as_dict(self) -> dict:
+        return {
+            "file": self.path,
+            "size_bytes": self.file_size,
+            "crc32": f"0x{self.crc32:08X}",
+            "format": "NES 2.0" if self.is_nes20 else "iNES 1.0",
+            "mapper": self.mapper,
+            "submapper": self.submapper,
+            "prg_banks": self.prg_banks,
+            "prg_bytes": self.prg_bytes,
+            "chr_banks": self.chr_banks,
+            "chr_bytes": self.chr_bytes,
+            "chr_rom_or_ram": "CHR-RAM" if self.is_chr_ram else "CHR-ROM",
+            "mirroring": self.mirroring,
+            "battery": self.has_battery,
+            "region_header": self.region_from_header,
+            "region_name": self.region_from_name,
+            "region": self.region_effective,
+            "warnings": self.mislabel_warnings,
+        }
+
+
+class BadRomFile(Exception):
+    """The file is not a valid iNES / NES 2.0 ROM."""
+
+
+def decode_header(path: str, *, full_crc: bool = True) -> RomHeader:
+    """Decode the 16-byte iNES header of a ROM file.
+
+    Args:
+        path: Path to the .nes file.
+        full_crc: If True (default), compute CRC32 over the whole file. Set
+            False for the `scan` subcommand to keep large library walks fast
+            (header-only mode reads 16 bytes per ROM).
+    """
+    p = Path(path)
+    if not p.is_file():
+        raise BadRomFile(f"Not a file: {path}")
+    with open(p, "rb") as f:
+        data = f.read()
+    return decode_bytes(data, source=str(p), full_crc=full_crc)
+
+
+def decode_bytes(data: bytes, *, source: str = "<bytes>", full_crc: bool = True) -> RomHeader:
+    """Decode the iNES header of an in-memory ROM buffer.
+
+    Used by [decode_header] (which reads the file) and by the Namco 108
+    patcher (which decodes the patched COPY from memory without writing
+    it to disk first). Tests use this entry point too — building the
+    bytes directly is the cleanest way to assert a specific header pattern.
+    """
+    if len(data) < INES_HEADER_SIZE:
+        raise BadRomFile(
+            f"Buffer is {len(data)} bytes; iNES header requires at least "
+            f"{INES_HEADER_SIZE} bytes"
+        )
+    if data[0:4] != INES_MAGIC:
+        raise BadRomFile(
+            f"Missing iNES header magic (got bytes "
+            f"{data[0]:02X} {data[1]:02X} {data[2]:02X} {data[3]:02X})"
+        )
+
+    h = RomHeader(path=source, raw=bytes(data[:INES_HEADER_SIZE]), file_size=len(data))
+
+    # Byte 4 = PRG banks (16KB units), byte 5 = CHR banks (8KB units, 0 = CHR-RAM).
+    # Header.kt reads these as raw bytes; we mirror with mask to stay unsigned.
+    h.prg_banks = data[4] & 0xFF
+    h.chr_banks = data[5] & 0xFF
+    h.prg_bytes = h.prg_banks * PRG_BANK_BYTES
+    h.chr_bytes = h.chr_banks * CHR_BANK_BYTES
+
+    # Byte 6: bit 0 mirroring (0=H, 1=V), bit 1 battery. Mapper bits 0-3 = b6>>4.
+    b6 = data[6]
+    h.has_battery = bool(b6 & 0x02)
+    h.mirroring = "vertical" if (b6 & 0x01) else "horizontal"
+
+    # NES 2.0 marker: byte 7 bits 2-3 == 0b10.
+    b7 = data[7]
+    h.is_nes20 = (b7 & 0x0C) == 0x08
+
+    # Mapper decode (must match Header.kt:170-172 EXACTLY).
+    #   bits 0-3  = byte 6 bits 4-7
+    #   bits 4-7  = byte 7 bits 4-7  (bit 4 IS mapper bit D4 in both iNES and NES 2.0)
+    #   bits 8-11 = byte 8 bits 0-3  (NES 2.0 only; high nibble of b8 is submapper)
+    # In plain iNES, byte 8 is the PRG-RAM size — NOT part of the mapper.
+    b8 = data[8] if len(data) > 8 else 0
+    h.mapper = (b6 >> 4) | (b7 & 0xF0) | ((b8 & 0x0F) << 8 if h.is_nes20 else 0)
+
+    # Submapper: NES 2.0 byte 8 high nibble. For plain iNES, byte 8 is the
+    # PRG-RAM size byte — semantically unrelated; Header.kt returns 0 in that case.
+    h.submapper = ((b8 >> 4) & 0x0F) if h.is_nes20 else 0
+
+    # Region detection: header first, then NO-INTRO filename marker, then NTSC.
+    # Header.kt treats iNES byte 9 bit 0 = 1 as PAL evidence; absence is NOT
+    # NTSC evidence (the bit is almost universally clear, including on PAL ROMs).
+    if h.is_nes20 and len(data) > 12:
+        region_bits = data[12] & 0x03
+        if region_bits == 0:
+            h.region_from_header = "NTSC"
+        elif region_bits in (1, 3):
+            h.region_from_header = "PAL"
+        # 2 = "both" -> undecided
+    else:
+        if len(data) > 9 and (data[9] & 0x01):
+            h.region_from_header = "PAL"
+
+    h.region_from_name = region_from_name(Path(source).name)
+    h.region_effective = h.region_from_header or h.region_from_name or "NTSC"
+
+    # CRC32 over the whole file (or just the header in scan mode).
+    if full_crc:
+        h.crc32 = zlib.crc32(data) & 0xFFFFFFFF
+    else:
+        h.crc32 = zlib.crc32(data[:INES_HEADER_SIZE]) & 0xFFFFFFFF
+
+    # Known-family verification prompts (e.g. "if this is one of the
+    # ~5 Namco 108 titles, the header is mislabeled; most mapper-4 games
+    # are real MMC3"). The warning is a heads-up, not a mislabel claim.
+    for entry in KNOWN_MISLABEL_FAMILIES.get(h.mapper, []):
+        h.mislabel_warnings.append(
+            f"iNES mapper {h.mapper} is the NO-INTRO label for mapper "
+            f"{entry['actual_mapper']} ({entry['family']}) for these "
+            f"specific titles: {entry['known_titles']}. If your ROM is "
+            f"one of them, the header is mislabeled; if not, ignore. "
+            f"Patch recipe if mislabeled: {entry['patch_recipe']}."
+        )
+
+    return h
+
+
+def region_from_name(name: str) -> Optional[str]:
+    """Return "NTSC" / "PAL" implied by NO-INTRO filename markers, else None.
+
+    Mirrors GamePak.regionFromName (GamePak.kt:145-150). PAL list wins ties
+    only when the NTSC list is silent; in practice the lists are disjoint.
+    """
+    lower = name.lower()
+    if any(m in lower for m in NTSC_MARKERS):
+        return "NTSC"
+    if any(m in lower for m in PAL_MARKERS):
+        return "PAL"
+    return None
+
+
+# =============================================================================
+# Vectors (NMI / RESET / IRQ at $FFFA-$FFFF of the fixed last bank)
+# =============================================================================
+
+@dataclass
+class RomVectors:
+    nmi: int
+    reset: int
+    irq: int
+
+    def as_dict(self) -> dict:
+        return {
+            "NMI": f"0x{self.nmi:04X}",
+            "RESET": f"0x{self.reset:04X}",
+            "IRQ": f"0x{self.irq:04X}",
+        }
+
+
+def read_vectors(path: str) -> RomVectors:
+    """Read NMI / RESET / IRQ vectors from $FFFA-$FFFF of the last 16KB bank.
+
+    For NROM (mapper 0) with one PRG bank the bank is mirrored to both $8000
+    and $C000, so this still resolves to the right place. Multi-bank games
+    (mapper 0 with 2 PRG banks, and most mappers) follow the convention that
+    the LAST 16KB bank is fixed at $C000 and holds the vectors.
+    """
+    p = Path(path)
+    with open(p, "rb") as f:
+        data = f.read()
+    if len(data) < INES_HEADER_SIZE + PRG_BANK_BYTES:
+        raise BadRomFile("ROM too small to contain a PRG bank")
+    h = decode_header(p, full_crc=False)
+    if h.prg_banks == 0:
+        raise BadRomFile("ROM declares zero PRG banks")
+
+    # File offset of the start of the last PRG bank:
+    #   16 (header) + (prg_banks - 1) * 16384
+    last_bank_offset = INES_HEADER_SIZE + (h.prg_banks - 1) * PRG_BANK_BYTES
+    # Vectors live at the END of that bank, at the file offset of $FFFA.
+    # Within the last (fixed) bank, $FFFA is at byte 0x3FFA (0xFFFA - 0xC000).
+    # The 6 vector bytes span [vec_offset .. vec_offset + 6).
+    vec_offset = last_bank_offset + (VECTOR_NMI - 0xC000)
+    if vec_offset + 6 > len(data):
+        raise BadRomFile(
+            f"ROM truncated before vectors (need {vec_offset + 6} bytes, "
+            f"have {len(data)})"
+        )
+    nmi, reset, irq = struct.unpack_from("<HHH", data, vec_offset)
+    return RomVectors(nmi=nmi, reset=reset, irq=irq)
+
+
+# =============================================================================
+# CPU addr <-> file offset math
+# =============================================================================
+
+@dataclass
+class AddrResult:
+    cpu_addr: int
+    bank: int                # 0-indexed PRG bank number
+    file_offset: int
+    hexdump: str
+
+    def as_dict(self) -> dict:
+        return {
+            "cpu_addr": f"0x{self.cpu_addr:04X}",
+            "bank": self.bank,
+            "file_offset": f"0x{self.file_offset:06X}",
+            "hexdump": self.hexdump,
+        }
+
+
+def cpu_to_file_offset(prg_banks: int, cpu_addr: int, bank: int) -> int:
+    """Translate a CPU address to a file offset.
+
+    Layout: [16-byte header][16KB PRG bank 0][16KB PRG bank 1]...
+    The PRG-ROM window is split in two:
+      - $8000-$BFFF: a swappable bank (bank index 0..N-2)
+      - $C000-$FFFF: the FIXED last bank (bank index N-1, where the
+        NMI / RESET / IRQ vectors live)
+
+    This split holds for every standard NES mapper: NROM, MMC3, VRC, etc.
+    NROM-128 (1 bank) is a degenerate case: bank 0 mirrors to BOTH halves,
+    so the "fixed last" and "swappable" collapse to the same bank.
+
+    Args:
+        prg_banks: Total PRG bank count (must be > 0).
+        cpu_addr: CPU address in $8000-$FFFF.
+        bank: PRG bank index to read from (0-indexed).
+
+    Raises:
+        ValueError: When cpu_addr / bank are out of range, or when the
+            cpu_addr / bank pair is inconsistent with the fixed/swappable
+            split above.
+    """
+    if prg_banks <= 0:
+        raise ValueError("ROM has zero PRG banks")
+    if not 0x8000 <= cpu_addr <= 0xFFFF:
+        raise ValueError(f"CPU address 0x{cpu_addr:04X} outside PRG ROM window $8000-$FFFF")
+    if not 0 <= bank < prg_banks:
+        raise ValueError(f"bank {bank} out of range 0..{prg_banks - 1}")
+    last = prg_banks - 1
+    if cpu_addr >= 0xC000:
+        # $C000-$FFFF is served ONLY by the fixed last bank.
+        if bank != last:
+            raise ValueError(
+                f"CPU 0x{cpu_addr:04X} is in the fixed last bank (bank {last}); "
+                f"got bank {bank}"
+            )
+        offset_in_bank = cpu_addr - 0xC000
+    else:
+        # $8000-$BFFF is a swappable bank. The 1-bank case (NROM-128)
+        # mirrors the only bank to both halves, so bank 0 == last is OK.
+        if bank == last and prg_banks > 1:
+            raise ValueError(
+                f"bank {bank} is the fixed last bank (mapped at $C000-$FFFF); "
+                f"CPU 0x{cpu_addr:04X} is in the swappable range $8000-$BFFF"
+            )
+        offset_in_bank = cpu_addr - 0x8000
+    return INES_HEADER_SIZE + bank * PRG_BANK_BYTES + offset_in_bank
+
+
+def file_to_cpu_addr(file_offset: int, prg_banks: int) -> Tuple[int, int]:
+    """Translate a file offset to (cpu_addr, bank).
+
+    Inverse of [cpu_to_file_offset]. The CPU mapping is asymmetric:
+    banks 0..N-2 are swappable at $8000-$BFFF, the LAST bank (index N-1)
+    is fixed at $C000-$FFFF and holds the reset/IRQ/NMI vectors. This
+    convention holds for every standard NES mapper (NROM, MMC3, VRC, etc.).
+
+    Args:
+        file_offset: Byte offset inside the ROM file (>= 16, NOT inside header).
+        prg_banks: Total PRG bank count from the iNES header.
+
+    Returns:
+        (cpu_addr, bank) where cpu_addr is the address a CPU would use to
+        read the same byte.
+    """
+    if prg_banks <= 0:
+        raise ValueError("prg_banks must be positive")
+    if file_offset < INES_HEADER_SIZE:
+        raise ValueError(
+            f"file offset 0x{file_offset:X} is inside the iNES header"
+        )
+    prg_offset = file_offset - INES_HEADER_SIZE
+    bank, offset_in_bank = divmod(prg_offset, PRG_BANK_BYTES)
+    if bank >= prg_banks:
+        raise ValueError(
+            f"file offset 0x{file_offset:X} is past the last PRG bank "
+            f"(prg_banks={prg_banks}, total PRG bytes={prg_banks * PRG_BANK_BYTES})"
+        )
+    cpu_base = 0xC000 if bank == prg_banks - 1 else 0x8000
+    return cpu_base + offset_in_bank, bank
+
+
+def resolve_bank(token: str, prg_banks: int) -> int:
+    """Parse a --bank argument. Accepts an integer or the literal 'last'/'fixed'."""
+    t = token.strip().lower()
+    if t in ("last", "fixed", "-1"):
+        return prg_banks - 1
+    n = int(t, 0)
+    if not 0 <= n < prg_banks:
+        raise argparse.ArgumentTypeError(
+            f"bank {n} out of range 0..{prg_banks - 1}"
+        )
+    return n
+
+
+def hexdump(data: bytes, base: int, width: int = 16) -> str:
+    """Format a hexdump with ASCII gutter, addresses relative to `base`."""
+    if not data:
+        return ""
+    lines = []
+    for i in range(0, len(data), width):
+        chunk = data[i:i + width]
+        hex_part = " ".join(f"{b:02X}" for b in chunk)
+        ascii_part = "".join(chr(b) if 32 <= b < 127 else "." for b in chunk)
+        lines.append(f"{base + i:06X}: {hex_part:<{width * 3}}  {ascii_part}")
+    return "\n".join(lines)
+
+
+def cpu_addr_resolve(path: str, cpu_addr: int, bank: int, length: int = 32) -> AddrResult:
+    """Resolve a CPU address in a ROM and return file offset + hexdump."""
+    h = decode_header(path, full_crc=False)
+    if h.prg_banks == 0:
+        raise BadRomFile("ROM declares zero PRG banks; cannot resolve CPU address")
+    bank = max(0, min(bank, h.prg_banks - 1))
+    off = cpu_to_file_offset(h.prg_banks, cpu_addr, bank)
+    with open(path, "rb") as f:
+        f.seek(off)
+        data = f.read(length)
+    if not data:
+        raise BadRomFile(f"file offset 0x{off:X} past EOF ({h.file_size} bytes)")
+    return AddrResult(cpu_addr=cpu_addr, bank=bank, file_offset=off, hexdump=hexdump(data, off))
+
+
+# =============================================================================
+# Library scan
+# =============================================================================
+
+@dataclass
+class ScanRow:
+    path: str
+    filename: str
+    mapper: int
+    submapper: int
+    prg_kb: int
+    chr_kb: int
+    region: str
+    battery: bool
+    mislabel: bool
+
+    def as_dict(self) -> dict:
+        return {
+            "file": self.filename,
+            "mapper": self.mapper,
+            "submapper": self.submapper,
+            "prg_kb": self.prg_kb,
+            "chr_kb": self.chr_kb,
+            "region": self.region,
+            "battery": self.battery,
+            "mislabel_warning": self.mislabel,
+        }
+
+
+def iter_roms(root: Path) -> Iterable[Path]:
+    """Yield every *.nes and *.7z under `root` (recursive).
+
+    On Windows, `rglob("*.nes")` and `rglob("*.NES")` can each yield the
+    same file (case-insensitive filesystem). We dedupe by case-folded
+    absolute path so the scan subcommand never double-counts a ROM.
+    """
+    seen: set = set()
+    for ext in ("*.nes", "*.NES", "*.7z"):
+        for p in root.rglob(ext):
+            key = str(p.resolve()).lower() if hasattr(p, "resolve") else str(p).lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            yield p
+
+
+def scan_library(root: Path, mapper: Optional[int] = None) -> List[ScanRow]:
+    """Walk `root`, decode headers, return rows filtered by mapper if given.
+
+    Header-only: reads 16 bytes per ROM. For a 1000-ROM library this is
+    dominated by filesystem traversal; the per-ROM decode is microseconds.
+    """
+    rows: List[ScanRow] = []
+    for p in iter_roms(root):
+        try:
+            h = decode_header(str(p), full_crc=False)
+        except (BadRomFile, OSError):
+            # Skip silently: a `.nes` suffix is not a guarantee of validity.
+            # Users running scan on a mixed-content directory get a clean
+            # listing of what decoded, not a flood of decode errors.
+            continue
+        if mapper is not None and h.mapper != mapper:
+            continue
+        rows.append(ScanRow(
+            path=str(p),
+            filename=p.name,
+            mapper=h.mapper,
+            submapper=h.submapper,
+            prg_kb=h.prg_bytes // 1024,
+            chr_kb=h.chr_bytes // 1024,
+            region=h.region_effective,
+            battery=h.has_battery,
+            mislabel=bool(h.mislabel_warnings),
+        ))
+    rows.sort(key=lambda r: (r.mapper, r.filename.lower()))
+    return rows
+
+
+# =============================================================================
+# Namco 108 patch (NO-INTRO label fix-up; see memory file
+# namco-108-ines-mapper-4-convention-2026-06-01.md)
+# =============================================================================
+
+def patch_namco108(src: str, dst: Optional[str] = None) -> Tuple[Path, dict]:
+    """Emit a patched COPY of a Namco 108 NO-INTRO dump with mapper 206 header.
+
+    Returns (output_path, diff_dict) where diff_dict summarises what changed.
+    NEVER modifies the source file. If `dst` is None the output is written
+    next to the source with the suffix `.mapper206.nes`.
+
+    The patch recipe (issue #152, byte-accurate to Mesen2's expected header):
+        byte6 = (b6 & 0x0F) | 0xE0
+        byte7 = (b7 & 0x0F) | 0xC0
+    The 0xC0 also clears any "title" / format / mapper-high bits in byte 7 that
+    NO-INTRO may have set. We treat every other byte as untouched.
+    """
+    p = Path(src)
+    if not p.is_file():
+        raise BadRomFile(f"Not a file: {src}")
+    with open(p, "rb") as f:
+        data = bytearray(f.read())
+    if len(data) < INES_HEADER_SIZE or data[0:4] != INES_MAGIC:
+        raise BadRomFile(f"{src} is not a valid iNES file")
+    if dst is None:
+        dst = str(p.with_name(p.stem + ".mapper206" + p.suffix))
+    out = Path(dst)
+
+    old_b6, old_b7 = data[6], data[7]
+    new_b6 = (old_b6 & 0x0F) | 0xE0
+    new_b7 = (old_b7 & 0x0F) | 0xC0
+    data[6] = new_b6
+    data[7] = new_b7
+
+    with open(out, "wb") as f:
+        f.write(data)
+
+    # Decode both before/after for the diff summary. Snapshot the original
+    # bytes BEFORE mutation so `before` reflects the source header, not the
+    # patched one. decode_bytes is the in-memory entry point — no need to
+    # re-read the patched buffer from disk just to get its header.
+    original = bytearray(data)
+    original[6] = old_b6
+    original[7] = old_b7
+    before = decode_bytes(bytes(original), source=str(p), full_crc=True)
+    after = decode_bytes(bytes(data), source=str(out), full_crc=True)
+    diff = {
+        "source": str(p),
+        "output": str(out),
+        "byte6_before": f"0x{old_b6:02X}",
+        "byte6_after": f"0x{new_b6:02X}",
+        "byte7_before": f"0x{old_b7:02X}",
+        "byte7_after": f"0x{new_b7:02X}",
+        "mapper_before": before.mapper,
+        "mapper_after": after.mapper,
+        "crc32_before": f"0x{before.crc32:08X}",
+        "crc32_after": f"0x{after.crc32:08X}",
+    }
+    return out, diff
+
+
+# =============================================================================
+# CLI (argparse subcommands)
+# =============================================================================
+
+def _bank_arg(s: str) -> str:
+    """argparse type: accept 'last' / 'fixed' / integer."""
+    t = s.strip().lower()
+    if t in ("last", "fixed"):
+        return t
+    try:
+        int(t, 0)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"bank must be integer or 'last', got {s!r}")
+    return s
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="rom_info.py",
+        description="NES ROM header decoder + library utilities.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  rom_info.py info game.nes\n"
+            "  rom_info.py scan S:\\\\Media\\\\Nintendo\\\\NES\\\\Games --mapper 33\n"
+            "  rom_info.py patch-namco108 game.nes --out game.mapper206.nes\n"
+            "  rom_info.py vectors game.nes\n"
+            "  rom_info.py addr game.nes --cpu-addr 0xEA40 --bank last\n"
+        ),
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    # info
+    pi = sub.add_parser("info", help="Decode a single ROM header.")
+    pi.add_argument("rom", help="Path to a .nes file.")
+
+    # scan
+    ps = sub.add_parser("scan", help="Walk a ROM library, list by mapper.")
+    ps.add_argument("dir", nargs="?", default=os.environ.get("ROMS_PATH", DEFAULT_LIBRARY),
+                    help=f"Library root (default: {DEFAULT_LIBRARY}, override via ROMS_PATH env var).")
+    ps.add_argument("--mapper", type=lambda s: int(s, 0), default=None,
+                    help="Filter to a single mapper number (e.g. 33, 206).")
+    ps.add_argument("--library", default=None,
+                    help="Override the library path (same as positional `dir`).")
+
+    # patch-namco108
+    pp = sub.add_parser("patch-namco108",
+                        help="Emit a sibling COPY with the NO-INTRO Namco 108 header patch (mapper 4 -> 206).")
+    pp.add_argument("rom", help="Source .nes file (will NOT be modified).")
+    pp.add_argument("--out", default=None, help="Output path (default: <stem>.mapper206.nes).")
+
+    # vectors
+    pv = sub.add_parser("vectors", help="Read NMI/RESET/IRQ vectors from the fixed last bank.")
+    pv.add_argument("rom", help="Path to a .nes file.")
+
+    # addr
+    pa = sub.add_parser("addr", help="Resolve a CPU address to a file offset (and hexdump).")
+    pa.add_argument("rom", help="Path to a .nes file.")
+    pa.add_argument("--cpu-addr", required=True,
+                    help="CPU address (e.g. 0xEA40 or 0xEA40).")
+    pa.add_argument("--bank", default="last", type=_bank_arg,
+                    help="PRG bank index, or 'last' (default).")
+    pa.add_argument("--length", type=lambda s: int(s, 0), default=32,
+                    help="Number of bytes to hexdump (default 32).")
+    pa.add_argument("--file-offset", default=None,
+                    help="Reverse direction: file offset -> CPU addr + bank.")
+
+    return p
+
+
+def _print_info(h: RomHeader) -> None:
+    d = h.as_dict()
+    print(f"File:        {d['file']}")
+    print(f"Size:        {d['size_bytes']} bytes")
+    print(f"CRC32:       {d['crc32']}")
+    print(f"Format:      {d['format']}")
+    print(f"Mapper:      {d['mapper']}" + (f" (submapper {d['submapper']})" if h.is_nes20 and d['submapper'] else ""))
+    print(f"PRG:         {d['prg_banks']} x 16KB = {d['prg_bytes']} bytes")
+    print(f"CHR:         {d['chr_banks']} x 8KB = {d['chr_bytes']} bytes ({d['chr_rom_or_ram']})")
+    print(f"Mirroring:   {d['mirroring']}")
+    print(f"Battery:     {d['battery']}")
+    print(f"Region:      {d['region']}  (header={d['region_header']}, name={d['region_name']})")
+    if d["warnings"]:
+        print()
+        print("Warnings:")
+        for w in d["warnings"]:
+            print(f"  - {w}")
+
+
+def _print_scan(rows: List[ScanRow], mapper: Optional[int]) -> None:
+    if not rows:
+        print(f"No ROMs found{' for mapper ' + str(mapper) if mapper is not None else ''}.")
+        return
+    header = f"{'mapper':>6}  {'sub':>3}  {'prg_kb':>6}  {'chr_kb':>6}  {'reg':<5}  {'bat':<3}  {'warn':<4}  filename"
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        sub = f"{r.submapper}" if r.submapper else "-"
+        warn = "!!" if r.mislabel else ""
+        bat = "yes" if r.battery else "-"
+        print(f"{r.mapper:>6}  {sub:>3}  {r.prg_kb:>6}  {r.chr_kb:>6}  {r.region:<5}  {bat:<3}  {warn:<4}  {r.filename}")
+
+
+def _print_vectors(v: RomVectors) -> None:
+    print(f"NMI:   0x{v.nmi:04X}")
+    print(f"RESET: 0x{v.reset:04X}")
+    print(f"IRQ:   0x{v.irq:04X}")
+
+
+def _print_addr_result(rom: str, cpu_addr: int, bank: int, length: int) -> None:
+    r = cpu_addr_resolve(rom, cpu_addr, bank, length=length)
+    print(f"ROM:         {rom}")
+    print(f"CPU addr:    0x{r.cpu_addr:04X}")
+    print(f"PRG bank:    {r.bank}")
+    print(f"File offset: 0x{r.file_offset:06X}")
+    print()
+    print(r.hexdump)
+
+
+def _print_addr_reverse(rom: str, file_offset: int) -> None:
+    h = decode_header(rom, full_crc=False)
+    cpu, bank = file_to_cpu_addr(file_offset, h.prg_banks)
+    print(f"ROM:         {rom}")
+    print(f"File offset: 0x{file_offset:06X}")
+    print(f"CPU addr:    0x{cpu:04X}")
+    print(f"PRG bank:    {bank}")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.cmd == "info":
+            _print_info(decode_header(args.rom, full_crc=True))
+        elif args.cmd == "scan":
+            root = Path(args.library or args.dir)
+            if not root.is_dir():
+                print(f"error: not a directory: {root}", file=sys.stderr)
+                return 2
+            _print_scan(scan_library(root, mapper=args.mapper), args.mapper)
+        elif args.cmd == "patch-namco108":
+            out, diff = patch_namco108(args.rom, args.out)
+            for k, v in diff.items():
+                print(f"{k}: {v}")
+        elif args.cmd == "vectors":
+            _print_vectors(read_vectors(args.rom))
+        elif args.cmd == "addr":
+            if args.file_offset is not None:
+                _print_addr_reverse(args.rom, int(args.file_offset, 0))
+            else:
+                h = decode_header(args.rom, full_crc=False)
+                bank = resolve_bank(args.bank, h.prg_banks)
+                _print_addr_result(args.rom, int(args.cpu_addr, 0), bank, args.length)
+    except BadRomFile as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    except (OSError, ValueError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_rom_info.py
+++ b/tools/test_rom_info.py
@@ -1,0 +1,597 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/rom_info.py.
+
+Run with: python tools/test_rom_info.py
+or:        python -m unittest tools/test_rom_info.py
+
+These tests exercise the iNES / NES 2.0 decoder against the byte equations
+documented in src/main/kotlin/.../gamepak/GamePak.kt (Header class). When
+those equations change, the Kotlin regression tests in GamePakTest.kt and
+these tests must be updated together.
+
+The fixture ROMs are built in memory to keep tests deterministic and free
+of any dependency on the developer's NO-INTRO library. nestest.nes is the
+one exception: it's a real in-repo ROM and is a useful cross-check.
+"""
+
+import os
+import struct
+import sys
+import tempfile
+import unittest
+import zlib
+from pathlib import Path
+
+# Make sure we can import the module under test whether invoked from the
+# repo root or from inside tools/.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import rom_info
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+def make_rom(
+    prg_banks: int = 1,
+    chr_banks: int = 1,
+    *,
+    b6: int = 0x00,
+    b7: int = 0x00,
+    b8: int = 0x00,
+    b9: int = 0x00,
+    b10: int = 0x00,
+    b11: int = 0x00,
+    b12: int = 0x00,
+    b13: int = 0x00,
+    b14: int = 0x00,
+    b15: int = 0x00,
+    fill_prg: int = 0xEA,
+    fill_chr: int = 0x00,
+) -> bytes:
+    """Build a minimal valid iNES / NES 2.0 ROM with custom header bytes.
+
+    All bank contents are filled with a single byte so the test can verify
+    "we read what we wrote" or distinguish banks if it needs to. The
+    16-byte header is constructed with the supplied control bytes; the
+    "NES\\x1A" magic and the bank counts (bytes 4 and 5) are pinned from
+    the function arguments.
+    """
+    header = bytearray(16)
+    header[0:4] = b"NES\x1A"
+    header[4] = prg_banks & 0xFF
+    header[5] = chr_banks & 0xFF
+    header[6] = b6
+    header[7] = b7
+    header[8] = b8
+    header[9] = b9
+    header[10] = b10
+    header[11] = b11
+    header[12] = b12
+    header[13] = b13
+    header[14] = b14
+    header[15] = b15
+    prg = bytes([fill_prg]) * (prg_banks * 16 * 1024)
+    chr_ = bytes([fill_chr]) * (chr_banks * 8 * 1024)
+    return bytes(header) + prg + chr_
+
+
+def write_temp_rom(data: bytes, suffix: str = ".nes") -> Path:
+    """Write `data` to a temp file and return the Path."""
+    fd, name = tempfile.mkstemp(suffix=suffix)
+    os.close(fd)
+    p = Path(name)
+    p.write_bytes(data)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Header decode — iNES 1.0
+# ---------------------------------------------------------------------------
+
+class PlainInesDecodeTest(unittest.TestCase):
+    """The plain-iNES paths of Header.kt mirrored in decode_header()."""
+
+    def test_nestest_rom_decodes_to_mapper_zero(self):
+        # The real in-repo ROM. If this fails, our decoder has drifted from
+        # Header.kt's known-true behaviour.
+        repo_root = Path(__file__).resolve().parent.parent
+        rom = repo_root / "testroms" / "nestest.nes"
+        if not rom.is_file():
+            self.skipTest(f"nestest.nes not found at {rom}")
+        h = rom_info.decode_header(str(rom))
+        self.assertEqual(h.is_nes20, False)
+        self.assertEqual(h.mapper, 0)
+        self.assertEqual(h.submapper, 0)
+        self.assertEqual(h.prg_banks, 1)
+        self.assertEqual(h.chr_banks, 1)
+        self.assertEqual(h.prg_bytes, 16 * 1024)
+        self.assertEqual(h.chr_bytes, 8 * 1024)
+        self.assertEqual(h.mirroring, "horizontal")
+        self.assertEqual(h.has_battery, False)
+        self.assertEqual(h.region_from_header, None)
+        self.assertEqual(h.region_from_name, None)  # filename has no marker
+        self.assertEqual(h.region_effective, "NTSC")
+        self.assertFalse(h.mislabel_warnings)
+
+    def test_plain_ines_byte7_bit4_is_mapper_bit(self):
+        # Crayon Shin-chan case from GamePakTest.kt:plainInesByte7Bit4IsMapperBit.
+        # byte6=0x00, byte7=0x10 -> mapper = 0 | 0x10 = 16.
+        rom = make_rom(b6=0x00, b7=0x10)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertEqual(h.is_nes20, False)
+        self.assertEqual(h.mapper, 16)
+        self.assertEqual(h.submapper, 0)
+
+    def test_plain_ines_byte8_is_prg_ram_not_submapper(self):
+        # In plain iNES, byte 8 is the PRG-RAM size field and must NOT be
+        # interpreted as a submapper. submapper stays 0.
+        rom = make_rom(b6=0x00, b7=0x00, b8=0xFF)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertEqual(h.is_nes20, False)
+        self.assertEqual(h.submapper, 0)
+
+    def test_vertical_mirroring_when_byte6_bit0_set(self):
+        rom = make_rom(b6=0x01)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertEqual(h.mirroring, "vertical")
+
+    def test_battery_flag_when_byte6_bit1_set(self):
+        rom = make_rom(b6=0x02)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertTrue(h.has_battery)
+
+    def test_mapper_4_namco108_verification_prompt(self):
+        # mapper 4 fires a verification prompt (most mapper-4 games are
+        # real MMC3; only the named Namco 108 titles are mislabeled).
+        # Real mapper-4 byte pattern: byte 6 high nibble = 4 -> b6 = 0x40.
+        rom = make_rom(b6=0x40, b7=0x00)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertEqual(h.mapper, 4)
+        self.assertTrue(h.mislabel_warnings, "mapper 4 should prompt Namco 108 verification")
+        # The prompt must mention the actual mapper, the family, the known
+        # titles, and the patch recipe — not assert "this IS a mislabel".
+        w = h.mislabel_warnings[0]
+        self.assertIn("206", w)
+        self.assertIn("Namco 108", w)
+        self.assertIn("Gauntlet", w)
+        self.assertIn("patch recipe", w.lower())
+        self.assertIn("if your rom", w.lower())
+
+
+# ---------------------------------------------------------------------------
+# Header decode — NES 2.0
+# ---------------------------------------------------------------------------
+
+class Nes20DecodeTest(unittest.TestCase):
+    """The NES 2.0 paths of Header.kt mirrored in decode_header()."""
+
+    def test_is_nes20_marker(self):
+        # byte 7 bits 2-3 == 0b10 means NES 2.0.
+        rom = make_rom(b7=0x08)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertTrue(h.is_nes20)
+
+    def test_is_not_nes20_when_marker_absent(self):
+        # byte 7 bits 2-3 == 0b00 -> iNES 1.0 even with high mapper bits.
+        rom = make_rom(b6=0x20, b7=0x10)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertFalse(h.is_nes20)
+
+    def test_nes20_byte7_bit4_is_mapper_bit(self):
+        # Rokudenashi Blues from GamePakTest.kt: byte6=0x02, byte7=0x18,
+        # byte8=0x50. mapper = 0 | (0x18 & 0xF0)=0x10 | 0 = 16.
+        # submapper = 5 (byte 8 high nibble).
+        rom = make_rom(b6=0x02, b7=0x18, b8=0x50)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertTrue(h.is_nes20)
+        self.assertEqual(h.mapper, 16)
+        self.assertEqual(h.submapper, 5)
+
+    def test_nes20_mapper_256_uses_byte8_low_nibble(self):
+        # NES 2.0 + mapper 256: byte 8 low nibble = 1 -> mapper = 256.
+        rom = make_rom(b7=0x08, b8=0x01)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertTrue(h.is_nes20)
+        self.assertEqual(h.mapper, 256)
+
+    def test_nes20_submapper_does_not_leak_into_mapper(self):
+        # byte 8 = 0x51: low nibble 1 (mapper bits 8-11) + high nibble 5 (submapper).
+        # mapper must be 256, NOT 0x5100.
+        rom = make_rom(b7=0x08, b8=0x51)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertEqual(h.mapper, 256)
+        self.assertEqual(h.submapper, 5)
+
+    def test_nes20_region_ntsc_when_byte12_low_bits_00(self):
+        rom = make_rom(b7=0x08, b12=0x00)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertEqual(h.region_from_header, "NTSC")
+        self.assertEqual(h.region_effective, "NTSC")
+
+    def test_nes20_region_pal_when_byte12_low_bits_01(self):
+        rom = make_rom(b7=0x08, b12=0x01)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertEqual(h.region_from_header, "PAL")
+        self.assertEqual(h.region_effective, "PAL")
+
+    def test_nes20_region_dendy_when_byte12_low_bits_11(self):
+        rom = make_rom(b7=0x08, b12=0x03)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertEqual(h.region_from_header, "PAL")
+        self.assertEqual(h.region_effective, "PAL")
+
+    def test_nes20_region_undecided_when_byte12_low_bits_10(self):
+        # "both" -> undecided. Region falls back to filename / NTSC.
+        rom = make_rom(b7=0x08, b12=0x02)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertIsNone(h.region_from_header)
+
+    def test_plain_ines_region_pal_flag_in_byte9(self):
+        # iNES byte 9 bit 0 = PAL. Set the bit; absence is NOT NTSC evidence.
+        rom = make_rom(b9=0x01)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertEqual(h.region_from_header, "PAL")
+        self.assertEqual(h.region_effective, "PAL")
+
+    def test_plain_ines_region_unset_byte9_means_no_header_evidence(self):
+        rom = make_rom(b9=0x00)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertIsNone(h.region_from_header)
+
+
+# ---------------------------------------------------------------------------
+# Region inference from NO-INTRO filename
+# ---------------------------------------------------------------------------
+
+class RegionFromNameTest(unittest.TestCase):
+
+    def test_usa_filename_implies_ntsc(self):
+        rom = make_rom()
+        p = write_temp_rom(rom)
+        try:
+            # Rename to mimic a NO-INTRO USA dump.
+            new_p = p.with_name("Gauntlet (USA).nes")
+            p.rename(new_p)
+            h = rom_info.decode_header(str(new_p), full_crc=False)
+            self.assertEqual(h.region_from_name, "NTSC")
+        finally:
+            if new_p.exists():
+                new_p.unlink()
+
+    def test_europe_filename_implies_pal(self):
+        rom = make_rom()
+        p = write_temp_rom(rom)
+        try:
+            new_p = p.with_name("Some Game (Europe).nes")
+            p.rename(new_p)
+            h = rom_info.decode_header(str(new_p), full_crc=False)
+            self.assertEqual(h.region_from_name, "PAL")
+        finally:
+            if new_p.exists():
+                new_p.unlink()
+
+    def test_header_wins_over_filename(self):
+        # NES 2.0 header says NTSC; filename says Europe. Effective is NTSC.
+        rom = make_rom(b7=0x08, b12=0x00)
+        p = write_temp_rom(rom)
+        try:
+            new_p = p.with_name("Conflict (Europe).nes")
+            p.rename(new_p)
+            h = rom_info.decode_header(str(new_p), full_crc=False)
+            self.assertEqual(h.region_from_name, "PAL")
+            self.assertEqual(h.region_from_header, "NTSC")
+            self.assertEqual(h.region_effective, "NTSC")
+        finally:
+            if new_p.exists():
+                new_p.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Vectors
+# ---------------------------------------------------------------------------
+
+class VectorsTest(unittest.TestCase):
+
+    def test_vectors_read_from_last_bank(self):
+        # Build a 2-PRG-bank ROM, place known vectors at the end of bank 1.
+        nmi = 0xC123
+        reset = 0xC456
+        irq = 0xC789
+        rom = bytearray(make_rom(prg_banks=2, chr_banks=0))
+        # Vector offsets within the file:
+        #   last_bank_start = 16 (header) + 1 * 16384 = 16400
+        #   $FFFA within the last bank is at byte 0x3FFA (0xFFFA - 0xC000).
+        #   So the NMI vector lives at file offset 16400 + 0x3FFA = 32778.
+        vec_offset = 16 + 1 * 16384 + 0x3FFA
+        struct.pack_into("<H", rom, vec_offset + 0, nmi)
+        struct.pack_into("<H", rom, vec_offset + 2, reset)
+        struct.pack_into("<H", rom, vec_offset + 4, irq)
+        p = write_temp_rom(bytes(rom))
+        try:
+            v = rom_info.read_vectors(str(p))
+            self.assertEqual(v.nmi, nmi)
+            self.assertEqual(v.reset, reset)
+            self.assertEqual(v.irq, irq)
+        finally:
+            p.unlink()
+
+    def test_vectors_for_one_bank_rom(self):
+        # NROM-128: 1 PRG bank mirrored to $8000 and $C000. Vectors at end
+        # of the (only) bank, file offset 16 + 0x3FFA.
+        nmi = 0x8000
+        reset = 0xC000
+        irq = 0xFFFA
+        rom = bytearray(make_rom(prg_banks=1, chr_banks=0))
+        vec_offset = 16 + 0x3FFA
+        struct.pack_into("<H", rom, vec_offset + 0, nmi)
+        struct.pack_into("<H", rom, vec_offset + 2, reset)
+        struct.pack_into("<H", rom, vec_offset + 4, irq)
+        p = write_temp_rom(bytes(rom))
+        try:
+            v = rom_info.read_vectors(str(p))
+            self.assertEqual(v.nmi, nmi)
+            self.assertEqual(v.reset, reset)
+            self.assertEqual(v.irq, irq)
+        finally:
+            p.unlink()
+
+
+# ---------------------------------------------------------------------------
+# CPU address <-> file offset math
+# ---------------------------------------------------------------------------
+
+class AddrMathTest(unittest.TestCase):
+
+    def test_cpu_to_file_offset_first_bank(self):
+        # $8000 in bank 0 of a 2-bank ROM = 16 + 0 = 16.
+        off = rom_info.cpu_to_file_offset(prg_banks=2, cpu_addr=0x8000, bank=0)
+        self.assertEqual(off, 16)
+
+    def test_cpu_to_file_offset_second_bank(self):
+        # $C000 in bank 1 of a 2-bank ROM. Bank 1 is the fixed last bank,
+        # so $C000 is the first byte of that bank (offset 0 within bank 1).
+        off = rom_info.cpu_to_file_offset(prg_banks=2, cpu_addr=0xC000, bank=1)
+        self.assertEqual(off, 16 + 1 * 16384 + 0)
+
+    def test_cpu_to_file_offset_within_bank(self):
+        # $EA40 in bank 1 of a 2-bank ROM. Bank 1 is fixed at $C000, so
+        # offset_in_bank = $EA40 - $C000 = $2A40, NOT $EA40 - $8000.
+        off = rom_info.cpu_to_file_offset(prg_banks=2, cpu_addr=0xEA40, bank=1)
+        self.assertEqual(off, 16 + 16384 + (0xEA40 - 0xC000))
+
+    def test_cpu_to_file_offset_rejects_swappable_addr_in_last_bank(self):
+        # $8000 in bank N-1 of a multi-bank ROM is inconsistent: the last
+        # bank is mapped at $C000-$FFFF only. The fixed/swappable split
+        # must be enforced.
+        with self.assertRaises(ValueError):
+            rom_info.cpu_to_file_offset(prg_banks=2, cpu_addr=0x8000, bank=1)
+
+    def test_cpu_to_file_offset_rejects_fixed_addr_in_swappable_bank(self):
+        # $C000 in bank 0 of a 2-bank ROM is inconsistent: bank 0 is
+        # mapped at $8000-$BFFF only.
+        with self.assertRaises(ValueError):
+            rom_info.cpu_to_file_offset(prg_banks=2, cpu_addr=0xC000, bank=0)
+
+    def test_cpu_to_file_offset_one_bank_mirrors_both_halves(self):
+        # NROM-128 (1 PRG bank): the single bank is mirrored to BOTH
+        # $8000-$BFFF and $C000-$FFFF. $8000 and $C000 point at the same
+        # file offset (16).
+        self.assertEqual(
+            rom_info.cpu_to_file_offset(prg_banks=1, cpu_addr=0x8000, bank=0),
+            16,
+        )
+        self.assertEqual(
+            rom_info.cpu_to_file_offset(prg_banks=1, cpu_addr=0xC000, bank=0),
+            16,
+        )
+
+    def test_cpu_to_file_offset_rejects_out_of_range(self):
+        with self.assertRaises(ValueError):
+            rom_info.cpu_to_file_offset(prg_banks=1, cpu_addr=0x7FFF, bank=0)
+        with self.assertRaises(ValueError):
+            rom_info.cpu_to_file_offset(prg_banks=1, cpu_addr=0x8000, bank=1)
+
+    def test_file_to_cpu_addr_roundtrip(self):
+        # 4-bank ROM; pick a deep address and check the round-trip.
+        # Each case: (file_offset, expected_cpu, expected_bank).
+        # The vector region ($FFFA-$FFFF) of bank 3 lives at file offsets
+        # 16 + 3*16384 + 0x3FFA .. 16 + 3*16384 + 0x4000 (exclusive).
+        # Bank 3 is the LAST bank, so file offsets inside it map to $C000+
+        # (not $8000+). Banks 0..2 are swappable at $8000+.
+        prg_banks = 4
+        cases = [
+            (16 + 0 * 16384 + 0x0000, 0x8000, 0),         # bank 0, first byte
+            (16 + 2 * 16384 + 0x1234, 0x9234, 2),         # bank 2, mid-PRG
+            (16 + 3 * 16384 + 0x0000, 0xC000, 3),         # bank 3, $C000
+            (16 + 3 * 16384 + 0x3FFA, 0xFFFA, 3),         # bank 3, NMI vector
+            (16 + 3 * 16384 + 0x3FFF, 0xFFFF, 3),         # bank 3, last byte
+        ]
+        for file_off, expected_cpu, expected_bank in cases:
+            cpu, bank = rom_info.file_to_cpu_addr(file_off, prg_banks)
+            self.assertEqual(cpu, expected_cpu, f"file 0x{file_off:X}")
+            self.assertEqual(bank, expected_bank, f"file 0x{file_off:X}")
+            # And the inverse should match. cpu_to_file_offset needs the
+            # CPU addr to be in the right half ($8000 for swappable banks,
+            # $C000 for the fixed last bank); we just confirm the function
+            # round-trips back to the same file offset.
+            self.assertEqual(
+                rom_info.cpu_to_file_offset(prg_banks=prg_banks, cpu_addr=cpu, bank=bank),
+                file_off,
+            )
+
+    def test_file_to_cpu_addr_one_bank_rom(self):
+        # NROM-128: 1 PRG bank mirrored to BOTH $8000 and $C000. A file
+        # offset anywhere in the bank should report the $C000-region
+        # address (since it's the only bank, it IS the last bank).
+        cpu, bank = rom_info.file_to_cpu_addr(16 + 0x3FFA, prg_banks=1)
+        self.assertEqual(cpu, 0xFFFA)
+        self.assertEqual(bank, 0)
+
+    def test_file_to_cpu_addr_rejects_header_offset(self):
+        with self.assertRaises(ValueError):
+            rom_info.file_to_cpu_addr(8, prg_banks=1)   # inside the 16-byte header
+
+    def test_resolve_bank_keyword(self):
+        self.assertEqual(rom_info.resolve_bank("last", 4), 3)
+        self.assertEqual(rom_info.resolve_bank("fixed", 4), 3)
+        self.assertEqual(rom_info.resolve_bank("2", 4), 2)
+        self.assertEqual(rom_info.resolve_bank("0x2", 4), 2)
+
+
+# ---------------------------------------------------------------------------
+# Namco 108 patch
+# ---------------------------------------------------------------------------
+
+class PatchNamco108Test(unittest.TestCase):
+
+    def test_patch_changes_byte6_and_byte7(self):
+        # NO-INTRO Namco 108 dump pattern: mapper 4 in bytes 6/7.
+        # b6 = 0x40 (mapper low = 4), b7 = 0x00.
+        rom = make_rom(b6=0x40, b7=0x00)
+        p = write_temp_rom(rom)
+        try:
+            out, diff = rom_info.patch_namco108(str(p))
+            try:
+                self.assertEqual(diff["byte6_before"], "0x40")
+                self.assertEqual(diff["byte6_after"], "0xE0")
+                self.assertEqual(diff["byte7_before"], "0x00")
+                self.assertEqual(diff["byte7_after"], "0xC0")
+                self.assertEqual(diff["mapper_after"], 206)
+                # Output must decode as mapper 206.
+                h = rom_info.decode_header(str(out), full_crc=False)
+                self.assertEqual(h.mapper, 206)
+            finally:
+                if out.exists():
+                    out.unlink()
+        finally:
+            p.unlink()
+
+    def test_patch_preserves_other_bytes(self):
+        rom = make_rom(b6=0x40, b7=0x00, fill_prg=0xCD)
+        p = write_temp_rom(rom)
+        try:
+            out, _ = rom_info.patch_namco108(str(p))
+            try:
+                with open(out, "rb") as f:
+                    patched = f.read()
+                # Header bytes 0..5 (magic + bank counts) must be unchanged.
+                self.assertEqual(patched[0:6], rom[0:6])
+                # Header bytes 8..15 must be unchanged.
+                self.assertEqual(patched[8:16], rom[8:16])
+                # PRG body must be unchanged.
+                self.assertEqual(patched[16:], rom[16:])
+            finally:
+                if out.exists():
+                    out.unlink()
+        finally:
+            p.unlink()
+
+    def test_patch_does_not_modify_source(self):
+        # The "never touches the source" guarantee is the whole point of
+        # using a sibling copy; lock it in with a hash check.
+        rom = make_rom(b6=0x40, b7=0x00)
+        p = write_temp_rom(rom)
+        try:
+            source_hash_before = zlib.crc32(rom) & 0xFFFFFFFF
+            out, _ = rom_info.patch_namco108(str(p))
+            try:
+                with open(p, "rb") as f:
+                    source_bytes_after = f.read()
+                source_hash_after = zlib.crc32(source_bytes_after) & 0xFFFFFFFF
+                self.assertEqual(source_hash_after, source_hash_before)
+                # And the file on disk is byte-identical to the original.
+                self.assertEqual(source_bytes_after, rom)
+            finally:
+                if out.exists():
+                    out.unlink()
+        finally:
+            p.unlink()
+
+    def test_patch_rejects_non_ines(self):
+        with tempfile.NamedTemporaryFile(suffix=".nes", delete=False) as f:
+            f.write(b"NOPE\x00" + b"\x00" * 100)
+            bad = f.name
+        try:
+            with self.assertRaises(rom_info.BadRomFile):
+                rom_info.patch_namco108(bad)
+        finally:
+            os.unlink(bad)
+
+
+# ---------------------------------------------------------------------------
+# Library scan
+# ---------------------------------------------------------------------------
+
+class ScanLibraryTest(unittest.TestCase):
+
+    def test_scan_finds_all_roms(self):
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            # Write three ROMs with known mappers.
+            (tdp / "a.nes").write_bytes(make_rom(b6=0x00))           # mapper 0
+            (tdp / "b.nes").write_bytes(make_rom(b6=0x20, b7=0x10))  # mapper 0x12 = 18
+            (tdp / "c.nes").write_bytes(make_rom(b6=0x40, b7=0x00))  # mapper 4 (Namco 108)
+            # One non-ROM file that must be skipped, not crash the scan.
+            (tdp / "readme.txt").write_text("not a ROM")
+
+            rows = rom_info.scan_library(tdp)
+            mappers = sorted(r.mapper for r in rows)
+            self.assertEqual(mappers, [0, 4, 18])
+            # Mislabel flag for the Namco 108 dump.
+            namco = next(r for r in rows if r.mapper == 4)
+            self.assertTrue(namco.mislabel)
+
+    def test_scan_filters_by_mapper(self):
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            (tdp / "a.nes").write_bytes(make_rom(b6=0x00))           # mapper 0
+            (tdp / "b.nes").write_bytes(make_rom(b6=0x20, b7=0x10))  # mapper 18
+            (tdp / "c.nes").write_bytes(make_rom(b6=0x40, b7=0x00))  # mapper 4
+            rows = rom_info.scan_library(tdp, mapper=0)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0].mapper, 0)
+
+    def test_scan_silently_skips_invalid_roms(self):
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            (tdp / "good.nes").write_bytes(make_rom(b6=0x00))
+            (tdp / "bad.nes").write_bytes(b"NOT A ROM AT ALL")
+            rows = rom_info.scan_library(tdp)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0].filename, "good.nes")
+
+
+# ---------------------------------------------------------------------------
+# Bad input handling
+# ---------------------------------------------------------------------------
+
+class BadInputTest(unittest.TestCase):
+
+    def test_missing_file(self):
+        with self.assertRaises(rom_info.BadRomFile):
+            rom_info.decode_header("/nonexistent/path.nes")
+
+    def test_truncated_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".nes", delete=False) as f:
+            f.write(b"NES\x1A")  # only 4 bytes
+            truncated = f.name
+        try:
+            with self.assertRaises(rom_info.BadRomFile):
+                rom_info.decode_header(truncated)
+        finally:
+            os.unlink(truncated)
+
+    def test_wrong_magic(self):
+        with tempfile.NamedTemporaryFile(suffix=".nes", delete=False) as f:
+            f.write(b"FOO\x00" + b"\x00" * 100)
+            wrong = f.name
+        try:
+            with self.assertRaises(rom_info.BadRomFile):
+                rom_info.decode_header(wrong)
+        finally:
+            os.unlink(wrong)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #152.

## What
A new Python tool, `tools/rom_info.py`, that decodes iNES / NES 2.0
headers and answers the "what is this ROM, really?" question that has
bitten five times in recent mapper work (Namco 108 mislabel, Captain
Tsubasa II vs TC0190, Alien Syndrome vs RAMBO-1, missing NES 2.0
submapper, PAL flag vs filename).

Five subcommands, all from the issue body:

```
info         <rom.nes>            decode header (mapper, submapper, NES 2.0?,
                                  PRG/CHR sizes, battery, mirroring, region
                                  from header + filename, CRC32, NO-INTRO
                                  mislabel verification prompt)
scan         <dir> [--mapper N]   walk a ROM library, list titles by mapper;
                                  header-only, ~16 bytes per ROM
patch-namco108 <rom.nes>          emit a sibling COPY with the NO-INTRO
                                  Namco 108 header patch applied
                                  (mapper 4 -> 206); never touches source
vectors      <rom.nes>            NMI / RESET / IRQ from the fixed last bank
addr         <rom.nes> --cpu-addr 0xXXXX [--bank N|last]
                                  CPU addr <-> file offset math + hexdump
```

## Why
- The decoder mirrors `Header.kt` byte-for-byte. Tests lock the
  equations in place against both synthetic fixtures and the
  in-repo `nestest.nes`.
- Region inference mirrors `GamePak.regionFromName`, so an agent and
  the emulator core never disagree about region.
- The Namco 108 patcher is the only one of its kind in the project
  today. The recipe previously lived in a session-memory file
  (`namco-108-ines-mapper-4-convention-2026-06-01.md`); it's now a
  one-liner with a clear diff printout.
- The bank-offset math (`addr`) was hand-rolled in two prior sessions;
  now it's tested and reusable.

## Tests
`tools/test_rom_info.py` has 43 unit tests covering:
- iNES 1.0 vs NES 2.0 decode (mapper, submapper, mirroring, battery)
- The byte-7-bit-4-is-mapper-bit fix from PR #117 / issue #118
  (Crayon Shin-chan, Rokudenashi Blues)
- Submapper-leak-into-mapper regression (mapper 256 with submapper 5)
- Region detection (NES 2.0 byte 12, iNES byte 9 bit 0, filename
  markers, header > name > NTSC precedence)
- Namco 108 patch: bytes change, other bytes preserved, source file
  byte-identical after patching
- Vectors: 1-bank (NROM-128 mirror) and 2-bank (NROM-256) ROMs
- Bank math: swappable vs fixed last bank asymmetry, NROM-128 mirror
- Library scan: find all, filter by mapper, silently skip invalid ROMs
- Bad input: missing file, truncated file, wrong magic

All 43 pass: `python tools/test_rom_info.py`.

## End-to-end smoke
Verified against the dev library on `S:\Media\Nintendo NES\Games`:
- `info` on `nestest.nes` -> CRC `0x9E179D92` (matches GamePak.kt
  `TEST_ROM_CRC` constant).
- `vectors` on `nestest.nes` -> RESET=`$C004`.
- `addr --cpu-addr 0xC341 --bank last` on `Kirby's Adventure` ->
  bank 31, file offset `0x07C351`; bytes are the canonical HAL Labs
  MMC3 NMI prologue (PHA TXA PHA TYA PHA LDA \$36 AND \$37 STA \$2001
  STA \$E000).
- `scan --mapper 4` on the full library returns all the real MMC3
  games with a `!!` verification flag; `scan --mapper 228` cleanly
  finds both Action 52 and Cheetahmen II.

## Notes on the warning UX
The `info` warning for mapper 4 is intentionally a **verification
prompt**, not a definite mislabel claim. The previous wording
"iNES mapper 4 is the NO-INTRO label for mapper 206" was a false
positive for every legitimate MMC3 game (Kirby, Mega Man, etc.).
The new wording reads: "if your ROM is one of {Gauntlet, Ring King,
RBI Baseball, Mappy-Land}, the header is mislabeled; if not, ignore.
Patch recipe if mislabeled: ..." — useful, honest, no false alarms.

## Followups (not in this PR)
- A `--strict-namco` / `--no-warnings` flag for `scan` to mute the
  `!!` column or filter to only known-mislabel titles. Out of scope
  for the initial issue body.