### PR TITLE
Memory Editor: live hex viewer + side-effect-free peek path (#168)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/Apu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Apu.kt
@@ -229,6 +229,34 @@ class Apu(private val dmaPort: DmaPort) {
         }
     }
 
+    /**
+     * Side-effect-free read of an APU register (issue #168, Memory Editor).
+     *
+     * `$4015` is the only APU register with a read side effect: [handleStatusRead]
+     * clears the frame-counter IRQ and the DMC IRQ. [peekRegisterRead] computes the
+     * identical status byte but leaves both IRQ flags pending, so a debug viewer
+     * polling `$4015` can never swallow an interrupt the game is waiting on. Every
+     * other register is plain backing storage, read straight from [apuMemory].
+     */
+    fun peekRegisterRead(address: Int): Byte = when (address) {
+        0x15 -> peekStatusRead()
+        else -> apuMemory[address]
+    }
+
+    private fun peekStatusRead(): Byte {
+        var status: Byte = 0
+        if (pulse1.getLengthCounterValue() > 0) status = status.setBit(0)
+        if (pulse2.getLengthCounterValue() > 0) status = status.setBit(1)
+        if (triangle.getLengthCounterValue() > 0) status = status.setBit(2)
+        if (noise.getLengthCounterValue() > 0) status = status.setBit(3)
+        if (dmc.getBytesRemaining() > 0) status = status.setBit(4)
+        if (frameIrq) status = status.setBit(6)
+        if (dmc.irqPending) status = status.setBit(7)
+        // Deliberately NOT clearing frameIrq / dmc IRQ — that is the side effect
+        // peek exists to avoid.
+        return status
+    }
+
     private fun handleStatusWrite(value: Byte) {
         apuMemory.status = value
 

--- a/src/main/kotlin/com/github/alondero/nestlin/Controller.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Controller.kt
@@ -88,6 +88,24 @@ class Controller {
         return (0x40 or data).toByte()
     }
 
+    /**
+     * Side-effect-free read of the value a `$4016`/`$4017` read would currently
+     * return, WITHOUT advancing the shift register (issue #168, Memory Editor).
+     *
+     * The real [read] shifts [shiftRegister] right by one and feeds in a 1 — so
+     * calling it from a debug viewer would desync the game's controller polling.
+     * [peek] computes the same next bit (the A button while strobe is high, else
+     * the shift register's LSB) but leaves all state untouched.
+     */
+    fun peek(): Byte {
+        val data = if (strobe) {
+            buttons and Button.A.mask
+        } else {
+            shiftRegister and 1
+        }
+        return (0x40 or data).toByte()
+    }
+
     fun saveState(out: DataOutput) {
         out.writeInt(buttons)
         out.writeInt(shiftRegister)

--- a/src/main/kotlin/com/github/alondero/nestlin/Memory.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Memory.kt
@@ -185,6 +185,39 @@ class Memory : DmaPort {
         return result
     }
 
+    /**
+     * Side-effect-free read of any CPU bus address (issue #168, Memory Editor).
+     *
+     * Returns the value [get] would return for ordinary backed storage, but
+     * triggers NONE of the read side effects that make [get] unsafe to call from a
+     * debug viewer:
+     *  - PPU `$2002`/`$2007`: no vblank clear, no write-toggle reset, no VRAM increment;
+     *  - APU `$4015`: no IRQ acknowledge;
+     *  - controller `$4016`/`$4017`: no shift-register advance;
+     *  - and crucially [dataBus] is NOT updated, so an open-bus mapper read on the
+     *    real CPU path still sees the last genuine CPU access, not a peek.
+     *
+     * One consequence of not touching [dataBus]: for the few mappers that emulate
+     * open-bus reads (returning their own latched bus value), peek reports that
+     * stale latch rather than re-deriving the bus the way [get] does. Open-bus is
+     * undefined anyway, so a viewer showing the last-driven value is acceptable —
+     * but peek is exact only for genuinely backed addresses.
+     *
+     * Thread safety: callers (the Memory Editor's 10 Hz UI timer) read this
+     * unsynchronised while the emulation thread mutates the same storage. Single
+     * `ByteArray` element reads are atomic per the JVM spec; a cosmetic torn read
+     * across two bytes is acceptable for a human-facing display (see ADR-0001).
+     */
+    fun peek(address: Int): Byte = when (address) {
+        in 0x0000..0x1FFF -> internalRam[address % 0x800]
+        in 0x2000..0x3FFF -> ppuAddressedMemory.peek(address % 8)
+        0x4016 -> controller1.peek()
+        0x4017 -> controller2.peek()
+        in 0x4000..0x401F -> apu?.peekRegisterRead(address - 0x4000) ?: apuAddressedMemory[address - 0x4000]
+        in 0x4020..0xFFFF -> mapper?.cpuPeek(address) ?: 0
+        else -> 0
+    }
+
     operator fun get(address1: Int, address2: Int): Short {
         val addr1 = this[address1].toUnsignedInt()
         val addr2 = this[address2].toUnsignedInt() shl 8

--- a/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
@@ -82,6 +82,15 @@ class Nestlin {
 
     fun ppuMask(): Int = memory.ppuAddressedMemory.mask.register.toUnsignedInt()
 
+    /**
+     * Side-effect-free read of a CPU bus address for the Memory Editor (issue #168).
+     * Delegates to [Memory.peek]; the same [memory] instance is reused across ROM
+     * loads and resets, so a viewer holding this reference keeps working without
+     * needing to reopen. See [Memory.peek] for the side-effect and thread-safety
+     * contract.
+     */
+    fun peekMemory(address: Int): Byte = memory.peek(address)
+
     fun powerReset() {
         cpu.reset()
         applyRegion()

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper.kt
@@ -8,6 +8,15 @@ import java.io.DataOutput
 interface Mapper {
     fun cpuRead(address: Int): Byte
     fun cpuWrite(address: Int, value: Byte)
+
+    /**
+     * Side-effect-free CPU read for the Memory Editor (issue #168). The default
+     * delegates to [cpuRead], which is already pure for every mapper currently
+     * implemented (bank lookups + PRG/CHR-RAM reads have no read side effects).
+     * Mappers that grow a read-triggered side effect later (e.g. a read-clocked
+     * IRQ counter) override this to return the backing byte without the effect.
+     */
+    fun cpuPeek(address: Int): Byte = cpuRead(address)
     fun ppuRead(address: Int): Byte
     fun ppuWrite(address: Int, value: Byte)
     fun currentMirroring(): MirroringMode

--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/PpuAddressedMemory.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/PpuAddressedMemory.kt
@@ -123,6 +123,30 @@ class PpuAddressedMemory {
         objectAttributeMemory.loadState(input)
     }
 
+    /**
+     * Side-effect-free read of a PPU register (issue #168, Memory Editor).
+     *
+     * Mirrors the value [get] would return but triggers NONE of the read side
+     * effects the real PPU has:
+     *  - `$2002` does NOT clear the vblank flag, the NMI latch, or the write toggle;
+     *  - `$2007` returns the read buffer ([data]) WITHOUT incrementing the VRAM
+     *    address (and without the palette fast-path, since that too would read
+     *    through to backing VRAM).
+     *
+     * [register] is the low 3 bits of the CPU address (`$2000-$2007`, mirrored
+     * every 8 bytes through `$3FFF`).
+     */
+    fun peek(register: Int): Byte = when (register and 7) {
+        0 -> controller.register
+        1 -> mask.register
+        2 -> status.register
+        3 -> oamAddress
+        4 -> objectAttributeMemory[oamAddress.toUnsignedInt()]
+        5 -> scroll
+        6 -> address
+        else /*7*/ -> data
+    }
+
     operator fun get(addr: Int): Byte {
         return when (addr) {
             0 -> controller.register

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
@@ -181,6 +181,13 @@ class NestlinApplication : FrameListener, Application() {
     // Load Recent submenu
     private val recentRomsMenu = Menu("Load Recent")
 
+    // Debug → Memory Editor (issue #168). The menu item is greyed out until a ROM
+    // is loaded; the window is created lazily on first open and reused thereafter.
+    // The same MemoryEditorWindow keeps refreshing across ROM loads/resets because
+    // it peeks through the long-lived Nestlin.memory instance.
+    private var memoryEditorMenuItem: MenuItem? = null
+    private var memoryEditorWindow: MemoryEditorWindow? = null
+
     // --- Movie record/playback state (issue #123) ---
     //
     // Exactly one of [liveRecorder] / [livePlayer] is non-null when a movie session is
@@ -354,6 +361,19 @@ class NestlinApplication : FrameListener, Application() {
             stopMovieItem.setOnAction { handleStopMovie() }
             movieMenu.items.addAll(startRecordItem, playMovieItem, stopMovieItem)
             menuBar.menus.add(movieMenu)
+
+            // Debug menu (issue #168). A single "Memory Editor" item (Ctrl+M) that
+            // opens the live hex viewer. Disabled until a ROM is loaded — peeking an
+            // empty bus is useless. updateDebugMenu() keeps the disable state in sync
+            // on every ROM change (alongside updateSlotMenu / updateTitle).
+            val debugMenu = javafx.scene.control.Menu("Debug")
+            val memoryEditorItem = MenuItem("Memory Editor")
+            memoryEditorItem.accelerator = javafx.scene.input.KeyCombination.keyCombination("Ctrl+M")
+            memoryEditorItem.setOnAction { handleOpenMemoryEditor() }
+            memoryEditorItem.isDisable = currentRomPath == null
+            memoryEditorMenuItem = memoryEditorItem
+            debugMenu.items.add(memoryEditorItem)
+            menuBar.menus.add(debugMenu)
 
             // Create layout with menu bar and the canvas holder. VBox.setVgrow lets the
             // holder expand to fill remaining vertical space in fullscreen / Fit mode.
@@ -665,6 +685,7 @@ class NestlinApplication : FrameListener, Application() {
                 Platform.runLater {
                     updateTitle()
                     updateSlotMenu()
+                    updateDebugMenu()
                 }
                 startEmulation()
             }
@@ -750,6 +771,7 @@ class NestlinApplication : FrameListener, Application() {
             updateTitle()
             // Refresh the slot menu: new ROM = new CRC = different slot files.
             updateSlotMenu()
+            updateDebugMenu()
             EmulatorConfig.addRecentRom(romPath)
             updateRecentMenu(EmulatorConfig.getRecentRoms())
             startEmulation()
@@ -760,6 +782,33 @@ class NestlinApplication : FrameListener, Application() {
     private fun clearPauseState() {
         nestlin.config.paused = false
         pauseMenuItem?.isSelected = false
+    }
+
+    /**
+     * Open the Memory Editor (issue #168), or focus it if already open. Lazily
+     * creates one [MemoryEditorWindow] and reuses it: the window peeks through the
+     * long-lived [Nestlin.memory], so it keeps refreshing across ROM loads and
+     * resets without needing to be recreated. The showing-property listener nulls
+     * our reference when the user closes the window so the next open builds fresh.
+     */
+    private fun handleOpenMemoryEditor() {
+        if (currentRomPath == null) return
+        val existing = memoryEditorWindow
+        if (existing != null) {
+            existing.show()
+            return
+        }
+        val window = MemoryEditorWindow { addr -> nestlin.peekMemory(addr) }
+        memoryEditorWindow = window
+        window.stage.showingProperty().addListener { _, _, showing ->
+            if (!showing) memoryEditorWindow = null
+        }
+        window.show()
+    }
+
+    /** Grey out the Debug → Memory Editor item when no ROM is loaded. */
+    private fun updateDebugMenu() {
+        memoryEditorMenuItem?.isDisable = currentRomPath == null
     }
 
     private fun setScaleMode(mode: ScaleMode) {
@@ -852,6 +901,7 @@ class NestlinApplication : FrameListener, Application() {
         // the new ROM's CRC. Without this, a user loading ROM B would see
         // ROM A's slot timestamps until they saved into a slot of their own.
         updateSlotMenu()
+        updateDebugMenu()
         startEmulation()
     }
 

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/MemoryEditorWindow.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/MemoryEditorWindow.kt
@@ -1,0 +1,103 @@
+package com.github.alondero.nestlin.ui
+
+import com.github.alondero.nestlin.toUnsignedInt
+import javafx.animation.Animation
+import javafx.animation.KeyFrame
+import javafx.animation.Timeline
+import javafx.event.EventHandler
+import javafx.scene.Scene
+import javafx.scene.control.ListCell
+import javafx.scene.control.ListView
+import javafx.scene.text.Font
+import javafx.stage.Stage
+import javafx.util.Duration
+
+/**
+ * The Memory Editor's live hex viewer — the tracer bullet for issue #168.
+ *
+ * A standalone floating [Stage] showing the entire CPU bus (`$0000-$FFFF`) as a
+ * scrollable hex grid: one row per 16 bytes, 4096 rows. A 10 Hz [Timeline]
+ * (ADR-0001) repaints the grid so values update live while the game runs.
+ *
+ * **Why a `ListView<Int>` of row indices.** JavaFX virtualises [ListView]: only
+ * the ~30-40 rows currently scrolled into view have live cells. The cell factory
+ * [peek]s memory directly inside `updateItem`, so [ListView.refresh] — which only
+ * re-runs `updateItem` on the *rendered* cells — naturally peeks just the visible
+ * rows per tick, never the full 64 KB. Scrolling to a new region costs nothing
+ * extra: the newly-visible cells peek their own bytes on render.
+ *
+ * This tracer is read-only (no editing, no change highlighting yet — those land
+ * with `poke` in a later slice of the parent #167).
+ */
+class MemoryEditorWindow(private val peek: (Int) -> Byte) {
+
+    val stage = Stage()
+
+    // Instance-level (not companion) so the pure [formatRow] in the companion can
+    // be unit-tested without booting the JavaFX toolkit a Font would require.
+    private val monoFont: Font = Font.font("Monospaced", 13.0)
+
+    private val listView = ListView<Int>().apply {
+        // One item per 16-byte row: row index 0..4095 → base address index*16.
+        items.setAll((0 until ROWS).toList())
+        isFocusTraversable = true
+        cellFactory = javafx.util.Callback {
+            object : ListCell<Int>() {
+                init {
+                    font = monoFont
+                }
+                override fun updateItem(item: Int?, empty: Boolean) {
+                    super.updateItem(item, empty)
+                    text = if (empty || item == null) null else formatRow(item, peek)
+                }
+            }
+        }
+    }
+
+    // 10 Hz repaint (ADR-0001). refresh() re-runs the cell factory on the visible
+    // cells only, so each tick peeks ~30-40 rows, not all 4096.
+    private val refreshTimer = Timeline(
+        KeyFrame(Duration.millis(REFRESH_INTERVAL_MS), EventHandler { listView.refresh() })
+    ).apply { cycleCount = Animation.INDEFINITE }
+
+    init {
+        stage.title = "Memory Editor"
+        // Float independently of the game canvas — not modal, not owned, so it can
+        // sit on a second monitor and never affects the game window's aspect ratio.
+        stage.scene = Scene(listView, 480.0, 600.0)
+        // Run the timer only while the window is actually showing, so a closed
+        // editor costs nothing.
+        stage.onShown = EventHandler { refreshTimer.play() }
+        stage.onHidden = EventHandler { refreshTimer.stop() }
+    }
+
+    /** Show the window, or bring it to the front if it's already open. */
+    fun show() {
+        if (stage.isShowing) stage.toFront() else stage.show()
+    }
+
+    companion object {
+        /** 16 bytes per row × 4096 rows = the full 64 KB CPU bus. */
+        const val ROWS = 0x10000 / 16
+
+        /** 10 Hz refresh per ADR-0001. */
+        const val REFRESH_INTERVAL_MS = 100.0
+
+        /**
+         * Render one 16-byte row as `"ADDR  B0 B1 ... B15"` (address + 16 hex bytes).
+         * Pure function of [rowIndex] and the [peek] provider — no JavaFX, so it's
+         * unit-testable on its own. [rowIndex] is 0..[ROWS]-1; the row covers CPU
+         * addresses `rowIndex*16 .. rowIndex*16+15`.
+         */
+        fun formatRow(rowIndex: Int, peek: (Int) -> Byte): String {
+            val base = rowIndex * 16
+            val sb = StringBuilder()
+            sb.append(String.format("%04X", base)).append("  ")
+            for (i in 0 until 16) {
+                sb.append(String.format("%02X", peek(base + i).toUnsignedInt()))
+                if (i != 15) sb.append(' ')
+            }
+            return sb.toString()
+        }
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/ApuPeekTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ApuPeekTest.kt
@@ -1,0 +1,65 @@
+package com.github.alondero.nestlin
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * [Apu.peekRegisterRead] — side-effect-free APU register reads for the Memory
+ * Editor (issue #168). The only APU register with a read side effect is $4015,
+ * whose real read ([Apu.handleRegisterRead] -> handleStatusRead) acknowledges the
+ * frame-counter and DMC IRQs. peek must report the same status but leave the IRQ
+ * flags pending, so a debug viewer can never swallow an interrupt the game wants.
+ */
+class ApuPeekTest {
+
+    private fun apuWithFrameIrqPending(): Apu {
+        val memory = Memory()
+        val apu = Apu(memory)
+        memory.apu = apu
+        // 4-step sequence, IRQ enabled (bit 7 = 0 mode, bit 6 = 0 inhibit).
+        apu.handleRegisterWrite(0x17, 0)
+        // Run the frame counter until it raises the frame IRQ (fires once per
+        // ~14,915-cycle NTSC sequence; the cap is a generous safety net).
+        var ticks = 0
+        while (!apu.isIrqPending() && ticks < 50_000) {
+            apu.tick()
+            ticks++
+        }
+        return apu
+    }
+
+    @Test
+    fun `peek of status does not clear pending IRQ flags`() {
+        val apu = apuWithFrameIrqPending()
+        assertThat("frame IRQ should be pending after running the frame counter",
+            apu.isIrqPending(), equalTo(true))
+
+        val peeked = apu.peekRegisterRead(0x15)
+
+        // The peeked status reports the frame IRQ (bit 6)...
+        assertThat(peeked.toInt() and 0x40, equalTo(0x40))
+        // ...and the IRQ is STILL pending — peek did not acknowledge it.
+        assertThat(apu.isIrqPending(), equalTo(true))
+    }
+
+    @Test
+    fun `real status read clears the IRQ that peek preserved`() {
+        val apu = apuWithFrameIrqPending()
+        apu.peekRegisterRead(0x15) // does not clear
+        assertThat(apu.isIrqPending(), equalTo(true))
+
+        apu.handleRegisterRead(0x15) // the real read acknowledges it
+        assertThat(apu.isIrqPending(), equalTo(false))
+    }
+
+    @Test
+    fun `peek of a non-status register returns the backing byte`() {
+        val memory = Memory()
+        val apu = Apu(memory)
+        memory.apu = apu
+        apu.handleRegisterWrite(0x03, 0xAB.toByte()) // pulse1 length/timer-high
+
+        assertThat(apu.peekRegisterRead(0x03), equalTo(0xAB.toByte()))
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/ControllerPeekTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ControllerPeekTest.kt
@@ -1,0 +1,46 @@
+package com.github.alondero.nestlin
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * [Controller.peek] — side-effect-free read of $4016/$4017 for the Memory Editor
+ * (issue #168). The real [Controller.read] advances the serial shift register;
+ * peek must return the same next bit without shifting, so a debug viewer polling
+ * the controller port can never desync the game's controller reads.
+ */
+class ControllerPeekTest {
+
+    @Test
+    fun `peek returns the next data bit without advancing the shift register`() {
+        val controller = Controller()
+        // Press A only, then strobe high->low to latch the button state.
+        controller.setButton(Controller.Button.A, true)
+        controller.write(1) // strobe high (reloads shift register from buttons)
+        controller.write(0) // strobe low (latches)
+
+        // peek repeatedly must keep returning bit 0 = A pressed = 1 (with open-bus 0x40).
+        assertThat(controller.peek(), equalTo(0x41.toByte()))
+        assertThat(controller.peek(), equalTo(0x41.toByte()))
+
+        // The real read consumes that bit; the NEXT bit (B, not pressed) is 0.
+        assertThat(controller.read(), equalTo(0x41.toByte()))
+        assertThat(controller.read(), equalTo(0x40.toByte()))
+    }
+
+    @Test
+    fun `peek does not disturb an in-progress read sequence`() {
+        val controller = Controller()
+        controller.setButton(Controller.Button.B, true) // bit 1 set
+        controller.write(1)
+        controller.write(0)
+
+        // Consume bit 0 (A = 0).
+        assertThat(controller.read(), equalTo(0x40.toByte()))
+        // Peeking now must report the upcoming bit 1 (B = 1) without consuming it.
+        assertThat(controller.peek(), equalTo(0x41.toByte()))
+        // The real read still sees B = 1, proving peek left the shift register alone.
+        assertThat(controller.read(), equalTo(0x41.toByte()))
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/MemoryPeekTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/MemoryPeekTest.kt
@@ -1,0 +1,74 @@
+package com.github.alondero.nestlin
+
+import com.github.alondero.nestlin.testutil.testGamePak
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * [Memory.peek] — the unified side-effect-free read across the whole CPU bus for
+ * the Memory Editor (issue #168). Verifies it dispatches to the correct backing
+ * store for each region, fires no read side effects, and — critically — never
+ * touches [Memory.dataBus] (which a real [Memory.get] always updates).
+ */
+class MemoryPeekTest {
+
+    @Test
+    fun `peek returns backing RAM value including mirrors`() {
+        val memory = Memory()
+        memory[0x0005] = 0x42
+
+        assertThat(memory.peek(0x0005), equalTo(0x42.toByte()))
+        // Internal RAM mirrors every $0800 through $1FFF.
+        assertThat(memory.peek(0x0805), equalTo(0x42.toByte()))
+        assertThat(memory.peek(0x1805), equalTo(0x42.toByte()))
+    }
+
+    @Test
+    fun `peek of PPU status does not clear vblank`() {
+        val memory = Memory()
+        memory.ppuAddressedMemory.setVBlank()
+
+        val peeked = memory.peek(0x2002)
+
+        assertThat(peeked.toInt() and 0x80, equalTo(0x80))
+        // A real read of $2002 clears the flag; peek must not.
+        assertThat(memory.ppuAddressedMemory.status.vBlankStarted(), equalTo(true))
+        // Mirrors of $2000-$2007 repeat every 8 bytes through $3FFF.
+        assertThat(memory.peek(0x3FFA).toInt() and 0x80, equalTo(0x80))
+    }
+
+    @Test
+    fun `peek does not update the data bus`() {
+        val memory = Memory()
+        memory[0x0005] = 0x42
+        memory.dataBus = 0x7E // sentinel
+
+        // Every region's peek must leave dataBus untouched (a real get sets it).
+        memory.peek(0x0005)  // RAM
+        memory.peek(0x2002)  // PPU
+        memory.peek(0x4016)  // controller
+        memory.peek(0x4015)  // APU
+
+        assertThat(memory.dataBus, equalTo(0x7E.toByte()))
+    }
+
+    @Test
+    fun `peek of cartridge space matches the mapper read`() {
+        val memory = Memory()
+        memory.readCartridge(testGamePak { mapper = 0; prgKb = 16; chrKb = 8 })
+        val mapper = memory.mapper!!
+
+        // cpuPeek defaults to cpuRead, so peek must agree with a direct mapper read
+        // across the $4020-$FFFF cartridge window (sampled).
+        for (addr in listOf(0x8000, 0xA000, 0xC000, 0xFFFC, 0xFFFF)) {
+            assertThat(memory.peek(addr), equalTo(mapper.cpuRead(addr)))
+        }
+    }
+
+    @Test
+    fun `peek of cartridge space returns 0 when no ROM is loaded`() {
+        val memory = Memory()
+        assertThat(memory.peek(0x8000), equalTo(0.toByte()))
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/MapperCpuPeekTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/MapperCpuPeekTest.kt
@@ -1,0 +1,23 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.github.alondero.nestlin.testutil.testGamePak
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * [Mapper.cpuPeek] default behaviour (issue #168). The default delegates to
+ * [Mapper.cpuRead], which is pure for every mapper currently implemented, so peek
+ * and read must agree byte-for-byte across the cartridge window.
+ */
+class MapperCpuPeekTest {
+
+    @Test
+    fun `default cpuPeek returns the same value as cpuRead`() {
+        val mapper = testGamePak { mapper = 0; prgKb = 32; chrKb = 8 }.createMapper()
+
+        for (addr in 0x8000..0xFFFF step 0x111) {
+            assertThat(mapper.cpuPeek(addr), equalTo(mapper.cpuRead(addr)))
+        }
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuAddressedMemoryPeekTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuAddressedMemoryPeekTest.kt
@@ -1,0 +1,72 @@
+package com.github.alondero.nestlin.ppu
+
+import com.github.alondero.nestlin.toSignedByte
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * [PpuAddressedMemory.peek] — side-effect-free PPU register reads for the
+ * Memory Editor (issue #168). The real [PpuAddressedMemory.get] mutates state on
+ * read ($2002 clears vblank + resets the write toggle, $2007 increments VRAM);
+ * peek must return the same value while touching nothing.
+ */
+class PpuAddressedMemoryPeekTest {
+
+    @Test
+    fun `peek returns the backing register bytes`() {
+        val ppu = PpuAddressedMemory()
+        ppu[0] = 0x80.toSignedByte() // PPUCTRL
+        ppu[1] = 0x1E.toSignedByte() // PPUMASK
+        ppu.oamAddress = 0x12
+
+        assertThat(ppu.peek(0), equalTo(0x80.toSignedByte()))
+        assertThat(ppu.peek(1), equalTo(0x1E.toSignedByte()))
+        assertThat(ppu.peek(3), equalTo(0x12.toSignedByte()))
+    }
+
+    @Test
+    fun `peek of status does not clear the vblank flag or nmi latch`() {
+        val ppu = PpuAddressedMemory()
+        ppu.setVBlank() // sets PPUSTATUS bit 7 and nmiOccurred
+
+        val peeked = ppu.peek(2)
+
+        // The peeked value reflects vblank being set...
+        assertThat(ppu.status.register.toInt() and 0x80, equalTo(0x80))
+        assertThat(peeked.toInt() and 0x80, equalTo(0x80))
+        // ...and crucially the flag is STILL set after peeking (a real read clears it).
+        assertThat(ppu.status.vBlankStarted(), equalTo(true))
+        assertThat(ppu.nmiOccurred, equalTo(true))
+    }
+
+    @Test
+    fun `peek of status does not reset the write toggle`() {
+        val ppu = PpuAddressedMemory()
+        // First $2006 write flips the toggle on and stages the high byte in t.
+        ppu[6] = 0x21.toSignedByte()
+
+        ppu.peek(2) // a real $2002 read would reset the toggle to false
+
+        // Second $2006 write: if the toggle is still ON, it sets the low byte and
+        // copies t -> v, so v becomes a non-zero address. If peek had reset the
+        // toggle, this would instead re-stage the high byte and v would stay 0.
+        ppu[6] = 0x08.toSignedByte()
+        assertThat(ppu.vRamAddress.asAddress(), equalTo(0x2108))
+    }
+
+    @Test
+    fun `peek of data returns the read buffer without incrementing VRAM`() {
+        val ppu = PpuAddressedMemory()
+        // Point VRAM at $2400 with the increment-by-1 mode (default).
+        ppu[6] = 0x24.toSignedByte()
+        ppu[6] = 0x00.toSignedByte()
+        val addrBefore = ppu.vRamAddress.asAddress()
+
+        ppu.peek(7)
+        ppu.peek(7)
+
+        // A real $2007 read increments the VRAM address each time; peek must not.
+        assertThat(ppu.vRamAddress.asAddress(), equalTo(addrBefore))
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/ui/MemoryEditorWindowTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ui/MemoryEditorWindowTest.kt
@@ -1,0 +1,41 @@
+package com.github.alondero.nestlin.ui
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-logic tests for [MemoryEditorWindow] (issue #168). Exercises the row
+ * formatting and grid dimensions without booting the JavaFX toolkit — the live
+ * Stage/ListView wiring is verified by hand and the side-effect-free read path it
+ * relies on has its own dedicated tests.
+ */
+class MemoryEditorWindowTest {
+
+    @Test
+    fun `grid covers the full 64 KB CPU bus at 16 bytes per row`() {
+        assertThat(MemoryEditorWindow.ROWS, equalTo(4096))
+        assertThat(MemoryEditorWindow.ROWS * 16, equalTo(0x10000))
+    }
+
+    @Test
+    fun `formatRow renders the address column and 16 hex bytes`() {
+        // Peek provider returns the low byte of each address, so the row content is
+        // predictable: row 0x10 covers $0100..$010F.
+        val peek: (Int) -> Byte = { addr -> (addr and 0xFF).toByte() }
+
+        val row = MemoryEditorWindow.formatRow(0x10, peek)
+
+        assertThat(row, equalTo("0100  00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F"))
+    }
+
+    @Test
+    fun `formatRow peeks exactly the 16 addresses of its row`() {
+        val peeked = mutableListOf<Int>()
+        val peek: (Int) -> Byte = { addr -> peeked.add(addr); 0 }
+
+        MemoryEditorWindow.formatRow(rowIndex = 0xFFF, peek = peek) // last row: $FFF0..$FFFF
+
+        assertThat(peeked, equalTo((0xFFF0..0xFFFF).toList()))
+    }
+}


### PR DESCRIPTION
Closes #168 — the tracer-bullet slice of the Memory Editor (parent #167).

## What this delivers
End-to-end, read-only live hex view of the whole CPU bus, backed by a new side-effect-free `peek()` read path that runs parallel to the real read path.

### Peek path (the foundation)
- `Memory.peek(addr)` dispatches the same address map as `get`, but with **no** side effects:
  - PPU `$2002`/`$2007`: no vblank clear, no write-toggle reset, no VRAM increment (`PpuAddressedMemory.peek`)
  - APU `$4015`: no frame/DMC IRQ acknowledge (`Apu.peekRegisterRead`)
  - Controller `$4016`/`$4017`: no shift-register advance (`Controller.peek`)
  - Cartridge: `Mapper.cpuPeek` (default delegates to `cpuRead`, pure for every current mapper)
  - **Never updates `dataBus`**, so the real CPU open-bus path is untouched.
- Exposed to the UI via `Nestlin.peekMemory`.

### UI
- `ui/MemoryEditorWindow`: floating Stage, virtualised `ListView` (4096 rows × 16 bytes) repainted at 10 Hz per **ADR-0001**. `ListView.refresh()` re-runs the cell factory only on the ~30–40 visible cells, so each tick peeks only the visible rows — never the full 64 KB.
- Debug menu → **Memory Editor** (Ctrl+M), greyed out until a ROM is loaded; the window is created lazily and survives ROM loads/resets via the long-lived `Memory` instance.

## Tests
- Side-effect-freedom for PPU, APU, controller, and the data bus (`*PeekTest.kt`).
- `cpuPeek == cpuRead` across the cartridge window.
- Pure row-formatting / grid-dimension tests for `MemoryEditorWindow` (no JavaFX toolkit needed).

## Deferred to later slices of #167
Editing / `poke` / change-highlighting. This slice is intentionally read-only.

## Verification
- `./gradlew build` green (full unit suite).
- `./gradlew bootcheck -Prom=...kirby.nes` → **PASS** (Mapper.kt was touched).
- The live JavaFX Stage wiring is the one piece without an automated test (no display in CI); a manual `./gradlew run` + Ctrl+M smoke-check is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)