### PR TITLE
Mapper-correctness enforcement: bootcheck, Stop hook, coverage lint, tag-based test lanes

### DIFF
--- a/.claude/hooks/mapper-verify-guard.ps1
+++ b/.claude/hooks/mapper-verify-guard.ps1
@@ -1,0 +1,72 @@
+<#
+Stop hook: refuse to let the session end "done" when a mapper was changed but no boot
+verification was actually run.
+
+Why: delegated models routinely edit a gamepak/Mapper*.kt, claim success, and stop - while the
+real game never booted (the strong Mesen2 gates skip when the oracle/ROM is absent, so nothing
+goes red). This hook makes the claim un-makeable without evidence: if a mapper source file is
+dirty in git and the transcript shows no bootcheck PASS/WARN (or a Mesen2 render MATCH), it blocks
+the stop and tells the agent what to run.
+
+Evidence accepted (any one):
+  - "BOOTCHECK VERDICT: PASS" or "... WARN"  (./gradlew bootcheck -Prom=<rom>)
+  - "render-output: MATCH" / "CHR banks: MATCH"  (a Mesen2 regression test ran)
+
+Behaviour:
+  - stop_hook_active (we already blocked once) -> exit 0  (never loop)
+  - no mapper source dirty                     -> exit 0  (not a mapper session)
+  - mapper dirty + evidence present            -> exit 0  (verified)
+  - mapper dirty + no evidence                 -> exit 2  (BLOCK; stderr tells the agent what to run)
+  - any error                                  -> exit 0  (fail open: a broken hook must never wedge a session)
+
+Windows-first by design (this project's dev platform), mirroring worktree-guard.ps1.
+ASCII-only on purpose: PowerShell 5.1 mis-parses non-ASCII (em-dash, smart quotes) in string literals.
+#>
+$ErrorActionPreference = 'Stop'
+
+try {
+    $payload = [Console]::In.ReadToEnd() | ConvertFrom-Json
+
+    # Never re-block: if this hook already fired and the agent looped back, let it stop.
+    if ($payload.stop_hook_active) { exit 0 }
+
+    $projectDir = $env:CLAUDE_PROJECT_DIR
+    if (-not $projectDir) { $projectDir = (Get-Location).Path }
+
+    # Is any mapper SOURCE file dirty (modified, added, or untracked) in this worktree?
+    $pathspec = 'src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper*.kt'
+    $status = & git -C $projectDir status --porcelain -- $pathspec 2>$null
+    if ($LASTEXITCODE -ne 0) { exit 0 }                      # not a git repo / git missing: fail open
+    $dirty = @($status | Where-Object { $_ -and $_.Trim().Length -gt 0 })
+    if ($dirty.Count -eq 0) { exit 0 }                       # no mapper changed this session
+
+    # Look for verification evidence in the session transcript.
+    $transcript = $payload.transcript_path
+    $verified = $false
+    if ($transcript -and (Test-Path $transcript)) {
+        $text = Get-Content -Raw -LiteralPath $transcript
+        # bootcheck PASS/WARN (a FAIL must NOT count), or a Mesen2 render/CHR MATCH from a regression
+        # test. \b word boundaries stop "PASSABLE"/"WARNING"/"MISMATCH" from spuriously satisfying it.
+        if ($text -match 'BOOTCHECK VERDICT:\s*(PASS|WARN)\b' -or
+            $text -match 'render-output:\s*\bMATCH\b' -or
+            $text -match 'CHR banks:\s*\bMATCH\b') {
+            $verified = $true
+        }
+    }
+
+    if ($verified) { exit 0 }
+
+    $changed = ($dirty | ForEach-Object { $_.Substring([Math]::Min(3, $_.Length)) }) -join ', '
+    $msg = "BLOCKED: you changed mapper source ($changed) but no boot verification ran this session. " +
+        "A passing unit suite does not prove a real game boots - the Mesen2 gates skip when the " +
+        "oracle/ROM is absent. Run the oracle-free smoke and cite the verdict before finishing:`n" +
+        "  ./gradlew bootcheck -Prom=<path-to-a-rom-for-this-mapper>`n" +
+        "Address a FAIL (did not load / blank screen) before claiming done. If you genuinely cannot " +
+        "run it (no ROM available), say so explicitly to the user instead of stopping silently."
+    [Console]::Error.WriteLine($msg)
+    exit 2
+}
+catch {
+    [Console]::Error.WriteLine("mapper-verify-guard hook error (allowing stop): $_")
+    exit 0
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/mapper-verify-guard.ps1"
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/.claude/skills/new-mapper/SKILL.md
+++ b/.claude/skills/new-mapper/SKILL.md
@@ -71,10 +71,29 @@ in order; do not skip steps because the mapper "looks simple".
    mid-frame double-fire (the RAMBO-1 v6 trap: "CHR matched byte-for-byte" while the
    IRQ fired twice per frame).
 
-## Step 4 — Boot verification against the real game
+## Step 4 — Boot verification against the real game (MANDATORY — the suite is not enough)
 
-- Run the game; if it doesn't boot, run `./gradlew diverge -Prom=<rom> -Pframe=60`
-  FIRST — the DivergenceLocalizer's classification table maps the divergence shape to
-  the likely subsystem before you form a hypothesis. Do not start from a guess.
-- Update `MAPPER_SUPPORT.md` (games tested, quirks) and close out with the regression
-  suite green: `./gradlew test` and `./gradlew testMesenComparison`.
+A green `./gradlew test` does **not** prove a real game boots: the Mesen2 byte-compare and the
+real-game boot tests `assumeTrue(romExists)` / `@RequiresMesen2`, so they *skip* (green) on a
+worktree without the ROM library or Mesen2. Skipping the steps below is exactly how a mapper ships
+"green" but renders garbage. Do them, in order:
+
+1. **Oracle-free smoke first — `./gradlew bootcheck -Prom=<rom> [-Pframes=120]`.** No Mesen2 or
+   ROM library needed. Prints `BOOTCHECK VERDICT: PASS|WARN|FAIL` from loaded/rendered/non-blank/
+   banks-moved/NMI+IRQ signals. A **FAIL** ("did not boot to a picture") or a blank-screen **WARN**
+   is a real bug — fix it before going further. A weak model claiming success without a PASS/WARN
+   here is the failure mode this gate exists to stop. (A `Stop` hook, `mapper-verify-guard.ps1`,
+   blocks ending the session when a `gamepak/Mapper*.kt` is dirty and no bootcheck PASS/WARN or
+   Mesen2 MATCH appears in the transcript — so cite the verdict.)
+2. **If bootcheck is not PASS, localise before guessing — `./gradlew diverge -Prom=<rom> -Pframe=60`.**
+   The DivergenceLocalizer's classification table maps the divergence shape to the likely subsystem.
+   Do not start from a guess.
+3. **Write the Mesen2 regression test — it self-wires.** Subclass `MapperRegressionTestBase` (it
+   carries `@Tag("mesen")`, which JUnit inherits) and annotate the render-output method
+   `@RequiresMesen2`. That is the *entire* wiring: `./gradlew testMesenComparison` discovers it by
+   tag and `./gradlew test` excludes it — there is **no list in `build.gradle.kts` to update** (the
+   old list is exactly what silently dropped 24/26/64). `MapperCoverageLintTest` fails the build if a
+   `Mapper*RegressionTest` is somehow not in the mesen lane, or if `MapperN.kt` lacks a `GamePak`
+   dispatch arm or a `## Mapper N` section in `MAPPER_SUPPORT.md`.
+4. **Update `MAPPER_SUPPORT.md`** (games tested, quirks) and close out with the regression suite
+   green: `./gradlew test` (includes the lint) and `./gradlew testMesenComparison`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,16 @@ Personal learning project. 6502 CPU + 2C02 PPU + 2A03 APU. JavaFX 21 UI, Mesen2 
 # plus automated LIKELY-CAUSE classification. Run this BEFORE forming a hypothesis.
 ./gradlew diverge -Prom=X:/src/nestlin/testroms/kirby.nes -Pframe=120
 
+# Oracle-free boot smoke (no Mesen2 / no ROM library needed): boot a ROM headless N frames and
+# print BOOTCHECK VERDICT: PASS|WARN|FAIL from loaded/rendered/non-blank/banks-moved/NMI+IRQ.
+# The mandatory self-check for any new/changed mapper — the Mesen2 gates skip when the oracle is
+# absent, so a green `test` proves nothing about a real game. (A Stop hook blocks ending a session
+# that edited gamepak/Mapper*.kt without a PASS/WARN here. MapperCoverageLintTest fails the build
+# if a mapper lacks a GamePak arm / MAPPER_SUPPORT section, or if a Mapper*RegressionTest isn't in
+# the tag-driven 'mesen' lane. Test lanes are @Tag-based now, not hand-listed: @Tag("mesen") +
+# @Tag("externalRom") are excluded from `test`; testMesenComparison runs @Tag("mesen").)
+./gradlew bootcheck -Prom=X:/src/nestlin/testroms/kirby.nes -Pframes=120
+
 # Print test-environment diagnostics (MESEN2_PATH resolution, ROM availability,
 # strict-mode flag) — run when a comparison test reports SKIPPED unexpectedly
 ./gradlew verifyTestEnv

--- a/MAPPER_SUPPORT.md
+++ b/MAPPER_SUPPORT.md
@@ -71,6 +71,22 @@ Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 24, 26, 33, 34,
   - IRQ counter reload: Fixed per NESdev spec - reload occurs when counter==0 OR reload flag is set
   - A12 edge detection: Wired from PPU pattern table access to mapper via a12EdgeListener
 
+## Mapper 5 (MMC5 / ExROM)
+**Status:** STUB — not yet playable
+
+- **Games (target):** Castlevania III: Dracula's Curse (the canonical MMC5 title), Just Breed,
+  Laser Invasion, Uncharted Waters, Metal Slader Glory.
+- **What works:** the cartridge loads and dispatches to `Mapper5`, and battery-backed PRG-RAM at
+  `$6000-$7FFF` persists (mapper 5 is in the `.sav` coverage list).
+- **What is missing (why Castlevania III is not playable):** the bank-select decode needs a
+  rewrite, plus MMC5's fill mode, the `$5205/$5206` multiplier output, ExRAM (`$5C00-$5FFF`)
+  nametable/attribute modes, and the scanline IRQ. There is **no expansion audio** (MMC5's two
+  pulse channels + PCM).
+- **Verification:** unit-level register coverage only; no end-to-end boot/render test yet — it would
+  fail until the items above land. Use `./gradlew bootcheck -Prom=<castlevania3.nes>` to track
+  progress (expect FAIL/garbage until the bank decode + scanline IRQ are implemented).
+- See the "Known limits" note in `CLAUDE.md` for the same summary.
+
 ## Mapper 9 (MMC2 / PxROM)
 **Status:** Working (Added 2026-05-20)
 
@@ -347,6 +363,10 @@ Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 24, 26, 33, 34,
   PRG-RAM-vs-PRG toggle (with the write-mask behaviour), CHR banking,
   mirroring, the full 16-bit IRQ, battery-backed RAM, and save/load
   round-trip.
+
+---
+
+## Mapper 11 (Color Dreams / NINA-007)
 **Status:** Working (Fixed 2026-04-17)
 
 - **Games:** Bible Adventures, Action 52, Crystalis (some versions)
@@ -356,6 +376,26 @@ Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 24, 26, 33, 34,
   2. PRG banking was fixed to bank 0 only; now properly switches 32KB PRG banks via bits 0-1
 - **Format (per NESdev wiki):** `CCCC LLPP` where CCCC = 8KB CHR bank (bits 4-7), LL = unused/lockout, PP = 32KB PRG bank (bits 0-1)
 - **Verified:** Bible Adventures now shows gameplay content (was all-black before fix)
+
+---
+
+## Mapper 34 (BNROM / NINA-001)
+**Status:** Working
+
+- **Games:** Deadly Towers (BNROM), Impossible Mission II / Darkseed-class NINA-001 titles.
+- **What it is:** two unrelated boards sharing one iNES number. Both bank the **entire** 32 KB
+  PRG window at `$8000-$FFFF` (no fixed bank, unlike UNROM/Mapper 2) and switch 8 KB CHR.
+- **Register decode (writes to `$8000-$FFFF`):** a single byte — `prgBank = value & 0x07`
+  (32 KB PRG bank, modulo PRG-bank count), `chrBank = (value >> 3) & 0x03` (8 KB CHR bank,
+  modulo CHR size). The NINA-001 sub-board uses separate `$7FFD/$7FFE/$7FFF` registers on real
+  hardware; this implementation models the BNROM-style combined `$8000` write.
+- **CHR:** 8 KB banked from CHR ROM; a 0 KB-CHR dump gets 8 KB of writable CHR RAM (same fallback
+  as Mappers 2/3/7/11/33/71).
+- **Mirroring:** fixed from the iNES header. No PRG-RAM, no IRQ.
+- **Verification:** `Mapper34Test` covers PRG/CHR bank select, the bit split, CHR-RAM fallback,
+  header mirroring, and save/load round-trip. End-to-end Mesen2 boot comparison is a follow-up
+  (Deadly Towers is the natural oracle) — run `./gradlew bootcheck -Prom=<deadly-towers.nes>`
+  for the oracle-free smoke in the meantime.
 
 ## Mapper 64 (Tengen RAMBO-1)
 **Status:** Working (Added 2026-06-07, issue #132)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,73 +67,35 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     }
 }
 
-// Exclude Mesen-dependent tests from the standard test pipeline.
-// These tests require Mesen2 to be installed and configured, so they should
-// only be run explicitly via: ./gradlew testMesenComparison
-val mesenTests = listOf(
-    "com.github.alondero.nestlin.compare.ScreenshotComparisonTest",
-    "com.github.alondero.nestlin.compare.StateComparisonTest",
-    "com.github.alondero.nestlin.compare.StateCaptureIntegrationTest",
-    "com.github.alondero.nestlin.compare.Mesen2StateCapturerSmokeTest",
-    "com.github.alondero.nestlin.compare.DebugMesen2CaptureTest",
-    "com.github.alondero.nestlin.compare.DebugStateCaptureTest",
-    "com.github.alondero.nestlin.compare.NestlinMapper4CaptureTest",
-    "com.github.alondero.nestlin.compare.Mapper10RegressionTest",
-    "com.github.alondero.nestlin.compare.Mapper33RegressionTest",
-    "com.github.alondero.nestlin.compare.GxRomStateComparisonTest",
-    "com.github.alondero.nestlin.compare.MicroMachinesMapper71SmokeTest",
-    "com.github.alondero.nestlin.compare.MicroMachinesMapper71StateComparisonTest",
-    "com.github.alondero.nestlin.compare.MicroMachinesExtendedCaptureTest",
-    "com.github.alondero.nestlin.compare.MicroMachinesDivergenceSweepTest",
-    "com.github.alondero.nestlin.compare.MicroMachinesPcDivergenceTest",
-    "com.github.alondero.nestlin.compare.MicroMachinesSplitTimingTest",
-    "com.github.alondero.nestlin.compare.MicroMachinesAttractHangTest",
-    "com.github.alondero.nestlin.compare.BigNoseHangTest"
-)
-
-// Also exclude debug/investigation tests that can hang or have pre-existing issues
-// Also exclude tests that depend on ROMs not in the repository
-val auxiliaryTests = listOf(
-    // Debug/investigation tests with external ROM dependencies
-    "com.github.alondero.nestlin.gamepak.Mapper4Verification",
-    "com.github.alondero.nestlin.gamepak.Mapper4GamesTest",
-    // Integration tests requiring external ROMs
-    "com.github.alondero.nestlin.Mapper1IntegrationTest",
-    // Compare tests that depend on external ROMs (kirby.nes, etc.)
-    "com.github.alondero.nestlin.compare.KirbyInstructionTraceTest",
-    "com.github.alondero.nestlin.compare.KirbyMesenVsNestlinOamTest",
-    "com.github.alondero.nestlin.compare.KirbyOamSnapshotTest",
-    "com.github.alondero.nestlin.compare.KirbyPpuCtrlTrackingTest",
-    "com.github.alondero.nestlin.compare.KirbyScreenshotTest",
-    "com.github.alondero.nestlin.compare.KirbyVBlankTest",
-    "com.github.alondero.nestlin.compare.MinimalVBlankSetTest",
-    "com.github.alondero.nestlin.compare.PpuCtrlNmiEdgeTest",
-    "com.github.alondero.nestlin.compare.ScreenshotCapture",
-    "com.github.alondero.nestlin.compare.VBlankPollingTest",
-    "com.github.alondero.nestlin.compare.VBlankReadRaceTest",
-    "com.github.alondero.nestlin.compare.VBlankTimingTest",
-    "com.github.alondero.nestlin.compare.VBlankTimingTest2"
-)
+// Test lanes are TAG-DRIVEN, not hand-listed. There is deliberately no list of test classes here:
+// the previous one silently went stale (it omitted the Mapper 24/26/64 regression tests for weeks,
+// so testMesenComparison quietly never ran them). Instead each test declares its own lane:
+//
+//   @Tag("mesen")        - needs the Mesen2 reference emulator. @RequiresMesen2 implies this tag
+//                          (it is meta-tagged), and MapperRegressionTestBase carries it so every
+//                          mapper regression test inherits it for free.
+//   @Tag("externalRom")  - needs a ROM not in git (kirby.nes etc.) or is a debug/investigation
+//                          test that can hang; excluded from the fast suite, no dedicated task.
+//
+// ./gradlew test               -> everything EXCEPT those two tags (fast, hermetic, ROM-free)
+// ./gradlew testMesenComparison -> only @Tag("mesen")
+// MapperCoverageLintTest fails the build if a compare/Mapper*RegressionTest is not in the mesen
+// lane, so "forgot to wire it up" is a red build, not a silent skip.
 
 tasks.test {
-    // Exclude Mesen-dependent tests from standard test run
-    mesenTests.forEach { testClass ->
-        exclude("**/${testClass.replace('.', '/')}.class")
+    // Fast suite: no Mesen2, no external ROMs. Tags do the exclusion - no class list to maintain.
+    useJUnitPlatform {
+        excludeTags("mesen", "externalRom")
     }
-    auxiliaryTests.forEach { testClass ->
-        exclude("**/${testClass.replace('.', '/')}.class")
-    }
-    useJUnitPlatform()
 }
 
 // Separate task to run Mesen comparison tests only when explicitly invoked
 tasks.register<Test>("testMesenComparison") {
     group = "verification"
     description = "Runs Mesen comparison tests that require Mesen2 to be installed"
-    mesenTests.forEach { testClass ->
-        include("**/${testClass.replace('.', '/')}.class")
+    useJUnitPlatform {
+        includeTags("mesen")
     }
-    useJUnitPlatform()
     // Forward MESEN2_PATH to the test JVM so the runner can locate Mesen2.
     // The Gradle daemon may not inherit shell env vars cleanly between invocations,
     // so we read it explicitly and pass it through.
@@ -199,6 +161,32 @@ tasks.register<JavaExec>("diverge") {
     if (mesen2Path != null) {
         environment("MESEN2_PATH", mesen2Path)
     }
+}
+
+// Oracle-free boot smoke: boot a ROM headless for N frames and print a PASS|WARN|FAIL verdict
+// (loaded / rendered / non-blank / banks-moved / NMI+IRQ counts). Needs NO Mesen2 and NO ROM
+// library — point it at any .nes. This is the self-check a delegated mapper task must run and
+// cite before claiming success (the strong Mesen2 gates skip when the oracle/ROM is absent).
+// Usage: ./gradlew bootcheck -Prom=X:/src/nestlin/testroms/kirby.nes [-Pframes=120]
+tasks.register<JavaExec>("bootcheck") {
+    group = "verification"
+    description = "Headless oracle-free boot verdict for a ROM (use -Prom=, optional -Pframes=)"
+    classpath = sourceSets["main"].runtimeClasspath
+    mainClass.set("com.github.alondero.nestlin.cli.BootCheckKt")
+
+    val rom = project.findProperty("rom") as String?
+    val frames = project.findProperty("frames") as String?
+    doFirst {
+        if (rom == null) {
+            throw GradleException("Missing -Prom=<path-to-rom>. Usage: ./gradlew bootcheck -Prom=rom.nes [-Pframes=120]")
+        }
+    }
+    args = buildList {
+        if (rom != null) add(rom)
+        if (frames != null) { add("--frames"); add(frames) }
+    }
+    // A FAIL verdict exits non-zero; surface it as a build failure so CI / the agent notices.
+    isIgnoreExitValue = false
 }
 
 // Sanity-check the local test environment (Mesen2, ROMs, strict mode) before

--- a/src/main/kotlin/com/github/alondero/nestlin/cli/BootCheck.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cli/BootCheck.kt
@@ -1,0 +1,324 @@
+package com.github.alondero.nestlin.cli
+
+import com.github.alondero.nestlin.Nestlin
+import com.github.alondero.nestlin.movie.runOneFrame
+import com.github.alondero.nestlin.ppu.Frame
+import com.github.alondero.nestlin.ppu.RESOLUTION_HEIGHT
+import com.github.alondero.nestlin.ppu.RESOLUTION_WIDTH
+import com.github.alondero.nestlin.ui.FrameListener
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Headless `bootcheck` command: boot a ROM cold, run it for N frames with no display and no
+ * reference emulator, and print a machine-greppable verdict about whether it plausibly *booted*.
+ *
+ * ## Why this exists
+ *
+ * The strong mapper gates — the Mesen2 byte-compare in [com.github.alondero.nestlin.compare]
+ * and the real-game boot tests — all `assumeTrue(romExists)` / `@RequiresMesen2`, so they
+ * *skip* (green) on a worktree that has neither the ROM library nor Mesen2. A weaker model
+ * delegated a mapper can then run `./gradlew test`, see green, and declare success having
+ * verified nothing about a real game. The two failure modes that slips through are exactly
+ * the ones a human notices immediately: the game **doesn't load** (throws / never renders) or
+ * shows **garbage/blank** (CHR-bank or mirroring bug).
+ *
+ * bootcheck is the oracle-free signal for both. It needs no Mesen2 and no library ROM — point
+ * it at whatever `.nes` you have. It can't *prove* a mapper is byte-correct (only Mesen2 can),
+ * but it reliably catches "didn't boot" and "blank screen", which is what weaker models miss.
+ *
+ * Determinism comes from [runOneFrame] (no threads, no wall clock) — the same seam `replay`
+ * uses — so it can't hang on a CPU spin-loop the way driving [Nestlin.start] on a thread could.
+ *
+ * ## The verdict
+ *
+ * Sampled once per completed frame: PPUMASK (rendering-enabled bits), the program counter, the
+ * mapper's bank snapshot, and the frame's pixels. Reported:
+ *
+ *  - `loaded`             — did a mapper instantiate? (its class name)
+ *  - `threw`              — did the emulator throw mid-run? (the message)
+ *  - `renderingEnabledBy` — first frame PPUMASK bits 3/4 went non-zero (null = never)
+ *  - `maxNonBlankRatio`   — peak fraction of pixels differing from the frame's modal colour
+ *                           (a uniform "blank" screen ≈ 0.00; a drawn screen is well above)
+ *  - `distinctPrgStates`  — number of distinct PRG-bank configurations seen (1 = never paged)
+ *  - `distinctChrStates`  — number of distinct CHR-bank configurations seen
+ *  - `nmiCount` / `irqCount` — interrupt totals (0 NMIs usually means rendering never armed)
+ *  - `distinctFramePCs`   — distinct program counters at frame boundaries (1 = wedged hard)
+ *
+ * Verdict = FAIL only on near-certain non-boot (threw, didn't load, or never-rendered-and-blank)
+ * so it does not cry wolf; WARN flags softer smells (blank despite rendering, banks never moved).
+ * Exit codes mirror `replay`: 0 PASS/WARN · 1 FAIL · 2 usage · 3 emulator threw.
+ */
+object BootCheck {
+
+    /** Exit codes are part of the CLI contract — CI, the Stop-hook, and agents branch on them. */
+    const val EXIT_OK = 0          // PASS or WARN
+    const val EXIT_FAIL = 1        // booted to nothing (blank + never rendered), or didn't load
+    const val EXIT_USAGE = 2
+    const val EXIT_THREW = 3       // emulator threw mid-run (crash / unimplemented mapper)
+
+    /** A near-uniform screen below this non-blank ratio is treated as "blank". */
+    private const val BLANK_RATIO = 0.01
+    /** Rendering is on but barely anything drawn — softer smell, a WARN not a FAIL. */
+    private const val SPARSE_RATIO = 0.02
+    const val DEFAULT_FRAMES = 120
+
+    enum class Grade { PASS, WARN, FAIL }
+
+    data class Options(val romPath: Path, val frames: Int = DEFAULT_FRAMES)
+
+    data class Verdict(
+        val grade: Grade,
+        val reasons: List<String>,
+        val loaded: Boolean,
+        val mapperName: String?,
+        val threw: Boolean,
+        val threwMessage: String?,
+        val framesRun: Int,
+        val renderingEnabledByFrame: Int?,
+        val maxNonBlankRatio: Double,
+        val distinctPrgStates: Int,
+        val distinctChrStates: Int,
+        val nmiCount: Int,
+        val irqCount: Int,
+        val distinctFramePCs: Int,
+    ) {
+        val exitCode: Int
+            get() = when {
+                threw -> EXIT_THREW
+                grade == Grade.FAIL -> EXIT_FAIL
+                else -> EXIT_OK
+            }
+    }
+
+    /** Run bootcheck, writing the human/greppable report to [out]. Returns the [Verdict]. */
+    fun run(opts: Options, out: Appendable): Verdict {
+        val verdict = try {
+            evaluate(opts)
+        } catch (t: Throwable) {
+            // Last-resort safety net for an unexpected harness error escaping evaluate(); the
+            // expected throw paths (load failure, mid-run crash) are handled inside evaluate() so
+            // they can report `loaded` accurately. We cannot tell here whether a mapper loaded.
+            failedToBoot(opts, threw = true, threwMessage = t.message ?: t.javaClass.simpleName, loaded = false)
+        }
+        report(opts, verdict, out)
+        return verdict
+    }
+
+    private fun evaluate(opts: Options): Verdict {
+        // Phase 1 — load. A throw here (unsupported mapper, bad header, unreadable file) means the
+        // cartridge genuinely did not come up: loaded = false.
+        val nestlin = try {
+            Nestlin().apply {
+                config.speedThrottlingEnabled = false
+                load(opts.romPath)
+                powerReset()
+            }
+        } catch (t: Throwable) {
+            return failedToBoot(opts, threw = true, threwMessage = t.message ?: t.javaClass.simpleName, loaded = false)
+        }
+        val mapper = nestlin.memory.mapper
+            ?: return failedToBoot(opts, threw = false, threwMessage = null, loaded = false) // header parsed but no mapper
+
+        // Past here a mapper IS instantiated, so loaded = true even if the run later crashes — a
+        // mapper that loads then throws mid-frame is exactly the bug bootcheck exists to surface,
+        // and must NOT be reported as "failed to load / unsupported mapper".
+        val capture = FrameCapture().also { nestlin.addFrameListener(it) }
+
+        var renderingEnabledByFrame: Int? = null
+        var maxNonBlankRatio = 0.0
+        val prgStates = linkedSetOf<String>()
+        val chrStates = linkedSetOf<String>()
+        val framePCs = linkedSetOf<Int>()
+        var framesRun = 0
+        var threwMessage: String? = null
+
+        try {
+            for (f in 1..opts.frames) {
+                nestlin.runOneFrame()
+                framesRun = f
+
+                if (renderingEnabledByFrame == null && (nestlin.ppuMask() and RENDER_MASK) != 0) {
+                    renderingEnabledByFrame = f
+                }
+                framePCs.add(nestlin.cpu.getCurrentPc().toInt() and 0xFFFF)
+
+                val banks = mapper.snapshot()?.banks
+                if (banks != null) {
+                    prgStates.add(bankSignature(banks, "prg"))
+                    chrStates.add(bankSignature(banks, "chr"))
+                }
+
+                capture.last?.let { maxNonBlankRatio = maxOf(maxNonBlankRatio, nonBlankRatio(it)) }
+            }
+        } catch (t: Throwable) {
+            threwMessage = t.message ?: t.javaClass.simpleName
+        }
+
+        val (grade, reasons) = if (threwMessage != null) {
+            Grade.FAIL to listOf("emulator threw at frame ${framesRun + 1} after loading $framesRun frame(s): $threwMessage")
+        } else {
+            gradeSignals(
+                renderingEnabledByFrame = renderingEnabledByFrame,
+                maxNonBlankRatio = maxNonBlankRatio,
+                distinctPrgStates = prgStates.size,
+                distinctChrStates = chrStates.size,
+                distinctFramePCs = framePCs.size,
+            )
+        }
+
+        return Verdict(
+            grade = grade,
+            reasons = reasons,
+            loaded = true,
+            mapperName = mapper.javaClass.simpleName,
+            threw = threwMessage != null,
+            threwMessage = threwMessage,
+            framesRun = framesRun,
+            renderingEnabledByFrame = renderingEnabledByFrame,
+            maxNonBlankRatio = maxNonBlankRatio,
+            distinctPrgStates = prgStates.size,
+            distinctChrStates = chrStates.size,
+            nmiCount = nestlin.cpu.nmiCount,
+            irqCount = nestlin.cpu.irqCount,
+            distinctFramePCs = framePCs.size,
+        )
+    }
+
+    /**
+     * Pure grading of the measured boot signals — extracted from [evaluate] so every PASS/WARN/FAIL
+     * branch is unit-testable without booting a ROM. FAIL is reserved for near-certain non-boot
+     * (never rendered AND blank) so the gate doesn't cry wolf; the softer smells are WARN.
+     */
+    internal fun gradeSignals(
+        renderingEnabledByFrame: Int?,
+        maxNonBlankRatio: Double,
+        distinctPrgStates: Int,
+        distinctChrStates: Int,
+        distinctFramePCs: Int,
+    ): Pair<Grade, List<String>> {
+        val rendered = renderingEnabledByFrame != null
+        val reasons = mutableListOf<String>()
+        if (!rendered && maxNonBlankRatio < BLANK_RATIO) {
+            reasons += "rendering never enabled (PPUMASK bits 3/4 stayed 0) and every frame is blank " +
+                "(maxNonBlankRatio=%.4f < %.2f) - the ROM did not boot to a picture".format(maxNonBlankRatio, BLANK_RATIO)
+            return Grade.FAIL to reasons
+        }
+        if (rendered && maxNonBlankRatio < SPARSE_RATIO) reasons += "rendering enabled at frame " +
+            "$renderingEnabledByFrame but the screen is almost empty (maxNonBlankRatio=%.4f) - " +
+            "possible CHR-bank/mirroring bug".format(maxNonBlankRatio)
+        if (distinctPrgStates <= 1 && distinctChrStates <= 1) reasons += "no bank ever moved during boot " +
+            "(prgStates=$distinctPrgStates, chrStates=$distinctChrStates) - fine for a single-bank board, " +
+            "suspicious for a banked one"
+        if (distinctFramePCs <= 1) reasons += "program counter never advanced past one frame-boundary value - CPU may be wedged"
+        return (if (reasons.isEmpty()) Grade.PASS else Grade.WARN) to reasons
+    }
+
+    private fun failedToBoot(opts: Options, threw: Boolean, threwMessage: String?, loaded: Boolean): Verdict {
+        val reason = if (threw) "emulator threw while loading: ${threwMessage ?: "unknown"}"
+        else "no mapper instantiated - ROM failed to load (bad header or unsupported mapper)"
+        return Verdict(
+            grade = Grade.FAIL, reasons = listOf(reason), loaded = loaded, mapperName = null,
+            threw = threw, threwMessage = threwMessage, framesRun = 0, renderingEnabledByFrame = null,
+            maxNonBlankRatio = 0.0, distinctPrgStates = 0, distinctChrStates = 0,
+            nmiCount = 0, irqCount = 0, distinctFramePCs = 0,
+        )
+    }
+
+    /** Fraction of pixels that differ from the frame's most-common colour. Blank screen ≈ 0. */
+    private fun nonBlankRatio(frame: Frame): Double {
+        val counts = HashMap<Int, Int>(1024)
+        var total = 0
+        for (y in 0 until RESOLUTION_HEIGHT) {
+            val line = frame.scanlines[y]
+            for (x in 0 until RESOLUTION_WIDTH) {
+                counts.merge(line[x], 1, Int::plus)
+                total++
+            }
+        }
+        if (total == 0) return 0.0
+        val modal = counts.values.maxOrNull() ?: 0
+        return (total - modal).toDouble() / total
+    }
+
+    /** Stable signature of the bank values whose key mentions [kind] (prg/chr), order-independent. */
+    private fun bankSignature(banks: Map<String, Int>, kind: String): String =
+        banks.filterKeys { it.contains(kind, ignoreCase = true) }
+            .toSortedMap()
+            .entries.joinToString(",") { "${it.key}=${it.value}" }
+
+    private fun report(opts: Options, v: Verdict, out: Appendable) {
+        out.appendLine("rom=${opts.romPath}")
+        out.appendLine("BOOTCHECK VERDICT: ${v.grade}")
+        out.appendLine("  loaded             : ${v.loaded}${v.mapperName?.let { "   ($it)" } ?: ""}")
+        out.appendLine("  threw              : ${v.threw}${v.threwMessage?.let { "   ($it)" } ?: ""}")
+        out.appendLine("  framesRun          : ${v.framesRun}")
+        out.appendLine("  renderingEnabledBy : ${v.renderingEnabledByFrame ?: "never"}")
+        out.appendLine("  maxNonBlankRatio   : %.4f".format(v.maxNonBlankRatio))
+        out.appendLine("  distinctPrgStates  : ${v.distinctPrgStates}")
+        out.appendLine("  distinctChrStates  : ${v.distinctChrStates}")
+        out.appendLine("  nmiCount           : ${v.nmiCount}    irqCount: ${v.irqCount}")
+        out.appendLine("  distinctFramePCs   : ${v.distinctFramePCs}")
+        if (v.reasons.isNotEmpty()) {
+            out.appendLine("  notes:")
+            v.reasons.forEach { out.appendLine("    - $it") }
+        }
+    }
+
+    private const val RENDER_MASK = 0x18 // PPUMASK bit 3 (show background) | bit 4 (show sprites)
+
+    /** Single-slot frame listener that keeps the most recently completed frame. */
+    private class FrameCapture : FrameListener {
+        var last: Frame? = null
+        override fun frameUpdated(frame: Frame) { last = frame }
+    }
+}
+
+/**
+ * Argument parsing for the headless `bootcheck` subcommand. Kept tiny and separate from
+ * [BootCheck] so the verdict logic stays unit-testable with a fabricated [BootCheck.Options].
+ *
+ *     nestlin bootcheck <rom.nes> [--frames N]
+ */
+object BootCheckCli {
+    val USAGE = """
+        usage: nestlin bootcheck <rom.nes> [--frames N]
+
+          --frames N   number of frames to run before judging (default: ${BootCheck.DEFAULT_FRAMES})
+
+        Prints a 'BOOTCHECK VERDICT: PASS|WARN|FAIL' block. No Mesen2 or ROM library needed.
+        Exit codes: 0 pass/warn · 1 boot-failed · 2 usage · 3 emulator threw.
+    """.trimIndent()
+
+    fun main(args: List<String>, out: Appendable = System.out): Int {
+        val positional = mutableListOf<String>()
+        var frames = BootCheck.DEFAULT_FRAMES
+        var i = 0
+        while (i < args.size) {
+            when (val arg = args[i]) {
+                "--frames" -> {
+                    val v = args.getOrNull(++i) ?: return usage(out, "--frames requires a value")
+                    frames = v.toIntOrNull()?.takeIf { it > 0 } ?: return usage(out, "--frames must be a positive integer, got '$v'")
+                }
+                else -> {
+                    if (arg.startsWith("--")) return usage(out, "unknown option '$arg'")
+                    positional.add(arg)
+                }
+            }
+            i++
+        }
+        if (positional.size != 1) return usage(out, "expected exactly one <rom.nes>, got ${positional.size}")
+        return BootCheck.run(BootCheck.Options(Paths.get(positional[0]), frames), out).exitCode
+    }
+
+    private fun usage(out: Appendable, message: String): Int {
+        out.appendLine("ERROR: $message")
+        out.appendLine(USAGE)
+        return BootCheck.EXIT_USAGE
+    }
+}
+
+/** Entry point for the Gradle `bootcheck` JavaExec task (mainClass = ...cli.BootCheckKt). */
+fun main(args: Array<String>) {
+    kotlin.system.exitProcess(BootCheckCli.main(args.toList()))
+}

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
@@ -54,6 +54,12 @@ fun main(args: Array<String>) {
     if (args.isNotEmpty() && args[0] == "replay") {
         kotlin.system.exitProcess(com.github.alondero.nestlin.cli.ReplayCli.main(args.drop(1)))
     }
+    // Headless `bootcheck` subcommand: boot a ROM N frames with no display and no reference
+    // emulator, print a PASS|WARN|FAIL verdict (loaded / rendered / non-blank / banks-moved).
+    // The oracle-free "did this mapper actually boot a real game?" gate for delegated work.
+    if (args.isNotEmpty() && args[0] == "bootcheck") {
+        kotlin.system.exitProcess(com.github.alondero.nestlin.cli.BootCheckCli.main(args.drop(1)))
+    }
     Application.launch(NestlinApplication::class.java, *args)
 }
 

--- a/src/test/kotlin/com/github/alondero/nestlin/Mapper1IntegrationTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/Mapper1IntegrationTest.kt
@@ -8,6 +8,7 @@ import com.natpryce.hamkrest.greaterThanOrEqualTo
 import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 
+@org.junit.jupiter.api.Tag("externalRom")
 class Mapper1IntegrationTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/cli/BootCheckTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cli/BootCheckTest.kt
@@ -1,0 +1,105 @@
+package com.github.alondero.nestlin.cli
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Paths
+
+/**
+ * Tests for the oracle-free `bootcheck` verdict. The grading branches are exercised purely
+ * (no ROM needed) via [BootCheck.gradeSignals]; one end-to-end case boots the only in-git ROM
+ * (nestest.nes) to prove the full load→run→report path works headlessly.
+ */
+class BootCheckTest {
+
+    // --- pure grading: every PASS/WARN/FAIL branch, deterministic, no emulator ---
+
+    @Test
+    fun `FAIL when never rendered and screen is blank`() {
+        val (grade, reasons) = BootCheck.gradeSignals(
+            renderingEnabledByFrame = null, maxNonBlankRatio = 0.0,
+            distinctPrgStates = 1, distinctChrStates = 1, distinctFramePCs = 5,
+        )
+        assertEquals(BootCheck.Grade.FAIL, grade)
+        assertTrue(reasons.single().contains("did not boot to a picture"))
+    }
+
+    @Test
+    fun `PASS when rendered, drawn, banks moved, PC advancing`() {
+        val (grade, reasons) = BootCheck.gradeSignals(
+            renderingEnabledByFrame = 8, maxNonBlankRatio = 0.42,
+            distinctPrgStates = 3, distinctChrStates = 4, distinctFramePCs = 40,
+        )
+        assertEquals(BootCheck.Grade.PASS, grade)
+        assertTrue(reasons.isEmpty())
+    }
+
+    @Test
+    fun `WARN when rendering on but screen near-empty (CHR-bank smell)`() {
+        val (grade, reasons) = BootCheck.gradeSignals(
+            renderingEnabledByFrame = 10, maxNonBlankRatio = 0.005,
+            distinctPrgStates = 2, distinctChrStates = 2, distinctFramePCs = 30,
+        )
+        assertEquals(BootCheck.Grade.WARN, grade)
+        assertTrue(reasons.any { it.contains("almost empty") })
+    }
+
+    @Test
+    fun `WARN (not FAIL) when blank but rendering WAS enabled`() {
+        // A blank screen on its own is only a FAIL when rendering also never armed; if the game
+        // armed rendering we down-grade to WARN so a legitimately-dark early frame isn't a hard fail.
+        val (grade, _) = BootCheck.gradeSignals(
+            renderingEnabledByFrame = 3, maxNonBlankRatio = 0.0,
+            distinctPrgStates = 2, distinctChrStates = 1, distinctFramePCs = 20,
+        )
+        assertEquals(BootCheck.Grade.WARN, grade)
+    }
+
+    @Test
+    fun `WARN notes a wedged PC`() {
+        val (grade, reasons) = BootCheck.gradeSignals(
+            renderingEnabledByFrame = 5, maxNonBlankRatio = 0.3,
+            distinctPrgStates = 2, distinctChrStates = 2, distinctFramePCs = 1,
+        )
+        assertEquals(BootCheck.Grade.WARN, grade)
+        assertTrue(reasons.any { it.contains("wedged") })
+    }
+
+    // --- CLI parsing ---
+
+    @Test
+    fun `usage error when no rom given`() {
+        val out = StringBuilder()
+        assertEquals(BootCheck.EXIT_USAGE, BootCheckCli.main(emptyList(), out))
+        assertTrue(out.contains("usage:"))
+    }
+
+    @Test
+    fun `usage error on non-integer frames`() {
+        val out = StringBuilder()
+        assertEquals(BootCheck.EXIT_USAGE, BootCheckCli.main(listOf("x.nes", "--frames", "lots"), out))
+    }
+
+    // --- end-to-end on the only in-git ROM ---
+
+    @Test
+    fun `boots nestest end-to-end and reports a verdict`() {
+        val rom = Paths.get("testroms/nestest.nes")
+        assumeTrue(Files.exists(rom), "nestest.nes not found at $rom")
+
+        val out = StringBuilder()
+        val verdict = BootCheck.run(BootCheck.Options(rom, frames = 30), out)
+
+        // We don't assert PASS — nestest runs in CPU-automation mode and never enables rendering,
+        // so it legitimately grades FAIL/WARN. What we prove is the headless path itself works:
+        // a mapper loaded, nothing threw, frames ran, and the greppable verdict block is emitted.
+        assertTrue(verdict.loaded, "expected a mapper to load for nestest")
+        assertFalse(verdict.threw, "nestest should not throw: ${verdict.threwMessage}")
+        assertEquals("Mapper0", verdict.mapperName)
+        assertEquals(30, verdict.framesRun)
+        assertTrue(out.contains("BOOTCHECK VERDICT:"), "report must contain the greppable verdict line")
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/BigNoseHangTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/BigNoseHangTest.kt
@@ -28,6 +28,7 @@ import kotlin.streams.toList
  *
  * After the fix the game progresses past the wait and re-enables rendering.
  */
+@org.junit.jupiter.api.Tag("mesen")
 class BigNoseHangTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/DebugMesen2CaptureTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/DebugMesen2CaptureTest.kt
@@ -7,6 +7,7 @@ import java.nio.file.Paths
 /**
  * Test to verify Mesen2 state capture works.
  */
+@org.junit.jupiter.api.Tag("mesen")
 class DebugMesen2CaptureTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/DebugStateCaptureTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/DebugStateCaptureTest.kt
@@ -6,6 +6,7 @@ import java.nio.file.Paths
 /**
  * Simple test to capture Nestlin state at various frames and inspect for debugging.
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class DebugStateCaptureTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/GxRomStateComparisonTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/GxRomStateComparisonTest.kt
@@ -43,6 +43,7 @@ import java.nio.file.Paths
  * name template moves from `@Parameterized.Parameters(name = ...)` to
  * `@ParameterizedTest(name = ...)`.
  */
+@org.junit.jupiter.api.Tag("mesen")
 class GxRomStateComparisonTest {
 
     companion object {

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyInstructionTraceTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyInstructionTraceTest.kt
@@ -16,6 +16,7 @@ import com.natpryce.hamkrest.contains
  *
  * This test validates that Kirby's boot sequence completes and NMIs start firing.
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class KirbyInstructionTraceTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyMesenVsNestlinOamTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyMesenVsNestlinOamTest.kt
@@ -11,6 +11,7 @@ import java.nio.file.Paths
  *
  * Requires Mesen2 + GUI + I/O permissions enabled.
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class KirbyMesenVsNestlinOamTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyOamSnapshotTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyOamSnapshotTest.kt
@@ -17,6 +17,7 @@ import javax.imageio.ImageIO
  *
  * Output: build/kirby-oam-snapshots.txt
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class KirbyOamSnapshotTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyPpuCtrlTrackingTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyPpuCtrlTrackingTest.kt
@@ -13,6 +13,7 @@ import com.natpryce.hamkrest.equalTo
  * Collapsed test from KirbyPpuCtrlTrackingTest and KirbyPpuCtrlWriteTrackerTest.
  * Asserts that PPUCTRL reaches $A8 (NMI enabled) by frame 10 of Kirby boot.
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class KirbyPpuCtrlTrackingTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyScreenshotTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyScreenshotTest.kt
@@ -14,6 +14,7 @@ import javax.imageio.ImageIO
  * Capture screenshot of Kirby's Adventure at various frames.
  * This lets us see what's actually being rendered over time.
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class KirbyScreenshotTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyVBlankTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/KirbyVBlankTest.kt
@@ -11,6 +11,7 @@ import java.nio.file.Paths
  * Detailed VBlank timing debug test.
  * Watches PPU state at exact cycle when VBlank should be set.
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class KirbyVBlankTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper33RegressionTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper33RegressionTest.kt
@@ -23,6 +23,7 @@ import java.nio.file.Paths
  * on Adam's machine. Skipped (not failed) when neither the ROM nor Mesen2
  * is present, since CI runners won't have either.
  */
+@org.junit.jupiter.api.Tag("mesen")
 class Mapper33RegressionTest {
 
     private val frameNumber = 60

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper64KlaxRegressionTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper64KlaxRegressionTest.kt
@@ -27,6 +27,7 @@ import java.nio.file.Paths
  * Adam's machine. Skipped (not failed) when the ROM or Mesen2 is missing,
  * since CI runners won't have either.
  */
+@org.junit.jupiter.api.Tag("mesen")
 class Mapper64KlaxRegressionTest {
 
     private fun klaxRom(): Path {

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/MapperRegressionTestBase.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/MapperRegressionTestBase.kt
@@ -5,6 +5,7 @@ import com.github.alondero.nestlin.ppu.Frame
 import com.github.alondero.nestlin.ui.FrameListener
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Tag
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -35,6 +36,12 @@ import java.nio.file.Paths
  * snapshots, the StateComparator diff, and the DivergenceLocalizer table are still
  * written to disk for inspection.
  */
+// Lane: this base carries @Tag("mesen"); JUnit 5 inherits class-level tags to subclasses, so every
+// MapperRegressionTestBase subclass is automatically in the Mesen2 comparison lane (excluded from
+// `./gradlew test`, included by `./gradlew testMesenComparison`) with no per-class wiring and no
+// build-script list to keep in sync. Annotate the render-output test method with @RequiresMesen2 so
+// it skips loudly (naming the resolved path) when Mesen2 is absent.
+@Tag("mesen")
 abstract class MapperRegressionTestBase {
 
     /**

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2StateCapturerSmokeTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2StateCapturerSmokeTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 
+@org.junit.jupiter.api.Tag("mesen")
 class Mesen2StateCapturerSmokeTest {
     @Test
     fun capturesNestestStateViaTestRunner() {

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/MicroMachinesAttractHangTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/MicroMachinesAttractHangTest.kt
@@ -18,6 +18,7 @@ import kotlin.streams.toList
  * "hangs when starting a race". A stall shows up as the instruction count plateauing
  * (CPU parked in a spin loop that never breaks) across many frames.
  */
+@org.junit.jupiter.api.Tag("mesen")
 class MicroMachinesAttractHangTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/MicroMachinesDivergenceSweepTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/MicroMachinesDivergenceSweepTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
  *
  * Skipped if Mesen2 is not installed.
  */
+@org.junit.jupiter.api.Tag("mesen")
 class MicroMachinesDivergenceSweepTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/MicroMachinesExtendedCaptureTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/MicroMachinesExtendedCaptureTest.kt
@@ -23,6 +23,7 @@ import kotlin.streams.toList
  * those change across boot. Also saves PNG screenshots at a handful of
  * frames so we can look for the "band" visual artifact the user reported.
  */
+@org.junit.jupiter.api.Tag("mesen")
 class MicroMachinesExtendedCaptureTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/MicroMachinesMapper71SmokeTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/MicroMachinesMapper71SmokeTest.kt
@@ -33,6 +33,7 @@ import kotlin.streams.toList
  *
  * Skips loudly if the ROM is not on this machine, like the other smoke tests.
  */
+@org.junit.jupiter.api.Tag("mesen")
 class MicroMachinesMapper71SmokeTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/MicroMachinesMapper71StateComparisonTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/MicroMachinesMapper71StateComparisonTest.kt
@@ -29,6 +29,7 @@ import java.nio.file.Paths
  *
  * ROMs come from the NO-INTRO library and skip loudly when absent.
  */
+@org.junit.jupiter.api.Tag("mesen")
 class MicroMachinesMapper71StateComparisonTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/MicroMachinesPcDivergenceTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/MicroMachinesPcDivergenceTest.kt
@@ -17,6 +17,7 @@ import kotlin.streams.toList
  * pin down the *moment* of divergence. Each step takes ~1 sec, so the test
  * is slow but the trajectory is the diagnostic.
  */
+@org.junit.jupiter.api.Tag("mesen")
 class MicroMachinesPcDivergenceTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/MicroMachinesSplitTimingTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/MicroMachinesSplitTimingTest.kt
@@ -17,6 +17,7 @@ import kotlin.streams.toList
  * compare against Mesen2's ground truth (forced-blank at scanline 107, re-enable at
  * scanline 115). Reveals how far Nestlin's cycle-counted split drifts from hardware.
  */
+@org.junit.jupiter.api.Tag("mesen")
 class MicroMachinesSplitTimingTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/MinimalVBlankSetTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/MinimalVBlankSetTest.kt
@@ -14,6 +14,7 @@ import com.natpryce.hamkrest.equalTo
  * More complex VBlank timing tests require cycle-accurate PPU state tracking
  * which is difficult to test in isolation.
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class MinimalVBlankSetTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/NestlinMapper4CaptureTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/NestlinMapper4CaptureTest.kt
@@ -10,6 +10,7 @@ import java.nio.file.Paths
  * Captures Nestlin state at specific frames for Kirby (Mapper 4).
  * Writes detailed output to build/debug-state/ for analysis.
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class NestlinMapper4CaptureTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/PpuCtrlNmiEdgeTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/PpuCtrlNmiEdgeTest.kt
@@ -15,6 +15,7 @@ import com.natpryce.hamkrest.equalTo
  * immediate NMI. Without bit-7 edge re-trigger, first NMI is delayed by up to
  * a frame, and downstream init code times out / corrupts state.
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class PpuCtrlNmiEdgeTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/RequiresMesen2.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/RequiresMesen2.kt
@@ -1,5 +1,6 @@
 package com.github.alondero.nestlin.compare
 
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.extension.ConditionEvaluationResult
 import org.junit.jupiter.api.extension.ExecutionCondition
 import org.junit.jupiter.api.extension.ExtendWith
@@ -17,9 +18,17 @@ import org.junit.jupiter.api.extension.ExtensionContext
  * machines/CI lanes where Mesen2 is supposed to exist, so a broken MESEN2_PATH
  * cannot false-green the comparison suite. Forwarded by the testMesenComparison
  * Gradle task.
+ *
+ * Lane assignment is automatic: this annotation is meta-tagged [@Tag][Tag]`("mesen")`,
+ * so every test that requires Mesen2 is excluded from `./gradlew test` and included by
+ * `./gradlew testMesenComparison` *with no build-script edit*. This is what retired the
+ * hand-maintained `mesenTests` list that silently went stale (Mapper24/26/64 were never
+ * added to it). A test that needs Mesen2 should carry THIS annotation rather than a bare
+ * `assumeTrue(mesen2Available)`, so it lands in the right lane and skips loudly when absent.
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
+@Tag("mesen")
 @ExtendWith(RequiresMesen2Condition::class)
 annotation class RequiresMesen2
 

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/ScreenshotCapture.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/ScreenshotCapture.kt
@@ -17,6 +17,7 @@ import java.nio.file.Paths
  *   export NESTLIN_SCREENSHOT_ROMS="/path/to/rom1.nes,/path/to/rom2.nes"
  *   ./gradlew test --tests "ScreenshotCapture" --no-daemon
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class ScreenshotCapture {
 
     companion object {

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/ScreenshotComparisonTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/ScreenshotComparisonTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.nio.file.Paths
 
+@org.junit.jupiter.api.Tag("mesen")
 class ScreenshotComparisonTest {
 
     companion object {

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/StateCaptureIntegrationTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/StateCaptureIntegrationTest.kt
@@ -2,16 +2,19 @@ package com.github.alondero.nestlin.compare
 
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
+import java.nio.file.Files
 import java.nio.file.Paths
 
 /**
  * Simple test to verify both Nestlin state capture and Mesen2 state capture work.
  */
+@org.junit.jupiter.api.Tag("mesen")
 class StateCaptureIntegrationTest {
 
     @Test
     fun captureNestlinStateAtFrame60() {
         val romPath = Paths.get("testroms/tetris.nes")
+        assumeTrue(Files.exists(romPath), "ROM not found: $romPath")
         val state = NestlinStateCapturer.captureState(romPath, 60)
 
         println("=== Nestlin State at frame 60 for tetris.nes ===")
@@ -25,6 +28,7 @@ class StateCaptureIntegrationTest {
         assumeTrue(Mesen2StateCapturer.isMesen2Available(), "Mesen2 not available")
 
         val romPath = Paths.get("testroms/tetris.nes")
+        assumeTrue(Files.exists(romPath), "ROM not found: $romPath")
         val state = Mesen2StateCapturer.captureState(romPath, 60)
 
         println("=== Mesen2 State at frame 60 for tetris.nes ===")
@@ -38,6 +42,7 @@ class StateCaptureIntegrationTest {
         assumeTrue(Mesen2StateCapturer.isMesen2Available(), "Mesen2 not available")
 
         val romPath = Paths.get("testroms/tetris.nes")
+        assumeTrue(Files.exists(romPath), "ROM not found: $romPath")
 
         val nestlinState = NestlinStateCapturer.captureState(romPath, 60)
         val mesen2State = Mesen2StateCapturer.captureState(romPath, 60)

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/StateComparisonTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/StateComparisonTest.kt
@@ -16,6 +16,7 @@ import java.nio.file.Paths
  * discovered by `@MethodSource("data")`. The test name template moves from
  * `@Parameterized.Parameters(name = ...)` to `@ParameterizedTest(name = ...)`.
  */
+@org.junit.jupiter.api.Tag("mesen")
 class StateComparisonTest {
 
     companion object {

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/VBlankPollingTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/VBlankPollingTest.kt
@@ -12,6 +12,7 @@ import java.nio.file.Paths
  * Uses the debug logging added to PpuAddressedMemory to track
  * every $2002 read and correlate with the instruction trace.
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class VBlankPollingTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/VBlankReadRaceTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/VBlankReadRaceTest.kt
@@ -16,6 +16,7 @@ import com.natpryce.hamkrest.equalTo
  * This is the race condition: game's poll happens to align with VBlank set,
  * and without suppression logic, both would conflict.
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class VBlankReadRaceTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/VBlankTimingTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/VBlankTimingTest.kt
@@ -10,6 +10,7 @@ import java.nio.file.Paths
 /**
  * Targeted test to find exactly where VBlank gets set vs when NMI fires.
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class VBlankTimingTest {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/VBlankTimingTest2.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/VBlankTimingTest2.kt
@@ -10,6 +10,7 @@ import java.nio.file.Paths
 /**
  * Test to understand timing between VBlank set and $2002 reads.
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class VBlankTimingTest2 {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper4GamesTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper4GamesTest.kt
@@ -10,6 +10,7 @@ import java.nio.file.Path
  * Test Mapper 4 games using official NES ROMs.
  * Tests: Kirby's Adventure, Simpsons Bart vs World, Super Mario Bros 3, Yoshi's Cookie
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class Mapper4GamesTest {
 
     data class GameInfo(val name: String, val path: String, val expectedMinPixels: Int)

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper4Verification.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper4Verification.kt
@@ -14,6 +14,7 @@ import javax.imageio.ImageIO
 /**
  * Headless test for mapper 4 verification.
  */
+@org.junit.jupiter.api.Tag("externalRom")
 class Mapper4Verification {
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/testutil/MapperCoverageLintTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/testutil/MapperCoverageLintTest.kt
@@ -1,0 +1,125 @@
+package com.github.alondero.nestlin.testutil
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.name
+import kotlin.io.path.readText
+
+/**
+ * Lint-as-test: enforces the manual steps a new mapper must complete, so they fail the build
+ * loudly instead of being silently forgotten.
+ *
+ * Why this exists: every one of these steps has been skipped at least once by a contributor
+ * (human or a delegated model) who then declared the mapper "done". The most damaging was the
+ * Mesen2-comparison wiring — Mapper 24, 26 and 64's regression tests were written but never added
+ * to the `mesenTests` list in `build.gradle.kts`, so `./gradlew testMesenComparison` quietly never
+ * ran them. Nothing went red; the gap sat for weeks. Prose checklists (the new-mapper skill) don't
+ * hold against that; a red build does.
+ *
+ * Two checks:
+ *
+ *  - **Registration + docs** — every `gamepak/MapperN.kt` has a dispatch arm in [GamePak] and a
+ *    section in `MAPPER_SUPPORT.md`. A missing arm is at least loud at load time
+ *    (`UnsupportedOperationException`); a missing doc section is silent, and a missing dispatch arm
+ *    on a renamed/half-wired mapper is caught here before it ships.
+ *  - **Oracle wiring** — every `compare/Mapper*RegressionTest.kt` (the Mesen2 byte-compare tests)
+ *    is referenced in `build.gradle.kts`, i.e. actually included by `testMesenComparison`. This is
+ *    the check that would have caught the 24/26/64 omission the day it happened.
+ */
+class MapperCoverageLintTest {
+
+    private val gamepakDir: Path = Paths.get("src/main/kotlin/com/github/alondero/nestlin/gamepak")
+    private val compareDir: Path = Paths.get("src/test/kotlin/com/github/alondero/nestlin/compare")
+    private val gamePakSource: Path = gamepakDir.resolve("GamePak.kt")
+    private val mapperSupport: Path = Paths.get("MAPPER_SUPPORT.md")
+
+    @Test
+    fun `every mapper is wired into GamePak dispatch and documented in MAPPER_SUPPORT`() {
+        assertTrue(Files.isDirectory(gamepakDir), "expected to run from the project root; missing $gamepakDir")
+        val gamePakText = gamePakSource.readText()
+        val supportText = mapperSupport.readText()
+
+        // Numbers that appear in any "## Mapper(s) ..." heading. Handles grouped headings like
+        // "## Mappers 21, 23, 25 (Konami VRC4)" — but only harvests the mapper-number list, which
+        // is the text BEFORE the first "(". Harvesting the whole line would scoop board-name digits
+        // ("## Mapper 3 (NINA-006)" -> 6, "## Mapper 206 (Namcot 108)" -> 108) and silently mark an
+        // undocumented Mapper6/Mapper108 as documented — the very false-green this lint exists to stop.
+        val documentedNumbers: Set<Int> = supportText.lineSequence()
+            .filter { it.startsWith("## Mapper") }
+            .map { it.substringBefore('(') }
+            .flatMap { Regex("""\d+""").findAll(it).map { m -> m.value.toInt() } }
+            .toSet()
+
+        val problems = mutableListOf<String>()
+        for (n in mapperNumbers()) {
+            // A dispatch arm like `33 -> Mapper33(this)`. `\s*->` after the exact number rejects a
+            // longer number's prefix (so `16` does not match `160 ->`).
+            if (!Regex("""(?m)^\s*$n\s*->""").containsMatchIn(gamePakText)) {
+                problems += "Mapper$n has no `$n -> Mapper$n(...)` dispatch arm in GamePak.createMapper()"
+            }
+            if (n !in documentedNumbers) {
+                problems += "Mapper$n has no `## Mapper $n` section in MAPPER_SUPPORT.md"
+            }
+        }
+
+        assertTrue(
+            problems.isEmpty(),
+            "New mapper bookkeeping is incomplete (see the new-mapper skill, Step 2/Step 4):\n  " +
+                problems.joinToString("\n  "),
+        )
+    }
+
+    @Test
+    fun `every Mesen2 mapper regression test is in the mesen lane`() {
+        assertTrue(Files.isDirectory(compareDir), "missing $compareDir")
+
+        // The Mesen2 byte-compare tests follow the MapperNNN...RegressionTest naming convention and
+        // live in the compare package. Each must be discoverable by `./gradlew testMesenComparison`
+        // (includeTags("mesen")) and excluded from the fast suite (excludeTags). A test joins that
+        // lane in one of three ways — any is sufficient:
+        //   - subclasses MapperRegressionTestBase (which carries @Tag("mesen"), inherited by JUnit),
+        //   - has @RequiresMesen2 (meta-tagged @Tag("mesen")), or
+        //   - has an explicit @Tag("mesen").
+        // There is intentionally no build.gradle.kts list to check anymore — the list is exactly
+        // what silently went stale and dropped 24/26/64. The tag IS the wiring.
+        val regressionFiles = Files.list(compareDir).use { stream ->
+            stream.filter { it.name.matches(Regex("""Mapper\d+.*RegressionTest\.kt""")) }
+                .sorted()
+                .toList()
+        }
+        assertTrue(
+            regressionFiles.isNotEmpty(),
+            "expected to find compare/Mapper*RegressionTest.kt files — has the package moved?",
+        )
+
+        val notInLane = regressionFiles.filter { file ->
+            val text = file.readText()
+            val subclassesBase = text.contains(": MapperRegressionTestBase")
+            val requiresMesen2 = text.contains("@RequiresMesen2")
+            val taggedMesen = Regex("""@(org\.junit\.jupiter\.api\.)?Tag\("mesen"\)""").containsMatchIn(text)
+            !(subclassesBase || requiresMesen2 || taggedMesen)
+        }.map { it.name }
+
+        assertTrue(
+            notInLane.isEmpty(),
+            "These Mesen2 mapper regression tests are not in the 'mesen' lane, so " +
+                "`./gradlew testMesenComparison` will not run them and `./gradlew test` may run them " +
+                "against an absent oracle (the 24/26/64 bug). Subclass MapperRegressionTestBase, or " +
+                "add @RequiresMesen2 / @Tag(\"mesen\"):\n  " + notInLane.joinToString("\n  "),
+        )
+    }
+
+    /** Mapper numbers implemented in `gamepak/` (from `MapperN.kt` filenames; ignores base/util files). */
+    private fun mapperNumbers(): List<Int> =
+        Files.list(gamepakDir).use { stream ->
+            stream.map { it.name }
+                .map { Regex("""^Mapper(\d+)\.kt$""").find(it)?.groupValues?.get(1)?.toInt() }
+                .filter { it != null }
+                .map { it!! }
+                .sorted()
+                .toList()
+        }
+}


### PR DESCRIPTION
## Why

Weaker delegated models often claim a mapper is done while the game doesn't boot or renders garbage. The strong Mesen2 byte-compare gates `assumeTrue(romExists)` / `@RequiresMesen2`, so they **skip green** on a worktree without the ROM library or Mesen2 — and the regression-test wiring was a hand-maintained `mesenTests` list in `build.gradle.kts` that **silently went stale** (it dropped the Mapper 24/26/64 regression tests for weeks). A passing `./gradlew test` proved nothing about a real game.

## What

Four interlocking layers — lint forces structure → bootcheck gives a verdict → hook forces the verdict to be run:

1. **`./gradlew bootcheck -Prom=<rom> [-Pframes=N]`** (`cli/BootCheck.kt`, also a JAR subcommand) — oracle-free headless verdict `BOOTCHECK VERDICT: PASS|WARN|FAIL` from loaded / rendered / non-blank-ratio / banks-moved / NMI+IRQ / stuck-PC. **No Mesen2 or ROM library needed.** PASS on Kirby, FAIL on a non-rendering ROM. Exit `0` pass/warn · `1` fail · `3` threw.
2. **`mapper-verify-guard.ps1` Stop hook** — blocks ending a session that edited a `gamepak/Mapper*.kt` without a bootcheck PASS/WARN or Mesen2 MATCH in the transcript. Fails open, honors `stop_hook_active`.
3. **`MapperCoverageLintTest`** (always-on) — fails the build if a `MapperN.kt` lacks a `GamePak` dispatch arm or a `## Mapper N` doc section, or if a `compare/Mapper*RegressionTest` isn't in the mesen lane. **Caught 3 undocumented mappers (5, 11, 34)** — now documented.
4. **Tag-based test lanes** — the stale `mesenTests`/`auxiliaryTests` lists are **deleted**. Tests self-describe via `@Tag("mesen")` / `@Tag("externalRom")`. `@RequiresMesen2` is meta-tagged `@Tag("mesen")` and `MapperRegressionTestBase` carries it — **JUnit 5 inherits class-level `@Tag` to subclasses** (verified), so every mapper regression test joins the comparison lane for free, no build-script edit.

Also fixes 3 pre-existing broken debug tests (two mis-tagged as needing Mesen2 when they only need a ROM; one missing its ROM-existence guard) and adds `MAPPER_SUPPORT.md` sections for Mappers 5/11/34. The `new-mapper` skill Step 4 and `CLAUDE.md` now point at `bootcheck` as the mandatory closing ritual.

## Verification

- `./gradlew test` — **green** (includes the new lint + bootcheck unit tests); every mesen/externalRom test excluded from the fast suite (incl. base-class tag inheritance).
- `./gradlew testMesenComparison` — **green**, selects exactly the mesen lane, clean skips without the oracle (was red in any worktree before — now fixed).
- `./gradlew bootcheck -Prom=kirby.nes` — PASS, exit 0.
- Stop hook tested across all branches (blocks on no-evidence / FAIL-only, allows on PASS/WARN/MATCH, never loops, fails open).
- Reviewed at high effort; fixed two real bugs found (lint heading-digit false-green from board names like `NINA-006`; `bootcheck.loaded` reported `false` on a mid-run crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)