### PR TITLE
docs: Memory Editor domain glossary and ADR-0001

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,14 @@
+# Nestlin — Domain Language
+
+## Glossary
+
+| Term | Definition |
+|---|---|
+| **CPU bus** | The 6502's 64 KB address space (`$0000–$FFFF`): internal RAM, PPU/APU registers, mapper I/O, and PRG-ROM. The primary memory space users interact with via the Memory Editor. |
+| **Memory Editor** | A debug window that displays live CPU bus contents in a hex grid and lets the user edit values while the game runs. Separate JavaFX `Stage`, opened from the Debug menu (Ctrl+M). |
+| **peek** | A side-effect-free read of a memory address — returns the backing value without triggering register side effects (vblank clear, latch shift, VRAM increment, data-bus update). Used exclusively by the Memory Editor for display. |
+| **poke** | A write to a memory address from the Memory Editor. Delegates to `Memory.set()` for full side effects, except `$4014` (OAM DMA) and `$4016` (controller strobe) which are blacklisted to prevent catastrophic unintended effects. |
+| **change highlight** | Visual feedback in the Memory Editor when a byte's value differs between refreshes. Directional: green = value increased, blue/cyan = value decreased. Fades over ~500 ms. |
+| **memory region** | A named band in the CPU bus memory map (RAM `$0000–$1FFF`, PPU `$2000–$3FFF`, APU/IO `$4000–$401F`, Cart `$4020–$FFFF`). Colour-coded in the Memory Editor's address gutter. |
+| **cheat search** | (v2) A structured workflow for narrowing candidate addresses: snapshot → filter (equals/increased/decreased) → repeat until a handful of candidates remain. Deferred from v1. |
+| **freeze** | (v2) Locking a memory address to a fixed value so the game can never change it (e.g., infinite lives). Requires hooking the emulation loop. Deferred from v1 — ships alongside cheat search. |

--- a/docs/adr/0001-memory-editor-refresh-strategy.md
+++ b/docs/adr/0001-memory-editor-refresh-strategy.md
@@ -1,0 +1,28 @@
+# ADR-0001: Memory Editor refresh strategy — poll at fixed UI rate
+
+**Status:** Accepted  
+**Date:** 2026-06-14  
+**Context:** The Memory Editor displays live CPU bus contents while the emulation loop runs at ~60fps (NTSC) / ~50fps (PAL), mutating memory thousands of times per frame. The editor needs to refresh its 64 KB hex grid periodically.
+
+## Decision
+
+The Memory Editor polls memory at a **fixed 10 Hz UI timer** (~100 ms interval), independent of the emulation frame rate.
+
+Each tick:
+1. `peek()` the visible address range (not the full 64 KB — only the rows currently scrolled into view).
+2. Diff against the previous snapshot to detect changed cells.
+3. Repaint only dirty cells; apply directional change highlighting (green = increased, blue/cyan = decreased, 500 ms fade).
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|---|---|
+| **Refresh every emulated frame (60 Hz)** | 64 KB diff + JavaFX repaint at 60 fps is expensive; humans can't read hex at that rate anyway. |
+| **Event-driven (memory write callback)** | CPU bus sees thousands of writes per frame; funnelling each one to the FX thread would drown the event queue and couple the hot emulation path to UI code. |
+| **User-configurable rate** | Extra UI complexity for uncertain benefit. Easy to add later if 10 Hz proves wrong — it's a single constant. |
+
+## Consequences
+
+- A change that lasts < 100 ms between two poll ticks may be missed by the editor. Acceptable — the editor is a human-facing debug tool, not a logic analyser.
+- The 500 ms fade highlight clears after ~5 refresh ticks, keeping the display readable even for rapidly-changing addresses (frame counters, timers).
+- Only visible rows are peeked, so scrolling to a different region has near-zero cost even at 10 Hz.


### PR DESCRIPTION
## Summary

Design documentation from the Memory Editor grilling session (#167).

### Files

- **CONTEXT.md** — Domain glossary defining 8 terms: CPU bus, Memory Editor, peek, poke, change highlight, memory region, cheat search (v2), freeze (v2).
- **docs/adr/0001-memory-editor-refresh-strategy.md** — ADR recording the decision to poll memory at a fixed 10 Hz UI rate rather than syncing to the emulation frame rate or using event-driven updates.

### Context

These docs were produced during the design session for #167 (Live Memory Editor PRD). The implementation is tracked by:
- #168 — Minimal live hex viewer (tracer bullet)
- #169 — Change highlighting with directional fade
- #170 — Click-to-edit hex cells (poke)
- #171 — Region colours, Go-to-address, ASCII column

No code changes — docs only.