### PR TITLE
Standardise workCyclesLeft on absolute assignment in Opcodes (issue #25)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/Opcodes.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/Opcodes.kt
@@ -168,7 +168,7 @@ class Opcodes {
         map[0x9a] = Opcode {
             it.apply {
                 it.registers.stackPointer = it.registers.indexX
-                it.workCyclesLeft += 2
+                it.workCyclesLeft = 2
             }
         } // TXS - Transfer X to Stack Pointer (doesn't set program counter)
         map[0xa8] = transfer ({it.accumulator}) { r, acc -> r.indexY = acc } //  TAY - Transfer A to Y
@@ -505,41 +505,41 @@ workCyclesLeft = 2
                 //  Relative addressing
                 registers.programCounter = (readByteAtPC() + registers.programCounter).toSignedShort()
 
-                workCyclesLeft++
+                workCyclesLeft = 3
                 if (hasCrossedPageBoundary(previousCounter, registers.programCounter)) pageBoundaryFlag = true
                 if ((previousCounter - 2).toSignedShort() == registers.programCounter) idle = true
             } else {
                 registers.programCounter++ // Increment the program counter
+                workCyclesLeft = 2
             }
-            workCyclesLeft += 2
         }
     }
 
     private fun storeOp(adr: (Cpu) -> Int, value: (Cpu) -> Byte) = Opcode {
         it.apply {
             memory[adr(it)] = value(it)
-            workCyclesLeft += 4
+            workCyclesLeft = 4
         }
     }
 
     private fun setOp(op: (Cpu) -> Unit) = Opcode {
         it.apply {
             op(it)
-            workCyclesLeft += 2
+            workCyclesLeft = 2
         }
     }
 
     private fun pushOp(value: (Cpu) -> Byte) = Opcode {
         it.apply {
             push(value(it))
-            workCyclesLeft += 3
+            workCyclesLeft = 3
         }
     }
 
     private fun clearOp(op: (Cpu) -> Unit) = Opcode {
         it.apply {
             op(it)
-            workCyclesLeft += 2
+            workCyclesLeft = 2
         }
     }
 
@@ -549,7 +549,7 @@ workCyclesLeft = 2
                 processorStatus.resolveZeroAndNegativeFlags(this)
             }
 
-            workCyclesLeft += 2
+            workCyclesLeft = 2
         }
     }
 
@@ -560,7 +560,7 @@ workCyclesLeft = 2
                 processorStatus.resolveZeroAndNegativeFlags(this)
             }
 
-            workCyclesLeft += 2
+            workCyclesLeft = 2
         }
     }
 
@@ -575,7 +575,7 @@ workCyclesLeft = 2
                 carry = register.toUnsignedInt() >= memValue.toUnsignedInt()
             }
 
-            workCyclesLeft += 2
+            workCyclesLeft = 2
         }
     }
 
@@ -585,7 +585,7 @@ workCyclesLeft = 2
                 processorStatus.resolveZeroAndNegativeFlags(this)
                 transfer(registers, this)
             }
-            workCyclesLeft += 2
+            workCyclesLeft = 2
         }
     }
 
@@ -604,7 +604,7 @@ workCyclesLeft = 2
                     ((currentAccumulator.toUnsignedInt() xor registers.accumulator.toUnsignedInt()) and 0x80 == 0x80)
             processorStatus.resolveZeroAndNegativeFlags(registers.accumulator)
 
-            workCyclesLeft += 2
+            workCyclesLeft = 2
         }
     }
 
@@ -623,7 +623,7 @@ workCyclesLeft = 2
                     ((currentAccumulator.toUnsignedInt() xor registers.accumulator.toUnsignedInt()) and 0x80 == 0x80)
             processorStatus.resolveZeroAndNegativeFlags(registers.accumulator)
 
-            workCyclesLeft += 6
+            workCyclesLeft = 6
         }
     }
 
@@ -637,7 +637,7 @@ workCyclesLeft = 2
             memory[address] = shiftedResult
             processorStatus.resolveZeroAndNegativeFlags(shiftedResult)
 
-            workCyclesLeft += 2
+            workCyclesLeft = 2
         }
     }
 
@@ -651,7 +651,7 @@ workCyclesLeft = 2
             memory[address] = shiftedResult
             processorStatus.resolveZeroAndNegativeFlags(shiftedResult)
 
-            workCyclesLeft += 2
+            workCyclesLeft = 2
         }
     }
 
@@ -666,7 +666,7 @@ workCyclesLeft = 2
             memory[address] = rotatedResult
             processorStatus.resolveZeroAndNegativeFlags(rotatedResult)
 
-            workCyclesLeft += 2
+            workCyclesLeft = 2
         }
     }
 
@@ -680,7 +680,7 @@ workCyclesLeft = 2
             memory[address] = (rotatedResult and 0xFF).toSignedByte()
             processorStatus.resolveZeroAndNegativeFlags((rotatedResult and 0xFF).toSignedByte())
 
-            workCyclesLeft += 2
+            workCyclesLeft = 2
         }
     }
 
@@ -692,7 +692,7 @@ workCyclesLeft = 2
             memory[address] = result
             processorStatus.resolveZeroAndNegativeFlags(result)
 
-            workCyclesLeft += 6
+            workCyclesLeft = 6
         }
     }
 
@@ -704,7 +704,7 @@ workCyclesLeft = 2
                 processorStatus.overflow = (this and 0b01000000) != 0
             }
 
-            workCyclesLeft += 3
+            workCyclesLeft = 3
         }
     }
 
@@ -753,14 +753,14 @@ workCyclesLeft = 2
             registers.accumulator = value
             registers.indexX = value
             processorStatus.resolveZeroAndNegativeFlags(value)
-            workCyclesLeft += 2
+            workCyclesLeft = 2
         }
     }
 
     private fun sax(addrFn: (Cpu) -> Int) = Opcode {
         it.apply {
             memory[addrFn(it)] = (registers.accumulator.toUnsignedInt() and registers.indexX.toUnsignedInt()).toSignedByte()
-            workCyclesLeft += 4
+            workCyclesLeft = 4
         }
     }
 
@@ -768,7 +768,7 @@ workCyclesLeft = 2
         it.apply {
             val value = (registers.accumulator.toUnsignedInt() and registers.indexX.toUnsignedInt() and 0x07).toSignedByte()
             memory[addrFn(it)] = value
-            workCyclesLeft += 4
+            workCyclesLeft = 4
         }
     }
 
@@ -819,7 +819,7 @@ workCyclesLeft = 2
             registers.indexX = value
             registers.stackPointer = value
             processorStatus.resolveZeroAndNegativeFlags(value)
-            workCyclesLeft += 4
+            workCyclesLeft = 4
         }
     }
 
@@ -832,7 +832,7 @@ workCyclesLeft = 2
             processorStatus.carry = comparison >= 0
             processorStatus.zero = comparison == 0
             processorStatus.negative = comparison.toSignedByte().isBitSet(7)
-            workCyclesLeft += 6
+            workCyclesLeft = 6
         }
     }
 
@@ -849,7 +849,7 @@ workCyclesLeft = 2
             processorStatus.overflow = ((currentAccumulator.toUnsignedInt() xor result.toUnsignedInt()) and 0x80 == 0x80) &&
                     ((currentAccumulator.toUnsignedInt() xor registers.accumulator.toUnsignedInt()) and 0x80 == 0x80)
             processorStatus.resolveZeroAndNegativeFlags(registers.accumulator)
-            workCyclesLeft += 6
+            workCyclesLeft = 6
         }
     }
 
@@ -863,7 +863,7 @@ workCyclesLeft = 2
             processorStatus.carry = newCarry
             registers.accumulator = (registers.accumulator.toUnsignedInt() and rotated.toUnsignedInt()).toSignedByte()
             processorStatus.resolveZeroAndNegativeFlags(registers.accumulator)
-            workCyclesLeft += 5
+            workCyclesLeft = 5
         }
     }
 
@@ -883,7 +883,7 @@ workCyclesLeft = 2
             processorStatus.overflow = ((currentAccumulator.toUnsignedInt() xor rotated.toUnsignedInt()) and 0x80 == 0x00) &&
                     ((currentAccumulator.toUnsignedInt() xor registers.accumulator.toUnsignedInt()) and 0x80 == 0x80)
             processorStatus.resolveZeroAndNegativeFlags(registers.accumulator)
-            workCyclesLeft += 5
+            workCyclesLeft = 5
         }
     }
 
@@ -896,7 +896,7 @@ workCyclesLeft = 2
             memory[address] = shifted
             registers.accumulator = (registers.accumulator.toUnsignedInt() or shifted.toUnsignedInt()).toSignedByte()
             processorStatus.resolveZeroAndNegativeFlags(registers.accumulator)
-            workCyclesLeft += 5
+            workCyclesLeft = 5
         }
     }
 
@@ -909,7 +909,7 @@ workCyclesLeft = 2
             memory[address] = shifted
             registers.accumulator = (registers.accumulator.toUnsignedInt() xor shifted.toUnsignedInt()).toSignedByte()
             processorStatus.resolveZeroAndNegativeFlags(registers.accumulator)
-            workCyclesLeft += 5
+            workCyclesLeft = 5
         }
     }
 
@@ -946,7 +946,7 @@ workCyclesLeft = 2
                 idle = true
             }
 
-            workCyclesLeft += 3
+            workCyclesLeft = 3
         }
     }
 

--- a/src/test/kotlin/com/github/alondero/nestlin/cpu/WorkCyclesLeftConsistencyTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cpu/WorkCyclesLeftConsistencyTest.kt
@@ -1,0 +1,175 @@
+package com.github.alondero.nestlin.cpu
+
+import com.github.alondero.nestlin.Memory
+import com.github.alondero.nestlin.toSignedByte
+import com.github.alondero.nestlin.toSignedShort
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression bar for issue #25 — `workCyclesLeft` mutation is inconsistent
+ * (`+= 2` mixed with `= 6`). The scheduler in [Cpu.tick] dispatches an
+ * instruction only when `workCyclesLeft <= 0`, so the convention *currently*
+ * produces the same observable behaviour either way. The contract these tests
+ * pin down is the one the refactor standardises on: every opcode sets
+ * `workCyclesLeft` to the **absolute** cycle count for that opcode.
+ *
+ * `tick()` decrements `workCyclesLeft` after the opcode runs, so immediately
+ * after a single `tick()` against an N-cycle instruction the field is `N - 1`,
+ * not `N`. The expected values below are written against that post-decrement
+ * value to keep the tests hermetic to the scheduler.
+ */
+class WorkCyclesLeftConsistencyTest {
+
+    private fun freshCpu() = Cpu(Memory()).apply { reset() }
+
+    @Test
+    fun nopImpliedSetsTwoCycles() {
+        val cpu = freshCpu()
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0xEA.toSignedByte() // NOP implied
+
+        cpu.tick()
+
+        // 2-cycle instruction, post-tick decrement leaves 1.
+        assertThat(cpu.workCyclesLeft, equalTo(1))
+    }
+
+    @Test
+    fun brkSetsSevenCycles() {
+        val cpu = freshCpu()
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x00.toSignedByte() // BRK
+        // BRK reads a 16-bit "return" address from PC; supply one so the
+        // bus reads don't bounce off unmapped memory.
+        cpu.memory[0x0001] = 0x00.toSignedByte()
+        cpu.memory[0x0002] = 0x80.toSignedByte()
+        // Reset vector -> $0000 so the loaded PC is sane if the test reuses
+        // the CPU; not strictly required for one tick.
+        cpu.memory[0xFFFE] = 0x00.toSignedByte()
+        cpu.memory[0xFFFF] = 0x00.toSignedByte()
+
+        cpu.tick()
+
+        // 7-cycle instruction, post-tick decrement leaves 6.
+        assertThat(cpu.workCyclesLeft, equalTo(6))
+    }
+
+    @Test
+    fun ldaImmediateSetsTwoCycles() {
+        val cpu = freshCpu()
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0xA9.toSignedByte() // LDA immediate
+        cpu.memory[0x0001] = 0x42.toSignedByte()
+
+        cpu.tick()
+
+        // 2-cycle instruction.
+        assertThat(cpu.workCyclesLeft, equalTo(1))
+    }
+
+    @Test
+    fun jsrSetsSixCycles() {
+        val cpu = freshCpu()
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x20.toSignedByte() // JSR absolute
+        cpu.memory[0x0001] = 0x00.toSignedByte() // low byte of target
+        cpu.memory[0x0002] = 0x80.toSignedByte() // high byte of target
+
+        cpu.tick()
+
+        // 6-cycle instruction, post-tick decrement leaves 5.
+        assertThat(cpu.workCyclesLeft, equalTo(5))
+    }
+
+    @Test
+    fun rtsSetsSixCycles() {
+        val cpu = freshCpu()
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x60.toSignedByte() // RTS
+        // RTS pops a 16-bit return address off the stack. Pre-populate the
+        // stack so pop() reads don't bounce off unmapped memory.
+        cpu.registers.stackPointer = 0xFE.toSignedByte()
+        cpu.memory[0x01FF] = 0x00.toSignedByte()
+        cpu.memory[0x0100] = 0x80.toSignedByte()
+
+        cpu.tick()
+
+        // 6-cycle instruction, post-tick decrement leaves 5.
+        assertThat(cpu.workCyclesLeft, equalTo(5))
+    }
+
+    @Test
+    fun clcImpliedSetsTwoCycles() {
+        val cpu = freshCpu()
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x18.toSignedByte() // CLC implied
+
+        cpu.tick()
+
+        // 2-cycle instruction.
+        assertThat(cpu.workCyclesLeft, equalTo(1))
+    }
+
+    @Test
+    fun nmiDispatchSetsSevenCycles() {
+        val cpu = freshCpu()
+        // NMI vector -> $0000 (a NOP, so we don't read garbage).
+        cpu.memory[0xFFFA] = 0x00.toSignedByte()
+        cpu.memory[0xFFFB] = 0x00.toSignedByte()
+        // Enable NMI generation (PPUCTRL bit 7) and mark vblank as occurred,
+        // matching what the PPU would do at scanline 241.
+        cpu.memory[0x2000] = 0x80.toSignedByte()
+        cpu.memory.ppuAddressedMemory.nmiOccurred = true
+        // The CPU is parked in a NOP at $0000.
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0xEA.toSignedByte()
+
+        // Scheduler timing for NMI dispatch (see Cpu.checkAndHandleNmi):
+        //   tick 1: ready, NMI not armed yet -> arms (returns false), then runs NOP
+        //           (workCyclesLeft becomes 2-1=1 after the post-opcode decrement)
+        //   tick 2: not ready (workCyclesLeft=1), just decrements to 0
+        //   tick 3: ready, NMI is now armed -> services it (workCyclesLeft=7, then 6)
+        // So 3 ticks are needed before the post-decrement 6 is visible.
+        repeat(3) { cpu.tick() }
+
+        // 7-cycle NMI service, post-tick decrement leaves 6.
+        assertThat(cpu.workCyclesLeft, equalTo(6))
+    }
+
+    @Test
+    fun bccBranchNotTakenSetsTwoCycles() {
+        val cpu = freshCpu()
+        // BCC $0010 with carry SET -> branch not taken (2 cycles).
+        // BCC = branch on carry CLEAR, so carry=set means no branch.
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x90.toSignedByte() // BCC relative
+        cpu.memory[0x0001] = 0x0E.toSignedByte() // offset +14 -> $0010
+        cpu.processorStatus.carry = true
+
+        cpu.tick()
+
+        // 2-cycle branch (not taken), post-tick decrement leaves 1.
+        assertThat(cpu.workCyclesLeft, equalTo(1))
+        // PC advanced past the 2-byte instruction (relative offset NOT applied).
+        assertThat(cpu.registers.programCounter, equalTo(0x0002.toSignedShort()))
+    }
+
+    @Test
+    fun bccBranchTakenSetsThreeCycles() {
+        val cpu = freshCpu()
+        // BCC $0010 with carry CLEAR -> branch taken (3 cycles, no page cross).
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x90.toSignedByte() // BCC relative
+        cpu.memory[0x0001] = 0x0E.toSignedByte() // offset +14 -> $0010
+        cpu.processorStatus.carry = false
+
+        cpu.tick()
+
+        // 3-cycle branch (taken, no page cross), post-tick decrement leaves 2.
+        assertThat(cpu.workCyclesLeft, equalTo(2))
+        // PC followed the relative offset.
+        assertThat(cpu.registers.programCounter, equalTo(0x0010.toSignedShort()))
+    }
+}


### PR DESCRIPTION
Closes #25.

## What

`Opcodes.kt` mixed `workCyclesLeft += N` (helper builders) with `workCyclesLeft = N` (one-off blocks). With `Cpu.tick()` only dispatching an instruction when `workCyclesLeft <= 0`, the two forms are observationally equivalent today, but the `+=` form is fragile: any future scheduler change that lets an opcode see a non-zero residual would silently double-count at the `+=` sites.

This PR standardises on `= N` (the absolute cycle count for that opcode) in all 30 helper-builder and one-off sites. The `branchOp` helper is also slightly restructured to set the absolute value in each arm (taken=3, not-taken=2) rather than the old `++` + `+= 2` accumulator pattern.

`Cpu.kt` was already clean (interrupt dispatch and the undocumented-opcode fallback all use `=`).

## Test

New `WorkCyclesLeftConsistencyTest` (9 tests) pins the cycle-count contract for: NOP, CLC, LDA imm, JSR, RTS, BRK, NMI dispatch, BCC taken, BCC not-taken. Each assertion is written against the post-decrement value (`N-1`) to stay hermetic to the scheduler.

`./gradlew test` → 602 tests, 0 failures, 6 ignored.

## Known follow-up (NOT in this PR)

The helper builders (`addToA`, `subtractFromA`, `load`, `storeOp`, `opWithA`, `compareOp`, shift/rotate, `unary`, `bit`) hardcode ONE cycle count for every addressing mode the helper is called for — so e.g. `addToA = 2` means ADC #imm is 2 (correct) but ADC $zp / $abs / (ind),Y are all 2 (wrong: real 6502 says 3/4/5). The scheduler invariant masks this as a uniform skew rather than a per-instruction bug, which is why the existing test suite stays green. A follow-up should thread a `cycles: Int` parameter into each helper so each call site passes the correct per-addressing-mode count.

Page-boundary +1 cycle accounting is also missing (`pageBoundaryFlag` is write-only) — pre-existing, separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)