### PR TITLE
Mapper 113 (HES NTD-8): fix register decode so Mind Blower Pak + Total Funpak boot (#139, #163)

### DIFF
--- a/MAPPER_SUPPORT.md
+++ b/MAPPER_SUPPORT.md
@@ -696,6 +696,48 @@ Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 24, 26, 33, 34,
   - MMC5 extended RAM (`$5C00-$5FFF`) is not persisted. Only the `$6000-$7FFF` PRG-RAM window is.
   - FDS (Famicom Disk System) saves use the `.fds` disk-image format and are out of scope.
 
+## Mapper 113 (HES NTD-8 / PT-554A)
+**Status:** Working
+
+- **Games:** *Mind Blower Pak* and *Total Funpak* — the two HES Australia (1992) unlicensed
+  multicarts. Unrelated to the NINA-003/006 family (Mapper 3) despite a superficially similar
+  register, and unrelated to MMC-anything.
+- **What it is:** a single 8-bit control register, banking the **entire** 32 KB PRG window at
+  `$8000-$FFFF` and the 8 KB CHR window at `$0000-$1FFF`. No fixed bank, no PRG-RAM, no IRQ.
+- **Register decode — the *only* Nestlin mapper whose banking register lives outside PRG space.**
+  The chip-select gate is `(addr & 0xE100) == 0x4100`: A8 set, A9-A12 clear, A13-A15 clear — so
+  the register aliases across `$4100-$41FF`, `$4300-$43FF`, … `$5F00-$5FFF` (16 pages), low 8 bits
+  ignored. Bit layout (NESdev iNES Mapper 113, matching Mesen `Mapper113::WriteRegister`):
+  ```
+  bit 7 6 5 4 3 2 1 0
+      M C P P P C C C
+  ```
+  `prgBank = (v >> 3) & 0x07` (bits 3-5), `chrBank = ((v >> 3) & 0x08) | (v & 0x07)` (bit 6 is the
+  CHR high bit, bits 0-2 the low bits), `vertical = (v & 0x80) != 0`. Both fields wrap modulo the
+  ROM's bank count.
+- **Power-on:** the **last** 32 KB PRG bank is mapped (not bank 0). Mind Blower Pak's init code
+  lives in the last bank; its first register write is `$59`, which under the correct decode selects
+  PRG bank 3 — i.e. *keeps* the last bank mapped — and the boot continues into the RAM main loop.
+- **Open-bus (`$0000-$7FFF`) reads:** the chip has nothing to drive there, so `cpuRead` returns the
+  residual 6502 data-bus byte (`Mapper.dataBus`, fed by `Memory`) rather than 0. Without it, Mind
+  Blower Pak's reset trampoline decodes a `BRK` and never boots.
+- **Region:** `(australia)` in the NO-INTRO filename is a *where-sold* marker, not a timing one —
+  HES shipped NTSC silicon. `GamePak.forceNtscMappers(113) = Region.NTSC` overrides the filename's
+  PAL guess to match the real cartridge's frame rate / palette / CPU:PPU ratio. It's a
+  hardware-accuracy override, not a boot fix — both games boot under either region once the decode
+  is correct (the #163 garbled title was the decode bug below, not a timing issue).
+- **CHR:** 8 KB banked from CHR ROM; a 0 KB-CHR dump gets 8 KB of writable CHR RAM (same fallback
+  as Mappers 2/3/7/11/33/34/71).
+- **Verification:** `Mapper113Test` covers the full PRG/CHR bank range, the bit decode (asserted
+  through a spec-encoding `reg(prg, chr, vertical)` helper so the tests can't drift into the
+  implementation's own formula), 16-page register aliasing, open-bus reads, CHR-RAM fallback, and
+  save/load. `Mapper113RegressionTest` (`@RequiresMesen2`) byte-compares CHR vs Mesen2 at frame 60.
+  `Mapper113TotalFunpakBootTest` checks the second HES game's power-on state. **Issue #163** was a
+  decode bug here — PRG read from bits 4-6 instead of 3-5 — which sent Mind Blower Pak's first boot
+  write to the wrong bank; the 31 original unit tests passed only because they hand-rolled the same
+  wrong formula. Lesson: assert mapper decode against the *spec value*, not a magic byte derived
+  from the implementation.
+
 ## Adding New Mappers
 
 1. Implement in `gamepak/` directory

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,7 @@ val mesenTests = listOf(
     "com.github.alondero.nestlin.compare.NestlinMapper4CaptureTest",
     "com.github.alondero.nestlin.compare.Mapper10RegressionTest",
     "com.github.alondero.nestlin.compare.Mapper33RegressionTest",
+    "com.github.alondero.nestlin.compare.Mapper113RegressionTest",
     "com.github.alondero.nestlin.compare.GxRomStateComparisonTest",
     "com.github.alondero.nestlin.compare.MicroMachinesMapper71SmokeTest",
     "com.github.alondero.nestlin.compare.MicroMachinesMapper71StateComparisonTest",
@@ -157,6 +158,11 @@ tasks.register<Test>("testMesenComparison") {
     if (donDokoDonRom != null) {
         environment("NESTLIN_DON_DOKO_DON_ROM", donDokoDonRom)
     }
+    // Forward the optional Mind Blower Pak ROM override (Mapper 113 regression test).
+    val mindBlowerPakRom = System.getenv("NESTLIN_MIND_BLOWER_PAK_ROM")
+    if (mindBlowerPakRom != null) {
+        environment("NESTLIN_MIND_BLOWER_PAK_ROM", mindBlowerPakRom)
+    }
     // Strict mode for @RequiresMesen2: when set, a missing Mesen2 hard-fails the
     // comparison tests instead of skipping them (guards against a broken
     // MESEN2_PATH silently false-greening the suite).
@@ -198,6 +204,11 @@ tasks.register<JavaExec>("diverge") {
     val mesen2Path = System.getenv("MESEN2_PATH")
     if (mesen2Path != null) {
         environment("MESEN2_PATH", mesen2Path)
+    }
+    // Forward the optional Mind Blower Pak ROM override (Mapper 113 divergence).
+    val mindBlowerPakRom = System.getenv("NESTLIN_MIND_BLOWER_PAK_ROM")
+    if (mindBlowerPakRom != null) {
+        environment("NESTLIN_MIND_BLOWER_PAK_ROM", mindBlowerPakRom)
     }
 }
 

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
@@ -47,17 +47,20 @@ class GamePak(data: ByteArray, displayName: String = "") {
      * Some mappers are *only* found on NTSC pirate / clone hardware even when
      * the NO-INTRO filename implies a PAL region. The HES NTD-8 / PT-554A
      * (mapper 113) is the canonical example: HES Australia sold their
-     * multicarts in a PAL TV market, but the silicon boots an NTSC
-     * self-replicating trampoline that needs NTSC cycle counts to land in
-     * the right bank. Under PAL timing the trampoline chain runs into a
-     * different mapper write, the game boots into the wrong bank, and
-     * the title screen renders garbled (the right PPU state, the wrong
-     * CHR data). See [RegionDetectionTest.\`mapper 113 is NTSC even when
-     * filename has australia marker\`] for the regression.
+     * multicarts into a PAL TV market, but the silicon itself is NTSC — so
+     * the `(australia)` filename is a *where-sold* marker, not a *timing*
+     * one. Forcing NTSC matches the real cartridge's frame rate, palette,
+     * and CPU:PPU ratio.
      *
-     * Only mappers that are *provably* NTSC-only get an override here —
-     * not all "Australia" games, just the ones where a wrong region
-     * breaks boot.
+     * This is a hardware-accuracy override, NOT a boot fix: both HES games
+     * boot fine under either region once the mapper register decode is
+     * correct (see Mapper113.cpuWrite and issue #163 — the garbled title
+     * screen there was a decode bug, never a PAL-vs-NTSC timing issue).
+     * See [RegionDetectionTest.\`mapper 113 is NTSC even when filename has
+     * australia marker\`] for the regression.
+     *
+     * Only mappers that are *provably* NTSC-only silicon get an override
+     * here — not all "Australia" games.
      */
     private fun forceNtscMappers(mapper: Int): Region? = when (mapper) {
         113 -> Region.NTSC

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
@@ -38,7 +38,31 @@ class GamePak(data: ByteArray, displayName: String = "") {
      * marker in the ROM name, then default to NTSC. A user-facing override (see
      * `EmulatorConfig.regionOverride`) is applied later, in [com.github.alondero.nestlin.Nestlin].
      */
-    val region: Region = header.detectedRegion ?: regionFromName(name) ?: Region.NTSC
+    val region: Region = header.detectedRegion
+        ?: forceNtscMappers(header.mapper)
+        ?: regionFromName(name)
+        ?: Region.NTSC
+
+    /**
+     * Some mappers are *only* found on NTSC pirate / clone hardware even when
+     * the NO-INTRO filename implies a PAL region. The HES NTD-8 / PT-554A
+     * (mapper 113) is the canonical example: HES Australia sold their
+     * multicarts in a PAL TV market, but the silicon boots an NTSC
+     * self-replicating trampoline that needs NTSC cycle counts to land in
+     * the right bank. Under PAL timing the trampoline chain runs into a
+     * different mapper write, the game boots into the wrong bank, and
+     * the title screen renders garbled (the right PPU state, the wrong
+     * CHR data). See [RegionDetectionTest.\`mapper 113 is NTSC even when
+     * filename has australia marker\`] for the regression.
+     *
+     * Only mappers that are *provably* NTSC-only get an override here —
+     * not all "Australia" games, just the ones where a wrong region
+     * breaks boot.
+     */
+    private fun forceNtscMappers(mapper: Int): Region? = when (mapper) {
+        113 -> Region.NTSC
+        else -> null
+    }
 
     init {
         // Use toUnsignedInt() because Header.programRomSize / chrRomSize are
@@ -125,6 +149,7 @@ class GamePak(data: ByteArray, displayName: String = "") {
         66 -> Mapper66(this)
         69 -> Mapper69(this)
         71 -> Mapper71(this)
+        113 -> Mapper113(this)
         153 -> Mapper153(this)
         206 -> Mapper206(this)
         else -> throw UnsupportedOperationException("Mapper ${header.mapper} not implemented")

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper113.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper113.kt
@@ -1,0 +1,179 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.github.alondero.nestlin.toUnsignedInt
+import java.io.DataInput
+import java.io.DataOutput
+
+/**
+ * Mapper 113 (HES NTD-8 / PT-554A) — used by the two HES Australia
+ * unlicensed multicarts *Mind Blower Pak* and *Total Funpak*. The chip is
+ * the silicon behind the HES 6-in-1 multicart and is unrelated to the
+ * NINA-003/006 family even though the register shape overlaps.
+ *
+ * **Register decode** — *the only Nestlin mapper with its banking
+ * register outside the normal PRG space*. The chip-select gate is
+ * `(addr & 0xE100) == 0x4100`: A8 must be set, A9-A12 must be clear, and
+ * A13-A15 must be clear; the low 8 bits are aliased. That gives 16
+ * distinct 256-byte pages — `$4100-$41FF`, `$4300-$43FF`, ..., up to
+ * `$5F00-$5FFF` — and every address in any of those pages latches the
+ * same control register.
+ *
+ * **Bit layout of the register byte:**
+ * ```
+ *   bit  7  6  5  4 | 3  2  1  0
+ *       M  P  P  P | C  C  C  C
+ * ```
+ * - Bit 7 (`M`): mirroring — 1 = vertical, 0 = horizontal.
+ * - Bits 4-6 (`PPP`): 32 KB PRG bank select (8 banks → 256 KB max PRG).
+ * - Bit 3 (`C`): high bit of CHR bank.
+ * - Bits 0-2 (`CCC`): low 3 bits of CHR bank.
+ * Net: 8 PRG banks × 16 CHR banks (128 KB max CHR).
+ *
+ * **PRG geometry:** 32 KB window at `$8000-$FFFF`, fully banked. There
+ * is no fixed last bank (the chip latches the whole window from one
+ * register, unlike UNROM-style mappers).
+ *
+ * **CHR geometry:** 8 KB window at `$0000-$1FFF`, banked.
+ *
+ * **No PRG-RAM, no IRQ.** All writes outside the chip-select window are
+ * silently ignored.
+ */
+class Mapper113(private val gamePak: GamePak) : Mapper {
+
+    private val programRom = gamePak.programRom
+    private val chrRom = gamePak.chrRom
+    // CHR RAM fallback for 0 KB-CHR dumps. The two HES Australia ROMs both
+    // ship CHR ROM, but a defensive fallback costs nothing and keeps
+    // homebrew or truncated dumps from crashing the PPU read path.
+    private val chrRam: ByteArray? = if (chrRom.isEmpty()) ByteArray(0x2000) else null
+
+    // 32 KB PRG bank count. `coerceAtLeast(1)` so a malformed 0-PRG ROM
+    // can't make the modulo in the read path go negative and crash.
+    private val prgBankCount = (programRom.size / 0x8000).coerceAtLeast(1)
+
+    // Power-on default: the LAST PRG bank is mapped, not bank 0.
+    //
+    // Why: Mind Blower Pak's bank-0 reset vector is $9FE0, a
+    // self-replicating trampoline that copies 11 bytes to $0400 then
+    // JMPs ($FFFC). The trampoline's purpose is to navigate between PRG
+    // banks: bank 0 writes 0x59 (PRG=2), bank 2 writes 0x1D (PRG=1),
+    // and bank 1's trampoline writes 0x1D again — looping forever
+    // because JMP ($FFFC) re-reads bank 1's reset vector. The only
+    // escape is the real init code in the LAST bank (bank 3, at
+    // $B44E), which expects the CPU to start with the last bank mapped
+    // and immediately runs `LDA #$59; STA $4120; SEI; ...; wait vblank;
+    // clear RAM; set up registers; enable PPU`.
+    //
+    // Confirmed against Mesen2 v2.1.1: a frame-1 trace of Mind Blower
+    // Pak shows the CPU executing in bank 3 at $B476 with zero
+    // mapper-register writes (so the bank hasn't been switched from
+    // its power-on value). A bank-0 default would loop forever in the
+    // bank-1 trampoline.
+    //
+    // The same power-on state matches Total Funpak (also Mapper 113,
+    // 4 PRG banks): bank 3's reset vector is $8010, also in the last
+    // bank, and the other banks' reset vectors point at real init
+    // code, not trampolines. The "fixed last bank" pattern is what
+    // every HES Australia multicart relies on for boot.
+    private var prgBank = prgBankCount - 1
+    private var chrBank = 0
+
+    // Mirroring lives in bit 7 of the most recent $4100+ write. The
+    // iNES header wires the initial value so a game that *never* writes
+    // the register still renders correctly.
+    private var verticalMirroring: Boolean =
+        gamePak.header.mirroring == Header.Mirroring.VERTICAL
+
+    // CPU data-bus value, set by Memory just before each `cpuRead`.
+    // The HES NTD-8 chip has nothing of its own to return for CPU
+    // reads in $0000-$7FFF, but a real 6502 returns the residual byte
+    // on the data bus (open-bus). Mind Blower Pak's reset-vector
+    // trampoline relies on this: a JMP $0400 at $FFE0 in PRG bank 0
+    // loads $0401 = 0x59 onto the bus, then JMPs to $59A9. On a real
+    // 6502 the opcode fetch at $59A9 returns 0x59 (the open-bus
+    // value), not 0; 0 would be BRK, which sends the boot to the IRQ
+    // vector and into a self-replicating loop. Returning [dataBus]
+    // for the unmapped range reproduces Mesen2's behaviour and lets
+    // the boot sequence escape the trampoline. The default Mapper
+    // property is 0-on-open-bus; overriding it with a real backing
+    // field opts this chip in.
+    override var dataBus: Byte = 0
+
+    override fun cpuRead(address: Int): Byte {
+        // Open-bus path. The chip has no PRG-RAM and no registers
+        // below $8000, so a CPU read in $0000-$7FFF has nothing of
+        // its own to return. On real hardware, the data bus holds
+        // whatever byte was last driven on it — the value [Memory]
+        // pushed into us just before this call.
+        if (address < 0x8000) return dataBus
+        // 32 KB at $8000-$FFFF, fully banked. Modulo keeps oversized bank
+        // numbers (a buggy write) from indexing past the ROM.
+        val bankOffset = prgBank * 0x8000
+        val offset = address - 0x8000
+        return programRom[(bankOffset + offset) % programRom.size]
+    }
+
+    override fun cpuWrite(address: Int, value: Byte) {
+        // Decode the chip-select gate. `(addr & 0xE100) == 0x4100` rejects
+        // any address outside the $4100-$5FFF chip-select window (e.g.
+        // $6100 sets A13, $6100-ish; $4000 clears A8; $6000+ sets A13).
+        if ((address and 0xE100) != 0x4100) return
+        val v = value.toUnsignedInt()
+        prgBank = (v ushr 4) and 0x07
+        chrBank = v and 0x0F
+        verticalMirroring = (v and 0x80) != 0
+    }
+
+    override fun ppuRead(address: Int): Byte {
+        val a = address and 0x1FFF
+        if (chrRam != null) return chrRam[a]
+        // 8 KB CHR bank. `% chrRom.size` so an out-of-range bank number
+        // (a buggy write, or a dump with fewer CHR banks than the game's
+        // code requests) just mirrors into the existing data instead of
+        // crashing on a bounds error.
+        return chrRom[(chrBank * 0x2000 + a) % chrRom.size]
+    }
+
+    override fun ppuWrite(address: Int, value: Byte) {
+        if (chrRam != null) chrRam[address and 0x1FFF] = value
+    }
+
+    override fun currentMirroring(): Mapper.MirroringMode {
+        return if (verticalMirroring) Mapper.MirroringMode.VERTICAL
+        else Mapper.MirroringMode.HORIZONTAL
+    }
+
+    override fun saveState(out: DataOutput) {
+        super.saveState(out)
+        out.writeInt(prgBank)
+        out.writeInt(chrBank)
+        out.writeBoolean(verticalMirroring)
+        out.writeBoolean(chrRam != null)
+        if (chrRam != null) out.write(chrRam)
+    }
+
+    override fun loadState(input: DataInput) {
+        super.loadState(input)
+        prgBank = input.readInt()
+        chrBank = input.readInt()
+        verticalMirroring = input.readBoolean()
+        val hasChrRam = input.readBoolean()
+        if (hasChrRam && chrRam != null) input.readFully(chrRam)
+    }
+
+    override fun snapshot(): MapperStateSnapshot {
+        return MapperStateSnapshot(
+            mapperId = 113,
+            type = "HES NTD-8 / PT-554A",
+            banks = mapOf(
+                "prgBank" to prgBank,
+                "chrBank" to chrBank
+            ),
+            registers = mapOf(
+                "verticalMirroring" to if (verticalMirroring) 1 else 0
+            ),
+            irqState = null,
+            chrRam = chrRam?.copyOf()
+        )
+    }
+}

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper113.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper113.kt
@@ -12,22 +12,29 @@ import java.io.DataOutput
  *
  * **Register decode** — *the only Nestlin mapper with its banking
  * register outside the normal PRG space*. The chip-select gate is
- * `(addr & 0xE100) == 0x4100`: A8 must be set, A9-A12 must be clear, and
- * A13-A15 must be clear; the low 8 bits are aliased. That gives 16
- * distinct 256-byte pages — `$4100-$41FF`, `$4300-$43FF`, ..., up to
- * `$5F00-$5FFF` — and every address in any of those pages latches the
+ * `(addr & 0xE100) == 0x4100`, i.e. of the four masked bits A8/A13/A14/A15
+ * only A14 and A8 are set (A13 and A15 clear). A14 set + A13/A15 clear pins
+ * the window to `$4000-$5FFF`; A8 set picks the odd 256-byte pages within
+ * it. A9-A12 and the low 8 bits (A0-A7) are *don't-care* — they alias. That
+ * gives 16 distinct 256-byte pages — `$4100-$41FF`, `$4300-$43FF`, ..., up
+ * to `$5F00-$5FFF` — and every address in any of those pages latches the
  * same control register.
  *
  * **Bit layout of the register byte:**
  * ```
- *   bit  7  6  5  4 | 3  2  1  0
- *       M  P  P  P | C  C  C  C
+ *   bit  7  6  5  4  3 | 2  1  0
+ *       M  C  P  P  P | C  C  C
  * ```
  * - Bit 7 (`M`): mirroring — 1 = vertical, 0 = horizontal.
- * - Bits 4-6 (`PPP`): 32 KB PRG bank select (8 banks → 256 KB max PRG).
- * - Bit 3 (`C`): high bit of CHR bank.
+ * - Bits 3-5 (`PPP`): 32 KB PRG bank select (8 banks → 256 KB max PRG).
+ * - Bit 6 (`C`): high bit of the CHR bank (bit 3 of the CHR index).
  * - Bits 0-2 (`CCC`): low 3 bits of CHR bank.
  * Net: 8 PRG banks × 16 CHR banks (128 KB max CHR).
+ *
+ * The PRG field is bits **3-5** and the CHR high bit is bit **6** — getting
+ * this wrong (e.g. PRG = bits 4-6) sends the first boot write (`$59` -> PRG
+ * bank 3, the last bank, where Mind Blower Pak's init code lives) to the
+ * wrong bank, and the whole boot diverges. This was issue #163.
  *
  * **PRG geometry:** 32 KB window at `$8000-$FFFF`, fully banked. There
  * is no fixed last bank (the chip latches the whole window from one
@@ -53,27 +60,24 @@ class Mapper113(private val gamePak: GamePak) : Mapper {
 
     // Power-on default: the LAST PRG bank is mapped, not bank 0.
     //
-    // Why: Mind Blower Pak's bank-0 reset vector is $9FE0, a
-    // self-replicating trampoline that copies 11 bytes to $0400 then
-    // JMPs ($FFFC). The trampoline's purpose is to navigate between PRG
-    // banks: bank 0 writes 0x59 (PRG=2), bank 2 writes 0x1D (PRG=1),
-    // and bank 1's trampoline writes 0x1D again — looping forever
-    // because JMP ($FFFC) re-reads bank 1's reset vector. The only
-    // escape is the real init code in the LAST bank (bank 3, at
-    // $B44E), which expects the CPU to start with the last bank mapped
-    // and immediately runs `LDA #$59; STA $4120; SEI; ...; wait vblank;
-    // clear RAM; set up registers; enable PPU`.
+    // Why: Mind Blower Pak's real init code lives in the LAST 32 KB bank
+    // (bank 3 of a 128 KB ROM); its reset vector is $B400 and the init
+    // routine at $B44E runs `LDA #$59; STA $4120; SEI; ...; wait vblank;
+    // clear RAM; copy the main loop into RAM; enable PPU`. With the
+    // canonical register decode (PRG = bits 3-5), the value $59 selects
+    // PRG bank 3 — i.e. it KEEPS the last bank mapped — so the init code
+    // continues running uninterrupted. The chip must therefore power on
+    // with the last bank already mapped; a bank-0 default would start in
+    // a different bank's code and never reach the init routine.
     //
-    // Confirmed against Mesen2 v2.1.1: a frame-1 trace of Mind Blower
-    // Pak shows the CPU executing in bank 3 at $B476 with zero
-    // mapper-register writes (so the bank hasn't been switched from
-    // its power-on value). A bank-0 default would loop forever in the
-    // bank-1 trampoline.
+    // (Historical note: an earlier decode bug — issue #163 — read PRG
+    // from bits 4-6 instead of 3-5, so $59 selected effective bank 1
+    // instead of 3 and the boot diverged immediately. The power-on bank
+    // was never the problem; the register decode was. See cpuWrite.)
     //
-    // The same power-on state matches Total Funpak (also Mapper 113,
-    // 4 PRG banks): bank 3's reset vector is $8010, also in the last
-    // bank, and the other banks' reset vectors point at real init
-    // code, not trampolines. The "fixed last bank" pattern is what
+    // The same "last bank holds init" pattern matches Total Funpak (also
+    // Mapper 113): its last bank's reset vector points at real init code,
+    // not a cross-bank trampoline. The "fixed last bank" power-on is what
     // every HES Australia multicart relies on for boot.
     private var prgBank = prgBankCount - 1
     private var chrBank = 0
@@ -119,8 +123,10 @@ class Mapper113(private val gamePak: GamePak) : Mapper {
         // $6100 sets A13, $6100-ish; $4000 clears A8; $6000+ sets A13).
         if ((address and 0xE100) != 0x4100) return
         val v = value.toUnsignedInt()
-        prgBank = (v ushr 4) and 0x07
-        chrBank = v and 0x0F
+        // NESdev iNES Mapper 113 / Mesen `Mapper113::WriteRegister`:
+        //   PRG = bits 3-5, CHR = (bit 6 << 3) | bits 0-2, mirroring = bit 7.
+        prgBank = (v ushr 3) and 0x07
+        chrBank = ((v ushr 3) and 0x08) or (v and 0x07)
         verticalMirroring = (v and 0x80) != 0
     }
 

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper113RegressionTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper113RegressionTest.kt
@@ -1,0 +1,140 @@
+package com.github.alondero.nestlin.compare
+
+import com.github.alondero.nestlin.gamepak.Mapper113
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Structured-state regression test for issue #139 (Mapper 113 / HES NTD-8).
+ *
+ * Two-pronged verification, mirroring `Mapper33RegressionTest` and
+ * `Mapper10RegressionTest`:
+ *  1. The Mind Blower Pak boot code actually moves the PRG/CHR bank
+ *     registers during boot — proves the $4100+ chip-select gate is
+ *     wired and the chip isn't stuck at its reset state.
+ *  2. Nestlin's CHR banks are byte-identical to Mesen2's at frame N —
+ *     proves the full PRG-bank + CHR-bank + mirroring interaction is
+ *     correct. Mind Blower Pak is a 6-in-1 HES multicart with a
+ *     self-replicating boot trampoline at $FFE0 in bank 1 (the IRQ
+ *     handler in bank 1 has to break out by modifying the JMP target),
+ *     so a CHR-only comparison is the right scope: the boot logic
+ *     upstream of PPU rendering is game-specific and not the mapper's
+ *     job.
+ *
+ * The ROM lives only in the NO-INTRO library (not in git). Override
+ * with `NESTLIN_MIND_BLOWER_PAK_ROM`; otherwise we fall back to the
+ * canonical path on Adam's machine. Skipped (not failed) when neither
+ * the ROM nor Mesen2 is present, since CI runners won't have either.
+ */
+class Mapper113RegressionTest {
+
+    private val frameNumber = 60
+
+    private fun mindBlowerPakRom(): Path {
+        val override = System.getenv("NESTLIN_MIND_BLOWER_PAK_ROM")
+        if (!override.isNullOrBlank()) return Paths.get(override)
+        return Paths.get("S:/Media/Nintendo NES/Games/Mind Blower Pak (Australia) (Unl).nes")
+    }
+
+    @Test
+    fun `hes ntd-8 prg and chr banks move during mind blower pak boot`() {
+        val rom = mindBlowerPakRom()
+        assumeTrue(Files.exists(rom), "Mind Blower Pak ROM not found at $rom")
+
+        val nestlin = com.github.alondero.nestlin.Nestlin().apply {
+            config.speedThrottlingEnabled = false
+            load(rom)
+        }
+        nestlin.powerReset()
+        val mapper = nestlin.memory.mapper as? Mapper113
+            ?: error("Expected Mapper113 for Mind Blower Pak; got ${nestlin.memory.mapper?.javaClass?.simpleName}")
+
+        val prgSeen = linkedSetOf<Int>()
+        val chrSeen = linkedSetOf<Int>()
+        var frameCount = 0
+        nestlin.addFrameListener(object : com.github.alondero.nestlin.ui.FrameListener {
+            override fun frameUpdated(frame: com.github.alondero.nestlin.ppu.Frame) {
+                val snap = mapper.snapshot()
+                prgSeen.add(snap.banks["prgBank"] ?: -1)
+                chrSeen.add(snap.banks["chrBank"] ?: -1)
+                if (++frameCount >= frameNumber) nestlin.stop()
+            }
+        })
+        nestlin.start()
+
+        // The HES NTD-8 boot sequence (verified by `Mapper113BootDiagnosticTest`)
+        // does: bank 0 reset vector -> copy-loop trampoline -> BRK at $59A9
+        // (because Mapper113 returns 0 for <$8000) -> IRQ handler in bank 0
+        // does the textbook NES init -> $4100 write with value $59 to switch
+        // to PRG bank 5, CHR bank 9, then JMP to $FFE0 in bank 5 ->
+        // bank 5's $FFE0 is a SECOND trampoline that re-writes 0x1D to $4120
+        // (PRG=1, CHR=13) and JMPs via the bank-1 reset vector. So the
+        // diagnostic should see at least PRG 1 and CHR 13 by frame 60.
+        Assertions.assertTrue(
+            prgSeen.size > 1 || prgSeen.firstOrNull()?.let { it != 0 } == true,
+            "HES NTD-8 PRG bank never changed during boot " +
+                "(prg seen: $prgSeen) — the \$4100+ chip-select gate may not be wired."
+        )
+        Assertions.assertTrue(
+            chrSeen.size > 1 || chrSeen.firstOrNull()?.let { it != 0 } == true,
+            "HES NTD-8 CHR bank never changed during boot " +
+                "(chr seen: $chrSeen) — the \$4100+ chip-select gate may not be wired."
+        )
+    }
+
+    /**
+     * Render-output state diff against Mesen2 (per `Mapper33RegressionTest`'s
+     * worked example and `mesen2-capturer-instant-offset-...` memory).
+     *
+     * Mesen2's `endFrame` fires at scanline 240, Nestlin's frame callback
+     * fires at scanline 261, so CPU regs / cycle counts / scanline are
+     * inherently non-comparable across the two. Render outputs (CHR, OAM,
+     * palette, PPUCTRL, PPUMASK) are stable across that offset and are
+     * exactly what a banking bug corrupts.
+     *
+     * The HES NTD-8 multicart's boot is complex (see kdoc on the
+     * prg-bank test above); if Nestlin's boot gets stuck in a loop before
+     * the title screen renders, the CHR bytes at frame 60 will reflect
+     * whatever CHR bank 13 has been latched at, not the title screen.
+     * The diff report will surface exactly which bytes diverge.
+     */
+    @Test
+    fun `mind blower pak chr banks match mesen2 at frame N`() {
+        val rom = mindBlowerPakRom()
+        assumeTrue(Files.exists(rom), "Mind Blower Pak ROM not found at $rom")
+        assumeTrue(Mesen2StateCapturer.isMesen2Available(), "Mesen2 not available")
+
+        val reportsDir = Paths.get("build/reports/state-diffs/mind-blower-pak-frame-$frameNumber")
+
+        val nestlinState = NestlinStateCapturer.captureState(rom, frameNumber)
+        val mesen2State = Mesen2StateCapturer.captureState(rom, frameNumber)
+
+        Files.createDirectories(reportsDir)
+        Files.writeString(reportsDir.resolve("nestlin-state.json"), nestlinState.toJson())
+        Files.writeString(reportsDir.resolve("mesen2-state.json"), mesen2State.toJson())
+        val fullDiff = StateComparator.compare(nestlinState, mesen2State)
+        StateComparator.writeReport(fullDiff, nestlinState, mesen2State, reportsDir.resolve("diff-report.txt"))
+
+        // The mapper's job is PRG + CHR banking. The other render outputs
+        // (OAM, palette, PPUCTRL, PPUMASK) are reported alongside for human
+        // inspection but are NOT asserted here — see the kdoc for the
+        // cross-emulator NMI/OAM offset rationale.
+        val chrDiffs = (nestlinState.chr.indices).filter {
+            nestlinState.chr[it] != mesen2State.chr[it]
+        }
+        if (chrDiffs.isNotEmpty()) {
+            val sample = chrDiffs.take(8).joinToString(", ") {
+                "[0x%04X] N=0x%02X M=0x%02X".format(it, nestlinState.chr[it], mesen2State.chr[it])
+            }
+            throw org.opentest4j.AssertionFailedError(
+                "CHR banks diverged from Mesen2 oracle in ${chrDiffs.size} byte(s): $sample\n" +
+                    "This is a mapper bug — see: ${reportsDir.resolve("diff-report.txt")}"
+            )
+        }
+        println("Mind Blower Pak frame $frameNumber CHR banks: MATCH (8KB across the 8KB CHR window)")
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper113RegressionTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper113RegressionTest.kt
@@ -29,7 +29,15 @@ import java.nio.file.Paths
  * with `NESTLIN_MIND_BLOWER_PAK_ROM`; otherwise we fall back to the
  * canonical path on Adam's machine. Skipped (not failed) when neither
  * the ROM nor Mesen2 is present, since CI runners won't have either.
+ *
+ * `@RequiresMesen2` puts both subtests in the `mesen` lane (excluded from
+ * `./gradlew test`, included by `./gradlew testMesenComparison`) — the
+ * `MapperCoverageLintTest` enforces that every `Mapper*RegressionTest`
+ * carries this. Both subtests need the Mind Blower Pak ROM, which is not
+ * in git, so the in-body `assumeTrue(Files.exists(rom))` still guards the
+ * ROM independently of the Mesen2 gate.
  */
+@RequiresMesen2
 class Mapper113RegressionTest {
 
     private val frameNumber = 60

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper113BootDiagnosticTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper113BootDiagnosticTest.kt
@@ -1,0 +1,120 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.github.alondero.nestlin.Nestlin
+import com.github.alondero.nestlin.toUnsignedInt
+import com.github.alondero.nestlin.ui.FrameListener
+import com.github.alondero.nestlin.ppu.Frame
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Diagnostic boot for *Mind Blower Pak* (Mapper 113 / HES NTD-8) — a
+ * first-pass look at whether the game's PRG/CHR/mirroring/NMI machinery
+ * is actually getting through the new mapper. Prints tagged
+ * `[DEBUG-mb-boot]` output every frame for the first few frames, then
+ * once per 60 frames. Captures final PC, instruction count, PPU mask,
+ * PPU ctrl, PRG/CHR banks, and NMI count.
+ *
+ * ROM path defaults to the canonical NO-INTRO location; override with
+ * `NESTLIN_MIND_BLOWER_PAK_ROM` if running on a machine without the
+ * full NO-INTRO library.
+ */
+class Mapper113BootDiagnosticTest {
+
+    private fun romPath(): Path {
+        val override = System.getenv("NESTLIN_MIND_BLOWER_PAK_ROM")
+        if (!override.isNullOrBlank()) return Paths.get(override)
+        return Paths.get("S:/Media/Nintendo NES/Games/Mind Blower Pak (Australia) (Unl).nes")
+    }
+
+    @Test
+    fun `mind blower pak boot diagnostic`() {
+        val rom = romPath()
+        assumeTrue(Files.exists(rom), "ROM not found at $rom")
+
+        val nestlin = Nestlin().apply {
+            config.speedThrottlingEnabled = false
+            load(rom)
+        }
+        nestlin.powerReset()
+        val mapper = nestlin.memory.mapper as Mapper113
+        val ppu = nestlin.memory.ppuAddressedMemory
+        val oam = ppu.objectAttributeMemory
+
+        val startInstr = nestlin.cpu.getInstructionCount()
+        val resetVector = (nestlin.memory[0xFFFC].toUnsignedInt() shl 8) or
+            nestlin.memory[0xFFFD].toUnsignedInt()
+        println("[DEBUG-mb-boot] ROM: $rom")
+        println("[DEBUG-mb-boot] region: ${nestlin.currentRegion()}")
+        println("[DEBUG-mb-boot] reset vector: $${resetVector.toString(16).padStart(4, '0')}")
+        println(
+            "[DEBUG-mb-boot] PRG0[0..3] = " +
+                "$${(nestlin.memory[0x8000].toUnsignedInt()).toString(16).padStart(2, '0')} " +
+                "$${(nestlin.memory[0x8001].toUnsignedInt()).toString(2).padStart(8, '0')}"
+        )
+
+        var frameCount = 0
+        val maxFrames = 240
+        val earlyFrames = 5
+        val sampleEvery = 60
+        val oamNonZero = mutableSetOf<Int>()
+        val visitedPrgBanks = mutableSetOf<Int>()
+        val visitedChrBanks = mutableSetOf<Int>()
+
+        nestlin.addFrameListener(object : FrameListener {
+            override fun frameUpdated(f: Frame) {
+                val instr = nestlin.cpu.getInstructionCount()
+                val pc = nestlin.cpu.registers.programCounter.toUnsignedInt()
+                val ppuMask = ppu.mask.register.toUnsignedInt()
+                val ppuCtrl = ppu.controller.register.toUnsignedInt()
+                val snap = mapper.snapshot()
+                val prg = snap.banks["prgBank"] ?: -1
+                val chr = snap.banks["chrBank"] ?: -1
+                visitedPrgBanks += prg
+                visitedChrBanks += chr
+                // Sample OAM (256 bytes). First hit per byte index is enough.
+                for (i in 0 until 256) {
+                    if (oam[i].toUnsignedInt() != 0) oamNonZero += i
+                }
+                if (frameCount < earlyFrames || frameCount % sampleEvery == 0) {
+                    println(
+                        "[DEBUG-mb-boot] frame=$frameCount instr=$instr pc=$${pc.toString(16).padStart(4, '0')} " +
+                            "ppumask=$${ppuMask.toString(16).padStart(2, '0')} ppuctrl=$${ppuCtrl.toString(16).padStart(2, '0')} " +
+                            "prg=$prg chr=$chr oamNonZero=${oamNonZero.size}"
+                    )
+                }
+                frameCount++
+                if (frameCount >= maxFrames) nestlin.stop()
+            }
+        })
+        nestlin.start()
+
+        val totalInstr = nestlin.cpu.getInstructionCount() - startInstr
+        val finalPc = nestlin.cpu.registers.programCounter.toUnsignedInt()
+        val finalPpuMask = ppu.mask.register.toUnsignedInt()
+        val finalPpuCtrl = ppu.controller.register.toUnsignedInt()
+        val finalPrg = mapper.snapshot().banks["prgBank"] ?: -1
+        val finalChr = mapper.snapshot().banks["chrBank"] ?: -1
+        println(
+            "[DEBUG-mb-boot] FINAL frame=$frameCount totalInstr=$totalInstr (avg ${totalInstr / maxFrames}/frame) " +
+                "pc=$${finalPc.toString(16).padStart(4, '0')} " +
+                "ppumask=$${finalPpuMask.toString(16).padStart(2, '0')} ppuctrl=$${finalPpuCtrl.toString(16).padStart(2, '0')} " +
+                "prg=$finalPrg chr=$finalChr oamNonZero=${oamNonZero.size}"
+        )
+        println(
+            "[DEBUG-mb-boot] PPUMASK bit3 (show bg) = ${(finalPpuMask and 0x08) != 0}, " +
+                "bit4 (show sprites) = ${(finalPpuMask and 0x10) != 0}, " +
+                "bits 0-2 (palette) = ${finalPpuMask and 0x07}"
+        )
+        println(
+            "[DEBUG-mb-boot] PPUCTRL bit7 (NMI enable) = ${(finalPpuCtrl and 0x80) != 0}, " +
+                "bit5 (8x16 sprites) = ${(finalPpuCtrl and 0x20) != 0}, " +
+                "bit4 (bg pattern table) = ${(finalPpuCtrl and 0x10) != 0}"
+        )
+        println("[DEBUG-mb-boot] PRG banks seen: $visitedPrgBanks")
+        println("[DEBUG-mb-boot] CHR banks seen: $visitedChrBanks")
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper113BootDiagnosticTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper113BootDiagnosticTest.kt
@@ -45,8 +45,9 @@ class Mapper113BootDiagnosticTest {
         val oam = ppu.objectAttributeMemory
 
         val startInstr = nestlin.cpu.getInstructionCount()
-        val resetVector = (nestlin.memory[0xFFFC].toUnsignedInt() shl 8) or
-            nestlin.memory[0xFFFD].toUnsignedInt()
+        // 6502 vectors are little-endian: low byte at $FFFC, high byte at $FFFD.
+        val resetVector = (nestlin.memory[0xFFFD].toUnsignedInt() shl 8) or
+            nestlin.memory[0xFFFC].toUnsignedInt()
         println("[DEBUG-mb-boot] ROM: $rom")
         println("[DEBUG-mb-boot] region: ${nestlin.currentRegion()}")
         println("[DEBUG-mb-boot] reset vector: $${resetVector.toString(16).padStart(4, '0')}")

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper113Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper113Test.kt
@@ -88,6 +88,29 @@ class Mapper113Test {
         return pak.createMapper() as Mapper113
     }
 
+    /**
+     * Encode a register byte from intent, using the canonical Mapper 113
+     * layout (NESdev / Mesen `Mapper113::WriteRegister`):
+     * ```
+     *   bit 7 6 5 4 3 2 1 0
+     *       M C P P P C C C
+     * ```
+     * PRG = bits 3-5, CHR = (bit 6 << 3) | bits 0-2, mirroring = bit 7.
+     *
+     * Tests assert through this helper rather than hand-rolled magic bytes
+     * so they encode the *spec*, not the implementation — the wrong-decode
+     * (`PRG = bits 4-6`) that shipped in issue #163 passed 31 hand-rolled
+     * tests precisely because those tests were written against the buggy
+     * formula.
+     */
+    private fun reg(prg: Int = 0, chr: Int = 0, vertical: Boolean = false): Byte {
+        val v = (if (vertical) 0x80 else 0x00) or
+            ((prg and 0x07) shl 3) or
+            ((chr and 0x08) shl 3) or   // CHR high bit (value 8) -> register bit 6
+            (chr and 0x07)
+        return v.toSignedByte()
+    }
+
     // ---- Dispatch ----
 
     @Test
@@ -154,29 +177,28 @@ class Mapper113Test {
     }
 
     @Test
-    fun `4100 write sets PRG bank via bits 4-6`() {
+    fun `4100 write sets PRG bank via bits 3-5`() {
         val m = newMapper113(prgBanks32k = 8)
-        // 0x10 = bit 4 set -> PRG bank 1.
-        m.cpuWrite(0x4100, 0x10.toSignedByte())
+        m.cpuWrite(0x4100, reg(prg = 1))
         assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(1))
         assertThat(m.cpuRead(0xFFFF).toUnsignedInt(), equalTo(1 xor 0xFF))
     }
 
     @Test
     fun `all 8 PRG banks are reachable`() {
-        // 8 PRG banks, 3-bit field — no wrap for any value 0..7.
+        // 8 PRG banks, 3-bit field (bits 3-5) — no wrap for any value 0..7.
         val m = newMapper113(prgBanks32k = 8)
         for (bank in 0..7) {
-            m.cpuWrite(0x4100, (bank shl 4).toSignedByte())
+            m.cpuWrite(0x4100, reg(prg = bank))
             assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(bank))
         }
     }
 
     @Test
-    fun `PRG bank field ignores bits 0-3 and bit 7`() {
-        // The PRG field is bits 4-6 only. Bits 0-3 hold the CHR field and
-        // bit 7 holds the mirroring bit. 0xFF = all bits set, but the PRG
-        // decode picks (0xFF >> 4) & 0x07 = 7.
+    fun `PRG bank field is bits 3-5 only`() {
+        // The PRG field is bits 3-5. Bits 0-2 + bit 6 hold the CHR field and
+        // bit 7 holds the mirroring bit. 0xFF = all bits set, so the PRG
+        // decode picks (0xFF >> 3) & 0x07 = 7.
         val m = newMapper113(prgBanks32k = 8)
         m.cpuWrite(0x4100, 0xFF.toSignedByte())
         assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(7))
@@ -188,17 +210,17 @@ class Mapper113Test {
         // last 16 KB bank fixed at $C000). After switching to bank 5, the
         // byte at $C000 must be the start of bank 5, NOT a fixed last bank.
         val m = newMapper113(prgBanks32k = 8)
-        m.cpuWrite(0x4100, (5 shl 4).toSignedByte())
+        m.cpuWrite(0x4100, reg(prg = 5))
         assertThat(m.cpuRead(0xC000).toUnsignedInt(), equalTo(5))
         assertThat(m.cpuRead(0xFFFF).toUnsignedInt(), equalTo(5 xor 0xFF))
     }
 
     @Test
     fun `PRG bank number larger than prgBankCount wraps modulo`() {
-        // 4 PRG banks: any value V%4 is the effective bank. 0x70 -> bank 7,
+        // 4 PRG banks: any value V%4 is the effective bank. Selecting PRG 7,
         // 7 % 4 = 3.
         val m = newMapper113(prgBanks32k = 4)
-        m.cpuWrite(0x4100, 0x70.toSignedByte())
+        m.cpuWrite(0x4100, reg(prg = 7))
         assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(3))
     }
 
@@ -250,7 +272,7 @@ class Mapper113Test {
         // data (the bank window starts at $8000). If a future refactor
         // ever widens the window, this test fails loud.
         val m = newMapper113(prgBanks32k = 8)
-        m.cpuWrite(0x4100, (5 shl 4).toSignedByte())  // PRG bank 5
+        m.cpuWrite(0x4100, reg(prg = 5))  // PRG bank 5
         m.dataBus = 0x42.toSignedByte()
         assertThat(m.cpuRead(0x0001).toUnsignedInt(), equalTo(0x42))
         assertThat(m.cpuRead(0x7FFF).toUnsignedInt(), equalTo(0x42))
@@ -269,10 +291,9 @@ class Mapper113Test {
     }
 
     @Test
-    fun `4100 write sets CHR bank via bits 0-3`() {
+    fun `4100 write sets CHR bank via bit 6 + bits 0-2`() {
         val m = newMapper113(chrBanks8k = 16)
-        // 0x05 = CHR bank 5, PRG bank 0.
-        m.cpuWrite(0x4100, 0x05.toSignedByte())
+        m.cpuWrite(0x4100, reg(chr = 5))  // CHR bank 5, PRG bank 0
         assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(5))
         assertThat(m.ppuRead(0x1FFF).toUnsignedInt(), equalTo(5 xor 0xFF))
     }
@@ -281,31 +302,33 @@ class Mapper113Test {
     fun `all 16 CHR banks are reachable`() {
         val m = newMapper113(chrBanks8k = 16)
         for (bank in 0..15) {
-            m.cpuWrite(0x4100, bank.toSignedByte())
+            m.cpuWrite(0x4100, reg(chr = bank))
             assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(bank))
         }
     }
 
     @Test
-    fun `CHR bank 15 (bit 3 set + low 3 bits set) is reachable`() {
-        // Bit 3 is the high bit of the CHR field. 0x0F = bank 15.
+    fun `CHR bank 15 (high bit + low 3 bits set) is reachable`() {
+        // The CHR high bit (bit 3 of the index) lives in register bit 6.
+        // reg(chr = 15) sets bit 6 and bits 0-2.
         val m = newMapper113(chrBanks8k = 16)
-        m.cpuWrite(0x4100, 0x0F.toSignedByte())
+        m.cpuWrite(0x4100, reg(chr = 15))
         assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(15))
     }
 
     @Test
-    fun `CHR bank 8 (bit 3 set) is reachable`() {
+    fun `CHR bank 8 (high bit only) is reachable`() {
+        // CHR bank 8 = high bit set, low bits clear = register bit 6 only.
         val m = newMapper113(chrBanks8k = 16)
-        m.cpuWrite(0x4100, 0x08.toSignedByte())
+        m.cpuWrite(0x4100, reg(chr = 8))
         assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(8))
     }
 
     @Test
     fun `CHR bank number larger than chrBankCount wraps modulo`() {
-        // 8 CHR banks; 0x0F = bank 15, 15 % 8 = 7.
+        // 8 CHR banks; selecting CHR 15, 15 % 8 = 7.
         val m = newMapper113(chrBanks8k = 8)
-        m.cpuWrite(0x4100, 0x0F.toSignedByte())
+        m.cpuWrite(0x4100, reg(chr = 15))
         assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(7))
     }
 
@@ -371,7 +394,7 @@ class Mapper113Test {
         // 0x4B00, 0x4D00, 0x4F00, 0x5100, 0x5300, 0x5500, 0x5700,
         // 0x5900, 0x5B00, 0x5D00, 0x5F00 — 16 total.
         for (page in 0x4100..0x5F00 step 0x0200) {
-            m.cpuWrite(page, 0xE5.toSignedByte())   // PRG 6, CHR 5, vert
+            m.cpuWrite(page, reg(prg = 6, chr = 5, vertical = true))
             assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(6))
             assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(5))
         }
@@ -380,20 +403,20 @@ class Mapper113Test {
     @Test
     fun `low 8 bits of the address are aliased`() {
         // Within a single page (e.g. $4100), any low address bits should
-        // decode to the same register. $4100, $4142, $41FF, $4100 again
-        // all write the same single byte.
+        // decode to the same register. $4142, $41FF all write the same
+        // single byte.
         val m = newMapper113()
-        m.cpuWrite(0x4142, 0xE5.toSignedByte())
+        m.cpuWrite(0x4142, reg(prg = 6, chr = 5, vertical = true))
         assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(6))
-        m.cpuWrite(0x41FF, 0x05.toSignedByte())
+        m.cpuWrite(0x41FF, reg(prg = 0))
         assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(0))
     }
 
     @Test
     fun `multiple writes overwrite the register`() {
         val m = newMapper113()
-        m.cpuWrite(0x4100, 0x10.toSignedByte())  // PRG 1
-        m.cpuWrite(0x4100, 0x30.toSignedByte())  // PRG 3
+        m.cpuWrite(0x4100, reg(prg = 1))
+        m.cpuWrite(0x4100, reg(prg = 3))
         assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(3))
     }
 
@@ -414,7 +437,7 @@ class Mapper113Test {
             stampChr8kBanks(chr)
         }
         val original = pak.createMapper() as Mapper113
-        original.cpuWrite(0x4100, 0xE5.toSignedByte())  // PRG 6, CHR 5, vert
+        original.cpuWrite(0x4100, reg(prg = 6, chr = 5, vertical = true))
         val bytes = ByteArrayOutputStream().use { baos ->
             DataOutputStream(baos).use { original.saveState(it) }
             baos.toByteArray()
@@ -452,7 +475,7 @@ class Mapper113Test {
     @Test
     fun `snapshot reflects all current state`() {
         val m = newMapper113(prgBanks32k = 8, chrBanks8k = 16, mirroring = Header.Mirroring.HORIZONTAL)
-        m.cpuWrite(0x4100, 0xE5.toSignedByte())   // PRG 6, CHR 5, vert
+        m.cpuWrite(0x4100, reg(prg = 6, chr = 5, vertical = true))
         val snap = m.snapshot()
         assertThat(snap.mapperId, equalTo(113))
         assertThat(snap.banks["prgBank"], equalTo(6))

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper113Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper113Test.kt
@@ -1,0 +1,496 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.github.alondero.nestlin.testutil.testGamePak
+import com.github.alondero.nestlin.testutil.testRom
+import com.github.alondero.nestlin.toSignedByte
+import com.github.alondero.nestlin.toUnsignedInt
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+
+/**
+ * Unit tests for Mapper 113 (HES NTD-8 / PT-554A) — *Mind Blower Pak*
+ * and *Total Funpak* (HES Australia, 1992).
+ *
+ * Test PRG/CHR are stamped with their bank index so a read asserts
+ * exactly which bank is mapped into a window:
+ *  - 32 KB PRG banks: every byte = bank index, byte 0x7FFF = bank XOR 0xFF.
+ *  - 8 KB CHR banks: every byte = bank index, byte 0x1FFF = bank XOR 0xFF.
+ *
+ * The chip has 8 PRG banks (3 bits) and 16 CHR banks (4 bits), so the
+ * default fixture is 256 KB PRG / 128 KB CHR — that exercises the full
+ * range without any modulo wrap. Smaller fixtures use a smaller
+ * `prgBankCount` and rely on the modulo to keep oversized bank numbers
+ * from indexing past the array.
+ *
+ * TestRomBuilder owns the 16-byte iNES header encoding. We use a custom
+ * bank-stamp helper (full-bank fill + XOR sentinel) because the
+ * built-in `stampPrgBanks` only stamps byte 0 of each window — for a
+ * 32 KB Mapper 113 bank, byte 0 alone can't tell us "the whole window
+ * is one bank, not the start of a fixed second bank at $C000".
+ */
+class Mapper113Test {
+
+    /**
+     * Stamp every byte of every 32 KB PRG bank with its bank index, and
+     * set the *last* byte of each bank (byte 0x7FFF, which maps to $FFFF)
+     * to `bank xor 0xFF` as a sentinel. The whole 32 KB window at
+     * $8000-$FFFF is one bank for this mapper, so we have to stamp every
+     * byte — unlike the 8 KB-bank fixtures (Mapper 33, 71) where the
+     * 8 KB window is itself the unit and the stamp at byte 0 + 0x1FFF
+     * is enough.
+     */
+    private fun stampPrg32kBanks(prg: ByteArray) {
+        val bankCount = prg.size / 0x8000
+        for (bank in 0 until bankCount) {
+            java.util.Arrays.fill(
+                prg, bank * 0x8000, bank * 0x8000 + 0x8000,
+                (bank and 0xFF).toByte()
+            )
+            prg[bank * 0x8000 + 0x7FFF] = (bank xor 0xFF).toByte()
+        }
+    }
+
+    /**
+     * Stamp every byte of every 8 KB CHR bank with its bank index, and
+     * set the *last* byte of each bank (byte 0x1FFF) to `bank xor 0xFF`
+     * as a sentinel. The 8 KB window at $0000-$1FFF is one bank for
+     * this mapper.
+     */
+    private fun stampChr8kBanks(chr: ByteArray) {
+        val bankCount = chr.size / 0x2000
+        for (bank in 0 until bankCount) {
+            java.util.Arrays.fill(
+                chr, bank * 0x2000, bank * 0x2000 + 0x2000,
+                (bank and 0xFF).toByte()
+            )
+            chr[bank * 0x2000 + 0x1FFF] = (bank xor 0xFF).toByte()
+        }
+    }
+
+    private fun newMapper113(
+        prgBanks32k: Int = 8,
+        chrBanks8k: Int = 16,
+        mirroring: Header.Mirroring = Header.Mirroring.HORIZONTAL
+    ): Mapper113 {
+        val pak = testGamePak {
+            mapper = 113
+            prgKb = prgBanks32k * 32
+            chrKb = chrBanks8k * 8
+            verticalMirroring = mirroring == Header.Mirroring.VERTICAL
+            stampPrg32kBanks(prg)
+            stampChr8kBanks(chr)
+        }
+        return pak.createMapper() as Mapper113
+    }
+
+    // ---- Dispatch ----
+
+    @Test
+    fun `mapper113 is selected for header mapper 113`() {
+        assertThat(newMapper113() is Mapper113, equalTo(true))
+    }
+
+    // ---- PRG banking ----
+
+    @Test
+    fun `defaults to PRG last bank across the whole 8000-FFFF window`() {
+        // The chip powers on with the LAST bank mapped, not bank 0. The
+        // 8-bank fixture stamps every byte with the bank index, so every
+        // PRG-window read should return 7 (= the last bank), and the
+        // 0x7FFF sentinel should be (7 xor 0xFF). Confirmed against
+        // Mesen2 v2.1.1: Mind Blower Pak's bank-3 init code at $B44E
+        // runs on the first instruction — the chip never even enters
+        // the self-replicating bank-1 trampoline that a bank-0 default
+        // would fall into. If a future refactor changes the power-on
+        // state, this test fails loud.
+        val m = newMapper113(prgBanks32k = 8)
+        val last = 7
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(last))
+        assertThat(m.cpuRead(0xA000).toUnsignedInt(), equalTo(last))
+        assertThat(m.cpuRead(0xC000).toUnsignedInt(), equalTo(last))
+        assertThat(m.cpuRead(0xE000).toUnsignedInt(), equalTo(last))
+        assertThat(m.cpuRead(0xFFFF).toUnsignedInt(), equalTo(last xor 0xFF))
+    }
+
+    @Test
+    fun `PRG initial state reads the last bank's reset vector at FFFC-FFFD`() {
+        // Mind Blower Pak's bank-3 reset vector is $B400 (the real init
+        // code), while bank-0's is $9FE0 (the self-replicating
+        // trampoline that the game uses to navigate between PRG banks).
+        // A bank-0 power-on default reads $9FE0 and gets stuck in the
+        // trampoline; a last-bank default reads $B400 and the boot
+        // escapes on the first instruction. Cross-checked against
+        // Mesen2 v2.1.1's frame-1 trace, which shows the CPU executing
+        // from $B476 (in bank 3) with zero mapper-register writes.
+        //
+        // Fixture: 4 PRG banks; bank 0 stamped with 0xAA everywhere, the
+        // last bank stamped with 0x55 everywhere. The reset vector in
+        // the LAST bank is read as 0x55 0x55 = $5555. If the power-on
+        // bank were 0, we'd see 0xAA 0xAA = $AAAA instead.
+        val pak = testGamePak {
+            mapper = 113
+            prgKb = 4 * 32
+            chrKb = 8
+            verticalMirroring = false
+            stampPrg32kBanks(prg)
+            // Override the stamp: bank 0 = 0xAA, all other banks = 0x55.
+            java.util.Arrays.fill(prg, 0, 0x8000, 0xAA.toByte())
+            for (bank in 1 until 4) {
+                java.util.Arrays.fill(
+                    prg, bank * 0x8000, bank * 0x8000 + 0x8000, 0x55.toByte()
+                )
+            }
+        }
+        val m = pak.createMapper() as Mapper113
+        val lo = m.cpuRead(0xFFFC).toUnsignedInt()
+        val hi = m.cpuRead(0xFFFD).toUnsignedInt()
+        assertThat(lo, equalTo(0x55))
+        assertThat(hi, equalTo(0x55))
+    }
+
+    @Test
+    fun `4100 write sets PRG bank via bits 4-6`() {
+        val m = newMapper113(prgBanks32k = 8)
+        // 0x10 = bit 4 set -> PRG bank 1.
+        m.cpuWrite(0x4100, 0x10.toSignedByte())
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(1))
+        assertThat(m.cpuRead(0xFFFF).toUnsignedInt(), equalTo(1 xor 0xFF))
+    }
+
+    @Test
+    fun `all 8 PRG banks are reachable`() {
+        // 8 PRG banks, 3-bit field — no wrap for any value 0..7.
+        val m = newMapper113(prgBanks32k = 8)
+        for (bank in 0..7) {
+            m.cpuWrite(0x4100, (bank shl 4).toSignedByte())
+            assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(bank))
+        }
+    }
+
+    @Test
+    fun `PRG bank field ignores bits 0-3 and bit 7`() {
+        // The PRG field is bits 4-6 only. Bits 0-3 hold the CHR field and
+        // bit 7 holds the mirroring bit. 0xFF = all bits set, but the PRG
+        // decode picks (0xFF >> 4) & 0x07 = 7.
+        val m = newMapper113(prgBanks32k = 8)
+        m.cpuWrite(0x4100, 0xFF.toSignedByte())
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(7))
+    }
+
+    @Test
+    fun `32KB PRG bank covers the whole 8000-FFFF window (no fixed bank at C000)`() {
+        // Differentiates Mapper 113 from Mapper 2 (UNROM, which has the
+        // last 16 KB bank fixed at $C000). After switching to bank 5, the
+        // byte at $C000 must be the start of bank 5, NOT a fixed last bank.
+        val m = newMapper113(prgBanks32k = 8)
+        m.cpuWrite(0x4100, (5 shl 4).toSignedByte())
+        assertThat(m.cpuRead(0xC000).toUnsignedInt(), equalTo(5))
+        assertThat(m.cpuRead(0xFFFF).toUnsignedInt(), equalTo(5 xor 0xFF))
+    }
+
+    @Test
+    fun `PRG bank number larger than prgBankCount wraps modulo`() {
+        // 4 PRG banks: any value V%4 is the effective bank. 0x70 -> bank 7,
+        // 7 % 4 = 3.
+        val m = newMapper113(prgBanks32k = 4)
+        m.cpuWrite(0x4100, 0x70.toSignedByte())
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(3))
+    }
+
+    // ---- Open-bus (6502 data-bus) reads for $0000-$7FFF ----
+    //
+    // HES NTD-8 has no PRG-RAM and no registers below $8000 — the chip
+    // has nothing of its own to return for a CPU read in $0000-$7FFF.
+    // On a real 6502 (and in Mesen2), such a read returns the residual
+    // byte on the data bus. Nestlin tracks that byte globally in
+    // Memory.kt and pushes it into the mapper via the `dataBus`
+    // property; the mapper must return it. Returning 0 instead is what
+    // trapped Mind Blower Pak's reset-vector trampoline at $59A9 in a
+    // self-replicating boot loop (see issue #139 and
+    // `Mapper113RegressionTest`). The Memory layer sets `dataBus`
+    // before each `cpuRead`; the test pre-seeds the value the same
+    // way the interface's setter would.
+
+    @Test
+    fun `read below 8000 returns the data-bus value, not zero`() {
+        val m = newMapper113(prgBanks32k = 8)
+        // 0x59 is the byte the divergent Mind Blower Pak read at $59A9
+        // — the JMP $0400 trampoline loaded $0401 = 0x59 onto the bus
+        // before fetching the opcode at $59A9. A correct mapper
+        // returns 0x59 (the open-bus value); the buggy implementation
+        // returns 0, which the CPU decodes as `BRK` and the boot
+        // path goes off the rails.
+        m.dataBus = 0x59.toSignedByte()
+        assertThat(m.cpuRead(0x59A9).toUnsignedInt(), equalTo(0x59))
+    }
+
+    @Test
+    fun `read below 8000 returns whatever byte was on the data bus`() {
+        // Same scenario, different bus value. Proves the mapper
+        // doesn't just return 0x59 — it returns the captured data-bus
+        // byte regardless of address or value.
+        val m = newMapper113(prgBanks32k = 8)
+        m.dataBus = 0xC3.toSignedByte()
+        assertThat(m.cpuRead(0x0001).toUnsignedInt(), equalTo(0xC3))
+        assertThat(m.cpuRead(0x07FF).toUnsignedInt(), equalTo(0xC3))
+        m.dataBus = 0x00.toSignedByte()
+        assertThat(m.cpuRead(0x5999).toUnsignedInt(), equalTo(0x00))
+        m.dataBus = 0xFF.toSignedByte()
+        assertThat(m.cpuRead(0x7FFF).toUnsignedInt(), equalTo(0xFF))
+    }
+
+    @Test
+    fun `read below 8000 ignores PRG bank selection`() {
+        // A read in $0000-$7FFF must not accidentally return PRG bank
+        // data (the bank window starts at $8000). If a future refactor
+        // ever widens the window, this test fails loud.
+        val m = newMapper113(prgBanks32k = 8)
+        m.cpuWrite(0x4100, (5 shl 4).toSignedByte())  // PRG bank 5
+        m.dataBus = 0x42.toSignedByte()
+        assertThat(m.cpuRead(0x0001).toUnsignedInt(), equalTo(0x42))
+        assertThat(m.cpuRead(0x7FFF).toUnsignedInt(), equalTo(0x42))
+    }
+
+    // ---- CHR banking ----
+
+    @Test
+    fun `defaults to CHR bank 0 across 0000-1FFF`() {
+        val m = newMapper113(chrBanks8k = 16)
+        assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(0))
+        // 0x1FFF is the last byte of the first 8KB CHR bank — sentinel.
+        assertThat(m.ppuRead(0x1FFF).toUnsignedInt(), equalTo(0 xor 0xFF))
+        assertThat(m.ppuRead(0x0800).toUnsignedInt(), equalTo(0))
+        assertThat(m.ppuRead(0x1000).toUnsignedInt(), equalTo(0))
+    }
+
+    @Test
+    fun `4100 write sets CHR bank via bits 0-3`() {
+        val m = newMapper113(chrBanks8k = 16)
+        // 0x05 = CHR bank 5, PRG bank 0.
+        m.cpuWrite(0x4100, 0x05.toSignedByte())
+        assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(5))
+        assertThat(m.ppuRead(0x1FFF).toUnsignedInt(), equalTo(5 xor 0xFF))
+    }
+
+    @Test
+    fun `all 16 CHR banks are reachable`() {
+        val m = newMapper113(chrBanks8k = 16)
+        for (bank in 0..15) {
+            m.cpuWrite(0x4100, bank.toSignedByte())
+            assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(bank))
+        }
+    }
+
+    @Test
+    fun `CHR bank 15 (bit 3 set + low 3 bits set) is reachable`() {
+        // Bit 3 is the high bit of the CHR field. 0x0F = bank 15.
+        val m = newMapper113(chrBanks8k = 16)
+        m.cpuWrite(0x4100, 0x0F.toSignedByte())
+        assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(15))
+    }
+
+    @Test
+    fun `CHR bank 8 (bit 3 set) is reachable`() {
+        val m = newMapper113(chrBanks8k = 16)
+        m.cpuWrite(0x4100, 0x08.toSignedByte())
+        assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(8))
+    }
+
+    @Test
+    fun `CHR bank number larger than chrBankCount wraps modulo`() {
+        // 8 CHR banks; 0x0F = bank 15, 15 % 8 = 7.
+        val m = newMapper113(chrBanks8k = 8)
+        m.cpuWrite(0x4100, 0x0F.toSignedByte())
+        assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(7))
+    }
+
+    // ---- Mirroring ----
+
+    @Test
+    fun `mirroring follows iNES header (vertical) when 4100 has not been written`() {
+        val m = newMapper113(mirroring = Header.Mirroring.VERTICAL)
+        assertThat(m.currentMirroring(), equalTo(Mapper.MirroringMode.VERTICAL))
+    }
+
+    @Test
+    fun `mirroring follows iNES header when 4100 has not been written`() {
+        val m = newMapper113(mirroring = Header.Mirroring.HORIZONTAL)
+        assertThat(m.currentMirroring(), equalTo(Mapper.MirroringMode.HORIZONTAL))
+    }
+
+    @Test
+    fun `bit 7 of 4100 write selects mirroring (1=vert, 0=horiz)`() {
+        val m = newMapper113(mirroring = Header.Mirroring.HORIZONTAL)
+        m.cpuWrite(0x4100, 0x80.toSignedByte())  // bit 7 set -> vertical
+        assertThat(m.currentMirroring(), equalTo(Mapper.MirroringMode.VERTICAL))
+        m.cpuWrite(0x4100, 0x00.toSignedByte())  // bit 7 clear -> horizontal
+        assertThat(m.currentMirroring(), equalTo(Mapper.MirroringMode.HORIZONTAL))
+    }
+
+    @Test
+    fun `mirroring bit is independent of the PRG and CHR bits`() {
+        val m = newMapper113(mirroring = Header.Mirroring.HORIZONTAL)
+        // 0xFF = all bits set: PRG=7, CHR=15, mirror=vertical.
+        m.cpuWrite(0x4100, 0xFF.toSignedByte())
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(7))   // PRG 7
+        assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(15))  // CHR 15
+        assertThat(m.currentMirroring(), equalTo(Mapper.MirroringMode.VERTICAL))
+    }
+
+    // ---- Register decode ($4100-$5FFF window) ----
+
+    @Test
+    fun `writes outside 4100-5FFF do not change state`() {
+        val m = newMapper113()
+        // Sanity: writes to $4000 (clears A8) and $6100 (sets A13) and
+        // $8000 (PRG window) all fall outside the chip-select gate.
+        m.cpuWrite(0x4000, 0xFF.toSignedByte())
+        m.cpuWrite(0x6100, 0xFF.toSignedByte())
+        m.cpuWrite(0x8000, 0xFF.toSignedByte())
+        m.cpuWrite(0xFFFF, 0xFF.toSignedByte())
+        // Default state preserved: PRG = LAST bank (power-on default),
+        // CHR 0, horizontal (from header). See the "defaults to PRG
+        // last bank" test for the power-on state rationale.
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(7))
+        assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(0))
+    }
+
+    @Test
+    fun `writes to the 8 base pages in 4100-5FFF all decode to the same register`() {
+        // (addr & 0xE100) == 0x4100 — low 8 bits are aliased across the
+        // entire $4100-$41FF range, and the same is true for $4300-$43FF
+        // ... $5F00-$5FFF. Every page in the chip-select window must
+        // reach the same single register.
+        val m = newMapper113()
+        // 8 distinct pages: 0x4100, 0x4300, 0x4500, 0x4700, 0x4900,
+        // 0x4B00, 0x4D00, 0x4F00, 0x5100, 0x5300, 0x5500, 0x5700,
+        // 0x5900, 0x5B00, 0x5D00, 0x5F00 — 16 total.
+        for (page in 0x4100..0x5F00 step 0x0200) {
+            m.cpuWrite(page, 0xE5.toSignedByte())   // PRG 6, CHR 5, vert
+            assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(6))
+            assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(5))
+        }
+    }
+
+    @Test
+    fun `low 8 bits of the address are aliased`() {
+        // Within a single page (e.g. $4100), any low address bits should
+        // decode to the same register. $4100, $4142, $41FF, $4100 again
+        // all write the same single byte.
+        val m = newMapper113()
+        m.cpuWrite(0x4142, 0xE5.toSignedByte())
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(6))
+        m.cpuWrite(0x41FF, 0x05.toSignedByte())
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(0))
+    }
+
+    @Test
+    fun `multiple writes overwrite the register`() {
+        val m = newMapper113()
+        m.cpuWrite(0x4100, 0x10.toSignedByte())  // PRG 1
+        m.cpuWrite(0x4100, 0x30.toSignedByte())  // PRG 3
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(3))
+    }
+
+    // ---- Save state ----
+
+    @Test
+    fun `saveState then loadState round-trips PRG, CHR, and mirroring`() {
+        // NOTE: do NOT introduce local `prg`/`chr` variables here — they
+        // would shadow TestRomBuilder's fields inside the `testGamePak`
+        // block, and the stamp helpers would mutate the wrong array.
+        // The `prg`/`chr` references inside the block are the builder's.
+        val pak = testGamePak {
+            mapper = 113
+            prgKb = 256
+            chrKb = 128
+            verticalMirroring = false
+            stampPrg32kBanks(prg)
+            stampChr8kBanks(chr)
+        }
+        val original = pak.createMapper() as Mapper113
+        original.cpuWrite(0x4100, 0xE5.toSignedByte())  // PRG 6, CHR 5, vert
+        val bytes = ByteArrayOutputStream().use { baos ->
+            DataOutputStream(baos).use { original.saveState(it) }
+            baos.toByteArray()
+        }
+        val fresh = pak.createMapper() as Mapper113
+        DataInputStream(ByteArrayInputStream(bytes)).use { fresh.loadState(it) }
+        assertThat(fresh.cpuRead(0x8000).toUnsignedInt(), equalTo(6))
+        assertThat(fresh.ppuRead(0x0000).toUnsignedInt(), equalTo(5))
+        assertThat(fresh.currentMirroring(), equalTo(Mapper.MirroringMode.VERTICAL))
+    }
+
+    @Test
+    fun `saveState round-trips CHR RAM when present`() {
+        // 0 KB CHR (chrKb = 0) -> mapper allocates an 8 KB CHR RAM. Writes
+        // survive a save+load round-trip.
+        val pak = testGamePak {
+            mapper = 113
+            prgKb = 256
+            chrKb = 0           // CHR-RAM (8 KB fallback)
+            stampPrg32kBanks(prg)
+        }
+        val m = pak.createMapper() as Mapper113
+        m.ppuWrite(0x0123, 0x77.toSignedByte())
+        val bytes = ByteArrayOutputStream().use { baos ->
+            DataOutputStream(baos).use { m.saveState(it) }
+            baos.toByteArray()
+        }
+        val fresh = pak.createMapper() as Mapper113
+        DataInputStream(ByteArrayInputStream(bytes)).use { fresh.loadState(it) }
+        assertThat(fresh.ppuRead(0x0123).toUnsignedInt(), equalTo(0x77))
+    }
+
+    // ---- Snapshot ----
+
+    @Test
+    fun `snapshot reflects all current state`() {
+        val m = newMapper113(prgBanks32k = 8, chrBanks8k = 16, mirroring = Header.Mirroring.HORIZONTAL)
+        m.cpuWrite(0x4100, 0xE5.toSignedByte())   // PRG 6, CHR 5, vert
+        val snap = m.snapshot()
+        assertThat(snap.mapperId, equalTo(113))
+        assertThat(snap.banks["prgBank"], equalTo(6))
+        assertThat(snap.banks["chrBank"], equalTo(5))
+        assertThat(snap.registers["verticalMirroring"], equalTo(1))
+    }
+
+    @Test
+    fun `snapshot reports header mirroring when 4100 has not been written`() {
+        val m = newMapper113(mirroring = Header.Mirroring.VERTICAL)
+        val snap = m.snapshot()
+        assertThat(snap.registers["verticalMirroring"], equalTo(1))
+    }
+
+    @Test
+    fun `snapshot reports horizontal mirroring after a 0x00 write`() {
+        val m = newMapper113(mirroring = Header.Mirroring.VERTICAL)
+        m.cpuWrite(0x4100, 0x10.toSignedByte())   // bit 7 clear -> horiz
+        val snap = m.snapshot()
+        assertThat(snap.registers["verticalMirroring"], equalTo(0))
+    }
+
+    // ---- CHR ROM fallback ----
+
+    @Test
+    fun `missing CHR ROM falls back to 8KB CHR RAM`() {
+        // 0 KB CHR in the header -> mapper treats the chip as having
+        // 8 KB of writable CHR RAM. ppuRead/ppuWrite must not throw.
+        val pak = testGamePak {
+            mapper = 113
+            prgKb = 256
+            chrKb = 0
+            stampPrg32kBanks(prg)
+        }
+        val m = pak.createMapper() as Mapper113
+        // CHR RAM is zero-initialised.
+        assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(0))
+        m.ppuWrite(0x0000, 0x42.toSignedByte())
+        assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(0x42))
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper113TotalFunpakBootTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper113TotalFunpakBootTest.kt
@@ -92,16 +92,24 @@ class Mapper113TotalFunpakBootTest {
         if (oamNonZero.isEmpty()) {
             throw AssertionFailedError("No sprites written to OAM by frame $maxFrames")
         }
-        // The PC should not be stuck in a 2-instruction loop. If the game
-        // is alive, the frame-end PC will change as NMI fires, code
-        // runs, and the CPU advances. A tight trampoline loop would have
-        // PC staying within a 4-byte window across all 240 frames; a
-        // healthy boot sees hundreds of distinct PC values.
-        if (distinctPcs.size < 10) {
+        // The boot must reach the game's RAM-resident menu shell. Both HES
+        // Australia multicarts copy their bank-switching menu loop into RAM
+        // ($0400+) during init and run it there (so it survives PRG bank
+        // switches), then idle in it waiting for SELECT/START. A correctly
+        // booted game therefore executes from RAM ($0000-$07FF) at some
+        // frame boundary; a game stuck in the power-on ROM trampoline never
+        // leaves $8000-$FFFF. (Don't count *distinct* frame-end PCs — a
+        // correctly idling menu sits in a tiny PC window, so a "few distinct
+        // PCs" heuristic false-flags a healthy boot. Issue #163: the wrong
+        // register decode made the game wander through many ROM PCs without
+        // ever reaching the RAM shell, which a distinct-count check passed.)
+        val reachedRamCode = distinctPcs.any { it < 0x0800 }
+        if (!reachedRamCode) {
             throw AssertionFailedError(
-                "PC only visited ${distinctPcs.size} distinct address(es) " +
-                    "in $maxFrames frames — the game looks stuck in a tight " +
-                    "loop. Sample PCs: ${distinctPcs.take(8)}"
+                "PC never reached the RAM-resident menu shell ($0000-$07FF) " +
+                    "in $maxFrames frames — the game looks stuck in the power-on " +
+                    "ROM trampoline. Sample PCs (hex): " +
+                    distinctPcs.take(8).joinToString(", ") { "$%04X".format(it) }
             )
         }
     }

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper113TotalFunpakBootTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper113TotalFunpakBootTest.kt
@@ -1,0 +1,108 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.github.alondero.nestlin.Nestlin
+import com.github.alondero.nestlin.toUnsignedInt
+import com.github.alondero.nestlin.ui.FrameListener
+import com.github.alondero.nestlin.ppu.Frame
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import org.opentest4j.AssertionFailedError
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Smoke test for the OTHER HES Australia Mapper 113 game — *Total Funpak* —
+ * to prove the new "power-on = last bank" default is correct for both
+ * titles, not just Mind Blower Pak.
+ *
+ * If Total Funpak boots cleanly (PPU enabled, OAM populated, PC
+ * navigating in real game code), the chip's power-on state is the last
+ * bank. If it gets stuck in a trampoline (the symmetric Mind Blower Pak
+ * failure mode), the mapper still has a bug.
+ */
+class Mapper113TotalFunpakBootTest {
+
+    private fun romPath(): Path {
+        val override = System.getenv("NESTLIN_TOTAL_FUNPAK_ROM")
+        if (!override.isNullOrBlank()) return Paths.get(override)
+        return Paths.get("S:/Media/Nintendo NES/Games/Total Funpak (Australia) (Unl).nes")
+    }
+
+    @Test
+    fun `total funpak boot reaches real game code past the mapper power-on state`() {
+        val rom = romPath()
+        assumeTrue(Files.exists(rom), "ROM not found at $rom")
+
+        val nestlin = Nestlin().apply {
+            config.speedThrottlingEnabled = false
+            load(rom)
+        }
+        nestlin.powerReset()
+        val ppu = nestlin.memory.ppuAddressedMemory
+        val oam = ppu.objectAttributeMemory
+
+        val maxFrames = 240
+        var frameCount = 0
+        val oamNonZero = mutableSetOf<Int>()
+        val visitedPrgBanks = mutableSetOf<Int>()
+        val visitedChrBanks = mutableSetOf<Int>()
+        var ppuEnabledAt = -1
+        var distinctPcs = mutableSetOf<Int>()
+
+        nestlin.addFrameListener(object : FrameListener {
+            override fun frameUpdated(f: Frame) {
+                val pc = nestlin.cpu.registers.programCounter.toUnsignedInt()
+                val ppuMask = ppu.mask.register.toUnsignedInt()
+                val mapper = nestlin.memory.mapper as Mapper113
+                val snap = mapper.snapshot()
+                val prg = snap.banks["prgBank"] ?: -1
+                val chr = snap.banks["chrBank"] ?: -1
+                visitedPrgBanks += prg
+                visitedChrBanks += chr
+                distinctPcs += pc
+                for (i in 0 until 256) {
+                    if (oam[i].toUnsignedInt() != 0) oamNonZero += i
+                }
+                // PPU enabled = bg or sprites visible (mask bit 3 or 4)
+                if (ppuEnabledAt < 0 && (ppuMask and 0x18) != 0) ppuEnabledAt = frameCount
+                frameCount++
+                if (frameCount >= maxFrames) nestlin.stop()
+            }
+        })
+        nestlin.start()
+
+        val finalMask = ppu.mask.register.toUnsignedInt()
+        val finalCtrl = ppu.controller.register.toUnsignedInt()
+        println(
+            "[DEBUG-tf-boot] FINAL frame=$frameCount ppumask=$${finalMask.toString(16).padStart(2, '0')} " +
+                "ppuctrl=$${finalCtrl.toString(16).padStart(2, '0')} oamNonZero=${oamNonZero.size} " +
+                "prgSeen=$visitedPrgBanks chrSeen=$visitedChrBanks ppuEnabledAt=$ppuEnabledAt " +
+                "distinctPcs=${distinctPcs.size}"
+        )
+
+        if (ppuEnabledAt < 0) {
+            throw AssertionFailedError(
+                "PPU never enabled by frame $maxFrames. The game is stuck " +
+                    "before enabling rendering — likely a power-on bank " +
+                    "bug. PPUCTRL=$${finalCtrl.toString(16).padStart(2, '0')} " +
+                    "PPUMASK=$${finalMask.toString(16).padStart(2, '0')}"
+            )
+        }
+        if (oamNonZero.isEmpty()) {
+            throw AssertionFailedError("No sprites written to OAM by frame $maxFrames")
+        }
+        // The PC should not be stuck in a 2-instruction loop. If the game
+        // is alive, the frame-end PC will change as NMI fires, code
+        // runs, and the CPU advances. A tight trampoline loop would have
+        // PC staying within a 4-byte window across all 240 frames; a
+        // healthy boot sees hundreds of distinct PC values.
+        if (distinctPcs.size < 10) {
+            throw AssertionFailedError(
+                "PC only visited ${distinctPcs.size} distinct address(es) " +
+                    "in $maxFrames frames — the game looks stuck in a tight " +
+                    "loop. Sample PCs: ${distinctPcs.take(8)}"
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/RegionDetectionTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/RegionDetectionTest.kt
@@ -77,12 +77,12 @@ class RegionDetectionTest {
     /**
      * HES Australia multicarts (Mapper 113) are NTSC pirate carts sold in
      * Australia. The "Australia" filename marker is a *where-sold* tag, not
-     * a *timing* tag — HES shipped NTSC boards even to PAL regions. The
-     * HES NTD-8's boot sequence (a self-replicating trampoline at $FFE0 in
-     * bank 1) only completes correctly under NTSC timing; under PAL the
-     * CPU has too many cycles per frame, the trampoline chain runs into a
-     * different write, and the game boots into the wrong bank (PRG=2, CHR=15
-     * instead of the Mesen2-verified PRG=1, CHR=13).
+     * a *timing* tag — HES shipped NTSC silicon even into PAL regions, so
+     * forcing NTSC matches the real cartridge's frame rate, palette, and
+     * CPU:PPU ratio. (This is a hardware-accuracy override; the games boot
+     * correctly under either region once the mapper decode is right — the
+     * garbled-title bug in issue #163 was a register-decode bug, not a
+     * PAL-vs-NTSC timing one.)
      *
      * The iNES header for these dumps is silent on region (byte 9 = 0), so
      * we override the filename-based fallback: when the mapper is 113, the

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/RegionDetectionTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/RegionDetectionTest.kt
@@ -74,6 +74,32 @@ class RegionDetectionTest {
         assertEquals(Region.PAL, GamePak(rom(byte9 = 0x01), "Some Game (USA)").region)
     }
 
+    /**
+     * HES Australia multicarts (Mapper 113) are NTSC pirate carts sold in
+     * Australia. The "Australia" filename marker is a *where-sold* tag, not
+     * a *timing* tag — HES shipped NTSC boards even to PAL regions. The
+     * HES NTD-8's boot sequence (a self-replicating trampoline at $FFE0 in
+     * bank 1) only completes correctly under NTSC timing; under PAL the
+     * CPU has too many cycles per frame, the trampoline chain runs into a
+     * different write, and the game boots into the wrong bank (PRG=2, CHR=15
+     * instead of the Mesen2-verified PRG=1, CHR=13).
+     *
+     * The iNES header for these dumps is silent on region (byte 9 = 0), so
+     * we override the filename-based fallback: when the mapper is 113, the
+     * timing must be NTSC.
+     */
+    @Test
+    fun `mapper 113 is NTSC even when filename has australia marker`() {
+        assertEquals(
+            Region.NTSC,
+            GamePak(rom(mapper = 113), "Mind Blower Pak (Australia) (Unl).nes").region
+        )
+        assertEquals(
+            Region.NTSC,
+            GamePak(rom(mapper = 113), "Total Funpak (Australia) (Unl).nes").region
+        )
+    }
+
     @Test
     fun `regionFromName ignores names without a region marker`() {
         assertNull(GamePak.regionFromName("nestest"))


### PR DESCRIPTION
Supersedes #162. Bundles the full Mapper 113 (HES NTD-8 / PT-554A) implementation **and** the fix for the boot divergence that #162 left open (tracked as #163), rebased onto current master's tag-driven test lanes.

## The bug (#163)

#162 shipped the mapper but Mind Blower Pak's title rendered as garbage tiles. The issue framed this as a **CPU/timing divergence** ("692K vs 1.78M cycles, 2.5× gap"). That was a red herring:

- The "cycle gap" was a **measurement artifact** — `692K` was Nestlin's *instruction* count, `1.78M` was Mesen2's *cycle* count. At ~2.5 cycles/instr they agree (correct NTSC). CPU timing was never wrong.
- "Mapper decode ruled out — 31/31 unit tests green" was a **self-referential false-green**: the tests hand-rolled register bytes from the implementation's *own* (wrong) formula.

The real cause: the register bit decode was off. Nestlin used `PRG = (v>>4)&7, CHR = v&0x0F`; the canonical HES NTD-8 layout (NESdev / Mesen `Mapper113::WriteRegister`) is:

```
bit 7 6 5 4 3 2 1 0
    M C P P P C C C   →  PRG = (v>>3)&7,  CHR = ((v>>3)&8)|(v&7)
```

The first boot write `$59` must select **PRG bank 3** (the last bank, where the init code lives). The wrong decode sent it to effective bank 1, so the game ran the wrong code from instruction one and latched CHR bank 15 (`0xFF` garbage).

## How it was found (no live oracle)

Mesen2 needs a display and is unavailable headless, so I traced from Nestlin's side: instrument every `$4100+` write with CPU context → the boot's only writes were `0x59` then `0x2F` (via a `LDA $FF0D,X; STA $4120` trampoline) → disassemble the bank the trampoline reads → realise `0x59` should map to PRG bank 3 → check the canonical decode → off-by-one in the bit fields.

## What changed

- **`Mapper113.cpuWrite`** — corrected the PRG/CHR bit decode (+ accurate chip-select-gate KDoc: A14 set, A13/A15 clear, A9-A12 aliased).
- **`Mapper113Test`** — rewrote all decode tests to derive register bytes through a spec-encoding `reg(prg, chr, vertical)` helper, so they assert the **spec**, not the implementation.
- **`Mapper113TotalFunpakBootTest`** — replaced a `distinctPcs >= 10` heuristic (which a correctly-idling menu fails) with "boot reaches RAM-resident menu shell (`PC < $0800`)".
- **NTSC override rationale** (GamePak / RegionDetectionTest / MAPPER_SUPPORT) — corrected: it's a **hardware-accuracy** override (HES is NTSC silicon), not a boot fix. Verified both games boot under PAL too.
- **`MAPPER_SUPPORT.md`** — new Mapper 113 section; `@RequiresMesen2` on the regression test (satisfies `MapperCoverageLintTest`).
- Minor: fixed a little-endian byte-order bug in the diagnostic reset-vector print.

## Verification

- `./gradlew clean test` — green (593 tests; Mapper113 Mesen2 regression correctly skipped into the `mesen` lane).
- `./gradlew build` — green.
- Both HES menus render correctly (Mind Blower Pak "4-PACK COMPILATION MK2"; Total Funpak "FOUR - IN - ONE") — screenshots verified.

Closes #139. Closes #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)