### PR TITLE
Memory Editor: click-to-edit hex cells (poke) (#170)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/Memory.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Memory.kt
@@ -218,6 +218,37 @@ class Memory : DmaPort {
         else -> 0
     }
 
+    /**
+     * Write a byte to any CPU bus address from the Memory Editor (issue #170).
+     *
+     * Unlike [peek] (deliberately side-effect-free), poke is a *real* write: it
+     * delegates to [set] so the running game sees the new value on its very next
+     * read, and so genuine side effects fire — including mapper register writes
+     * that trigger bank switches, which power users rely on for experimentation.
+     *
+     * TWO addresses are blacklisted and silently dropped, because a hand-poked
+     * value there is never what the user means and the effect is catastrophic:
+     *  - `$4014` (OAM DMA): a write would halt the CPU for 513 cycles and overwrite
+     *    all 256 bytes of OAM from the page named by [value] — turning a stray
+     *    keystroke into a corrupted sprite table plus a timing desync.
+     *  - `$4016` (controller strobe): a write would reset both controllers' shift
+     *    registers, desyncing the game's input polling mid-frame.
+     *
+     * Note `$4017` is NOT blacklisted — a write there is the APU frame-counter
+     * register, a legitimate (if niche) thing to poke. Only the two registers
+     * whose *write* side effect would wreck the session are dropped; see ADR-0001
+     * and the CONTEXT.md "poke" glossary entry.
+     *
+     * Thread safety mirrors [peek]: callers are the Memory Editor's JavaFX timer /
+     * input handlers, writing unsynchronised while the emulation thread runs. A
+     * single byte store is atomic per the JVM spec, which is sufficient for a
+     * human-driven debug poke (ADR-0001).
+     */
+    fun poke(address: Int, value: Byte) {
+        if (address == 0x4014 || address == 0x4016) return
+        this[address] = value
+    }
+
     operator fun get(address1: Int, address2: Int): Short {
         val addr1 = this[address1].toUnsignedInt()
         val addr2 = this[address2].toUnsignedInt() shl 8

--- a/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
@@ -91,6 +91,14 @@ class Nestlin {
      */
     fun peekMemory(address: Int): Byte = memory.peek(address)
 
+    /**
+     * Write a byte to a CPU bus address from the Memory Editor (issue #170).
+     * Delegates to [Memory.poke], which applies full game-visible side effects
+     * (the running game sees the value on its next read) except for the
+     * blacklisted `$4014`/`$4016` I/O registers. See [Memory.poke].
+     */
+    fun pokeMemory(address: Int, value: Byte) = memory.poke(address, value)
+
     fun powerReset() {
         cpu.reset()
         applyRegion()

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
@@ -802,7 +802,10 @@ class NestlinApplication : FrameListener, Application() {
             existing.show()
             return
         }
-        val window = MemoryEditorWindow { addr -> nestlin.peekMemory(addr) }
+        val window = MemoryEditorWindow(
+            peek = { addr -> nestlin.peekMemory(addr) },
+            poke = { addr, value -> nestlin.pokeMemory(addr, value) },
+        )
         memoryEditorWindow = window
         window.stage.showingProperty().addListener { _, _, showing ->
             if (!showing) memoryEditorWindow = null

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/HexEditState.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/HexEditState.kt
@@ -1,0 +1,93 @@
+package com.github.alondero.nestlin.ui
+
+/**
+ * The Memory Editor's click-to-edit state machine (issue #170).
+ *
+ * Pure logic, no JavaFX: the window wires mouse clicks, hex keystrokes, and
+ * arrow keys to the methods here, and renders from the read-only state. Keeping
+ * it toolkit-free means the editing rules (how two nibbles combine, what arrow
+ * keys do, when a partial edit is abandoned) are unit-testable without booting
+ * the FX thread — the same split the project uses for [MemorySnapshot].
+ *
+ * The machine deliberately owns no memory. A completed two-nibble edit is
+ * returned as a [Poke] for the caller to apply via `Memory.poke`; the editor
+ * stays decoupled from the bus and the blacklist lives in one place.
+ *
+ * Editing model (PRD user stories 9–11):
+ *  - **Select** a cell by clicking ([select]); a selected cell can be edited.
+ *  - **Type** a hex digit ([typeHexDigit]). The first digit is buffered as
+ *    [pendingNibble] (shown as a partial edit like `A_`); the second completes
+ *    the byte and yields a [Poke].
+ *  - **Navigate** with arrow keys ([move]); 16 columns per row. Moving abandons
+ *    any half-typed nibble — pressing an arrow is a navigation action, not a
+ *    commit.
+ */
+class HexEditState {
+
+    /** The CPU address of the currently selected cell, or null if none. */
+    var selectedAddress: Int? = null
+        private set
+
+    /**
+     * The high nibble of a half-typed byte (0..15), or null when no edit is in
+     * progress. The renderer shows this as a partial edit (`A_`) so the user
+     * gets feedback that the first keystroke registered (PRD user story 10).
+     */
+    var pendingNibble: Int? = null
+        private set
+
+    /** Select [address] for editing, abandoning any in-progress partial edit. */
+    fun select(address: Int) {
+        require(address in 0..0xFFFF) { "address must be a 16-bit CPU address, got $address" }
+        selectedAddress = address
+        pendingNibble = null
+    }
+
+    /** Clear the selection entirely (e.g. when the editor loses focus). */
+    fun clearSelection() {
+        selectedAddress = null
+        pendingNibble = null
+    }
+
+    /**
+     * Move the selection by [dCol] columns and [dRow] rows (16 bytes per row),
+     * clamping to the `$0000-$FFFF` bus rather than wrapping. No-op when nothing
+     * is selected. Always abandons a pending nibble — arrow keys navigate, they
+     * don't commit a half-typed byte.
+     */
+    fun move(dCol: Int, dRow: Int) {
+        val current = selectedAddress ?: return
+        pendingNibble = null
+        val target = current + dCol + dRow * 16
+        if (target in 0..0xFFFF) {
+            selectedAddress = target
+        }
+        // Out-of-range target: keep the current selection (clamp, no wrap).
+    }
+
+    /**
+     * Feed one hex digit ([nibble], 0..15) to the selected cell.
+     *
+     * Returns null and buffers [nibble] as [pendingNibble] when it's the first
+     * digit of a byte; returns the completed [Poke] (and clears the buffer) when
+     * it's the second. No-op returning null when nothing is selected.
+     */
+    fun typeHexDigit(nibble: Int): Poke? {
+        require(nibble in 0..15) { "nibble must be 0..15, got $nibble" }
+        val address = selectedAddress ?: return null
+        val high = pendingNibble
+        return if (high == null) {
+            pendingNibble = nibble
+            null
+        } else {
+            pendingNibble = null
+            Poke(address, (high shl 4) or nibble)
+        }
+    }
+
+    /**
+     * A completed two-nibble edit: write [value] (0..255) to [address]. The
+     * caller applies it through `Memory.poke`, which owns the I/O blacklist.
+     */
+    data class Poke(val address: Int, val value: Int)
+}

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/MemoryEditorWindow.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/MemoryEditorWindow.kt
@@ -10,6 +10,9 @@ import javafx.scene.Node
 import javafx.scene.Scene
 import javafx.scene.control.ListCell
 import javafx.scene.control.ListView
+import javafx.scene.input.KeyCode
+import javafx.scene.input.KeyEvent
+import javafx.scene.input.MouseEvent
 import javafx.scene.layout.HBox
 import javafx.scene.layout.StackPane
 import javafx.scene.text.Font
@@ -48,8 +51,24 @@ import java.util.TreeSet
  * `previousVisibleBytes` is also dropped so the diff restarts from a clean
  * baseline — without that, cells that happened to share the same value across
  * the reset would never flash.
+ *
+ * **Click-to-edit (issue #170).** Clicking a byte cell selects it (drawn with a
+ * border); typing two hex digits overwrites the byte via [poke] (the game sees
+ * it on its next read); arrow keys move the selection. All the editing *rules*
+ * live in the pure [HexEditState] — this window only translates JavaFX mouse /
+ * key events into calls on it and renders its state. A completed edit's natural
+ * change-highlight (the next tick's diff flashes the poked cell green/blue) is
+ * the visual confirmation, so no special post-poke flash is needed.
  */
-class MemoryEditorWindow(private val peek: (Int) -> Byte) {
+class MemoryEditorWindow(
+    private val peek: (Int) -> Byte,
+    private val poke: (Int, Byte) -> Unit,
+) {
+
+    // The pure selection / pending-nibble / navigation state machine (issue #170).
+    // Mutated only on the JavaFX thread (mouse + key handlers); the cell factory
+    // reads it to render the selection border and any partial edit.
+    private val editState = HexEditState()
 
     val stage = Stage()
 
@@ -87,11 +106,18 @@ class MemoryEditorWindow(private val peek: (Int) -> Byte) {
                         // children inside the HBox use the monospaced font —
                         // they don't inherit the cell's font automatically.
                         text = null
-                        graphic = renderRow(item, peek, ::currentDirection, ::currentAge, monoFont)
+                        graphic = renderRow(
+                            item, peek, ::currentDirection, ::currentAge, monoFont,
+                            editState.selectedAddress, editState.pendingNibble, ::onByteClicked,
+                        )
                     }
                 }
             }
         }
+        // Arrow keys would otherwise scroll the ListView's own row selection; we
+        // want them to move the *cell* selection instead. A KEY_PRESSED filter on
+        // the ListView intercepts hex digits and arrows before the skin sees them.
+        addEventFilter(KeyEvent.KEY_PRESSED) { event -> handleKeyPressed(event) }
     }
 
     // 10 Hz repaint (ADR-0001). [onRefreshTick] peeks + diffs the visible range
@@ -308,7 +334,113 @@ class MemoryEditorWindow(private val peek: (Int) -> Byte) {
     private fun currentAge(addr: Int): Int =
         highlightAge[addr] ?: 0
 
+    // ---- Click-to-edit input handling (issue #170) --------------------------
+
+    /**
+     * A byte cell was clicked: select it and repaint so the border appears
+     * immediately (rather than waiting up to 100 ms for the next refresh tick).
+     * Also pull keyboard focus to the ListView so the subsequent hex/arrow keys
+     * are delivered to [handleKeyPressed].
+     */
+    private fun onByteClicked(addr: Int) {
+        editState.select(addr)
+        listView.requestFocus()
+        listView.refresh()
+    }
+
+    /**
+     * Translate a key press into an edit action on [editState]:
+     *  - a hex digit (0-9 / A-F, either case) feeds [HexEditState.typeHexDigit];
+     *    a completed two-nibble byte is applied via [applyPoke];
+     *  - an arrow key moves the selection one cell (consumed so the ListView's
+     *    own row navigation doesn't also fire);
+     *  - Escape clears the selection.
+     *
+     * Anything else is left for the ListView (e.g. Page Up/Down scrolling). The
+     * handler is a no-op when nothing is selected, so the editor still scrolls
+     * normally before the user has clicked a cell.
+     */
+    private fun handleKeyPressed(event: KeyEvent) {
+        val nibble = hexDigit(event.code)
+        when {
+            // Only act on (and consume) a hex digit when a cell is actually
+            // selected — otherwise leave the key for the ListView so we don't
+            // silently swallow keystrokes the editor isn't going to use.
+            nibble != null && editState.selectedAddress != null -> {
+                val pokeRequest = editState.typeHexDigit(nibble)
+                if (pokeRequest != null) applyPoke(pokeRequest)
+                listView.refresh()
+                event.consume()
+            }
+            event.code == KeyCode.LEFT -> moveSelection(dCol = -1, dRow = 0, event)
+            event.code == KeyCode.RIGHT -> moveSelection(dCol = 1, dRow = 0, event)
+            event.code == KeyCode.UP -> moveSelection(dCol = 0, dRow = -1, event)
+            event.code == KeyCode.DOWN -> moveSelection(dCol = 0, dRow = 1, event)
+            event.code == KeyCode.ESCAPE && editState.selectedAddress != null -> {
+                editState.clearSelection()
+                listView.refresh()
+                event.consume()
+            }
+        }
+    }
+
+    /** Move the cell selection, scroll it into view, repaint. Consumes the event. */
+    private fun moveSelection(dCol: Int, dRow: Int, event: KeyEvent) {
+        if (editState.selectedAddress == null) return // let the ListView scroll
+        editState.move(dCol, dRow)
+        // Only scroll when the target row is off-screen — scrolling on every
+        // arrow press (e.g. moving LEFT/RIGHT within a visible row) would jolt
+        // the viewport unnecessarily.
+        editState.selectedAddress?.let {
+            val row = it / 16
+            if (!isRowVisible(row)) listView.scrollTo(row)
+        }
+        listView.refresh()
+        event.consume()
+    }
+
+    /** True if [row] currently has a live (on-screen) ListCell. */
+    private fun isRowVisible(row: Int): Boolean =
+        listView.lookupAll(".list-cell").any { it is ListCell<*> && it.index == row }
+
+    /**
+     * Apply a completed edit through the [poke] callback (which routes to
+     * `Memory.poke` and its I/O blacklist). The poked cell isn't flashed here —
+     * the next refresh tick's diff sees the new value and highlights it
+     * green/blue naturally, which is the user's confirmation the write landed.
+     */
+    private fun applyPoke(request: HexEditState.Poke) {
+        poke(request.address, request.value.toByte())
+    }
+
     companion object {
+
+        /**
+         * Map a [KeyCode] to its hex nibble (0..15), or null if it isn't a hex
+         * digit. Covers the number row, the numpad (DIGIT/NUMPAD variants), and
+         * A-F. Case is irrelevant — [KeyCode] is the physical key, not the typed
+         * character.
+         */
+        fun hexDigit(code: KeyCode): Int? = when (code) {
+            KeyCode.DIGIT0, KeyCode.NUMPAD0 -> 0
+            KeyCode.DIGIT1, KeyCode.NUMPAD1 -> 1
+            KeyCode.DIGIT2, KeyCode.NUMPAD2 -> 2
+            KeyCode.DIGIT3, KeyCode.NUMPAD3 -> 3
+            KeyCode.DIGIT4, KeyCode.NUMPAD4 -> 4
+            KeyCode.DIGIT5, KeyCode.NUMPAD5 -> 5
+            KeyCode.DIGIT6, KeyCode.NUMPAD6 -> 6
+            KeyCode.DIGIT7, KeyCode.NUMPAD7 -> 7
+            KeyCode.DIGIT8, KeyCode.NUMPAD8 -> 8
+            KeyCode.DIGIT9, KeyCode.NUMPAD9 -> 9
+            KeyCode.A -> 0xA
+            KeyCode.B -> 0xB
+            KeyCode.C -> 0xC
+            KeyCode.D -> 0xD
+            KeyCode.E -> 0xE
+            KeyCode.F -> 0xF
+            else -> null
+        }
+
         /** 16 bytes per row × 4096 rows = the full 64 KB CPU bus. */
         const val ROWS = 0x10000 / 16
 
@@ -378,6 +510,18 @@ class MemoryEditorWindow(private val peek: (Int) -> Byte) {
          * [directionAt] and [ageAt] are lookup functions rather than direct
          * collections so the cell factory can stay decoupled from the window's
          * internal maps — useful for testing and for future renderer swaps.
+         *
+         * **Selection + editing (issue #170).** The cell whose address equals
+         * [selectedAddress] gets an amber ring so the user can see what they're
+         * about to edit. While a partial edit is in progress (the user has typed
+         * the first of two nibbles), [pendingNibble] is non-null and the selected
+         * cell shows `"X_"` (e.g. `A_`) instead of its current byte — the
+         * underscore reads as "waiting for the second digit". Every byte cell
+         * gets a click handler ([onByteClick]) so a click selects it. A cell that
+         * needs a background (fading) and/or a selection ring is wrapped in a
+         * [StackPane]; the ring is drawn with layered `-fx-background-color` +
+         * `-fx-background-insets` (NOT `-fx-border-width`) so a selected cell
+         * stays the exact width of a bare byte — the issue #169 invariant.
          */
         fun renderRow(
             rowIndex: Int,
@@ -385,6 +529,9 @@ class MemoryEditorWindow(private val peek: (Int) -> Byte) {
             directionAt: (Int) -> Direction,
             ageAt: (Int) -> Int,
             font: Font,
+            selectedAddress: Int?,
+            pendingNibble: Int?,
+            onByteClick: (Int) -> Unit,
         ): Node {
             val base = rowIndex * 16
             val row = HBox().apply {
@@ -395,39 +542,65 @@ class MemoryEditorWindow(private val peek: (Int) -> Byte) {
 
             for (i in 0 until 16) {
                 val addr = base + i
-                val byteText = Text(String.format("%02X", peek(addr).toUnsignedInt())).apply {
-                    this.font = font
-                }
-                val age = ageAt(addr)
+                val selected = addr == selectedAddress
 
-                if (age > 0) {
-                    val direction = directionAt(addr)
-                    // Linear alpha: 1.0 at FADE_TICKS, 0.0 at 1. Multiplied by
-                    // 0.5 so the tint reads as a subtle highlight rather than a
-                    // solid block — readability of the hex digits matters more
-                    // than the colour's saturation.
-                    val alpha = (age.toDouble() / FADE_TICKS) * 0.5
-                    val (r, g, b) = when (direction) {
+                // Selected cell mid-edit shows the half-typed nibble as "X_";
+                // otherwise the live byte value. Both are two monospaced chars,
+                // so the cell width never changes between display and edit.
+                val label = if (selected && pendingNibble != null) {
+                    String.format("%X_", pendingNibble)
+                } else {
+                    String.format("%02X", peek(addr).toUnsignedInt())
+                }
+                val byteText = Text(label).apply { this.font = font }
+
+                val age = ageAt(addr)
+                // The fade tint (issue #169), if this cell is currently changing.
+                // Linear alpha: 1.0 at FADE_TICKS, 0.0 at 1, then halved so the
+                // tint stays subtle enough to read the digits through it.
+                val fadeFill: String? = if (age > 0) {
+                    val (r, g, b) = when (directionAt(addr)) {
                         Direction.UP -> UP_COLOR
                         Direction.DOWN -> DOWN_COLOR
                         Direction.UNCHANGED -> DEFAULT_COLOR
                     }
-                    val cellBox = StackPane().apply {
-                        alignment = Pos.CENTER
-                        // No padding: a highlighted cell must be the same width
-                        // as a bare Text node, otherwise the row's total width
-                        // grows when bytes start flashing and the row wraps
-                        // (the original bug — see issue #169 wrap report). The
-                        // 2-px background-radius gives the highlight a soft edge
-                        // even with no padding.
-                        style = "-fx-background-color: rgba($r, $g, $b, $alpha);" +
-                                "-fx-background-radius: 2;"
+                    val alpha = (age.toDouble() / FADE_TICKS) * 0.5
+                    "rgba($r, $g, $b, $alpha)"
+                } else null
+
+                val node: Node = if (fadeFill != null || selected) {
+                    val style = if (selected) {
+                        // Draw the selection as a 1px ring via *background* layers
+                        // + `-fx-background-insets`, NOT `-fx-border-width`. A real
+                        // border adds 2px to the cell's layout size, which would
+                        // re-introduce issue #169's row-width-growth landmine (a
+                        // selected cell must stay the exact width of a bare byte).
+                        // Layer 0 (inset 0) = amber ring; layer 1 (inset 1) = the
+                        // fade tint, or transparent when the cell isn't fading.
+                        val (r, g, b) = SELECT_COLOR
+                        val inner = fadeFill ?: "transparent"
+                        "-fx-background-color: rgb($r, $g, $b), $inner;" +
+                            "-fx-background-insets: 0, 1;" +
+                            "-fx-background-radius: 2, 1;"
+                    } else {
+                        // Fading only: a single tinted background, exactly as #169.
+                        "-fx-background-color: $fadeFill;" +
+                            "-fx-background-radius: 2;"
                     }
-                    cellBox.children.add(byteText)
-                    row.children.add(cellBox)
+                    StackPane().apply {
+                        alignment = Pos.CENTER
+                        // No padding / no border-width: a background-only StackPane
+                        // sizes to its content, so a highlighted or selected cell is
+                        // the same width as a bare Text node (the issue #169 invariant).
+                        this.style = style
+                        children.add(byteText)
+                    }
                 } else {
-                    row.children.add(byteText)
+                    byteText
                 }
+
+                node.onMouseClicked = EventHandler<MouseEvent> { onByteClick(addr) }
+                row.children.add(node)
 
                 if (i != 15) {
                     row.children.add(Text(" ").apply { this.font = font })
@@ -442,5 +615,11 @@ class MemoryEditorWindow(private val peek: (Int) -> Byte) {
         private val UP_COLOR = Triple(46, 204, 64)     // green
         private val DOWN_COLOR = Triple(52, 152, 219)   // blue/cyan
         private val DEFAULT_COLOR = Triple(0, 0, 0)     // sentinel; never used (UNCHECKED never reaches the renderer)
+
+        // Selection border (issue #170): a warm gold that reads clearly as
+        // "this is the edit cursor" against both the default background and the
+        // muted green/blue change tints — distinct from either so a selected
+        // cell that's also fading is unambiguous.
+        private val SELECT_COLOR = Triple(255, 193, 7)  // amber/gold
     }
 }

--- a/src/test/kotlin/com/github/alondero/nestlin/MemoryPokeTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/MemoryPokeTest.kt
@@ -1,0 +1,103 @@
+package com.github.alondero.nestlin
+
+import com.github.alondero.nestlin.cpu.Cpu
+import com.github.alondero.nestlin.testutil.testGamePak
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * [Memory.poke] — the Memory Editor's write path (issue #170). Unlike [Memory.peek]
+ * (which is deliberately side-effect-free), poke is a *real* write that the running
+ * game must see on its next read. It delegates to [Memory.set] for full side effects
+ * — including mapper bank switches — EXCEPT two catastrophic I/O registers which are
+ * silently dropped:
+ *
+ *  - `$4014` (OAM DMA): would halt the CPU for 513 cycles and overwrite all of OAM
+ *    from an arbitrary RAM page — a hand-poked value here is never what the user means.
+ *  - `$4016` (controller strobe): would reset the controller shift registers and
+ *    desync the game's input polling.
+ *
+ * Everything else — RAM, PPU registers, APU registers, mapper registers — passes
+ * through so the user can cheat or experiment freely.
+ */
+class MemoryPokeTest {
+
+    @Test
+    fun `poke writes through to RAM and the game's read path sees it`() {
+        val memory = Memory()
+
+        memory.poke(0x0076, 0x09) // e.g. the lives counter from the issue
+
+        // get() is the path the running game uses; it must observe the poked value.
+        assertThat(memory[0x0076], equalTo(0x09.toByte()))
+        // Internal RAM mirrors every $0800; the poke went to backing storage so the
+        // mirror reflects it too.
+        assertThat(memory[0x0876], equalTo(0x09.toByte()))
+    }
+
+    @Test
+    fun `poke of 4014 does not trigger OAM DMA`() {
+        val memory = Memory()
+        val cpu = Cpu(memory)
+        memory.cpu = cpu
+        // Seed a recognisable page so we'd notice if a DMA copied it into OAM.
+        for (i in 0 until 256) memory[0x0100 + i] = i.toSignedByte()
+
+        memory.poke(0x4014, 0x01) // page $01 — would DMA into OAM if honoured
+
+        // A real $4014 write halts the CPU for 513 cycles; the blacklist must skip it.
+        assertThat(cpu.workCyclesLeft, equalTo(0))
+        // And OAM must be untouched (still all zero), not the page we seeded.
+        for (i in 0 until 256) {
+            assertThat(
+                "OAM[$i] must be untouched by a blacklisted \$4014 poke",
+                memory.ppuAddressedMemory.objectAttributeMemory[i].toUnsignedInt(),
+                equalTo(0)
+            )
+        }
+    }
+
+    @Test
+    fun `poke of 4016 does not strobe the controllers`() {
+        val memory = Memory()
+        memory.controller1.buttons = 0xFF
+
+        // Latch the 0xFF button state into the shift register: strobe high reloads,
+        // strobe low latches.
+        memory[0x4016] = 1
+        memory[0x4016] = 0
+
+        // Change the live buttons. An errant $4016 write with bit 0 high would set
+        // strobe high again and reload the shift register from this NEW value,
+        // destroying the latched 0xFF.
+        memory.controller1.buttons = 0x00
+
+        memory.poke(0x4016, 1) // blacklisted — must NOT reach Controller.write
+
+        // Because strobe stayed low and the latch survived, the first read returns
+        // the latched LSB (1 from 0xFF). If the poke had strobed, read() would see
+        // strobe-high and return buttons&A == 0 instead.
+        assertThat(memory.controller1.read().toInt() and 1, equalTo(1))
+    }
+
+    @Test
+    fun `poke of a mapper register triggers the bank switch`() {
+        val memory = Memory()
+        // Mapper 2 (UNROM): $8000-$BFFF is the switchable 16KB PRG window, selected
+        // by the low 3 bits of any $8000-$FFFF write. 128KB = 8 banks; stamp each
+        // bank's first byte with its index so the mapped bank is directly readable.
+        memory.readCartridge(testGamePak {
+            mapper = 2
+            prgKb = 128
+            chrKb = 8
+            stampPrgBanks(windowKb = 16)
+        })
+
+        memory.poke(0x8000, 0x03) // select PRG bank 3 into $8000-$BFFF
+
+        // The game's read path (and the editor's peek) now see bank 3's stamp.
+        assertThat(memory[0x8000], equalTo(0x03.toByte()))
+        assertThat(memory.peek(0x8000), equalTo(0x03.toByte()))
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/ui/HexEditStateTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ui/HexEditStateTest.kt
@@ -1,0 +1,135 @@
+package com.github.alondero.nestlin.ui
+
+import com.natpryce.hamkrest.absent
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.present
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-logic tests for [HexEditState] (issue #170) — the Memory Editor's
+ * click-to-select / type-two-nibbles / arrow-navigate state machine, extracted
+ * from the JavaFX window so it can be tested without the toolkit.
+ *
+ * The machine owns no memory: a completed two-nibble edit is returned as a
+ * [HexEditState.Poke] for the caller to apply via `Memory.poke`. Everything the
+ * UI needs to render (which cell is selected, whether a half-typed nibble is
+ * pending) is exposed as read-only state.
+ */
+class HexEditStateTest {
+
+    @Test
+    fun `starts with nothing selected and no pending nibble`() {
+        val state = HexEditState()
+        assertThat(state.selectedAddress, absent())
+        assertThat(state.pendingNibble, absent())
+    }
+
+    @Test
+    fun `select sets the address and clears any pending nibble`() {
+        val state = HexEditState()
+        state.select(0x0076)
+        state.typeHexDigit(0xA) // half-typed
+        assertThat(state.pendingNibble, equalTo(0xA))
+
+        state.select(0x0100)
+        assertThat(state.selectedAddress, equalTo(0x0100))
+        assertThat(state.pendingNibble, absent()) // re-selecting abandons the partial edit
+    }
+
+    @Test
+    fun `typing two hex digits returns a poke combining high then low nibble`() {
+        val state = HexEditState()
+        state.select(0x0076)
+
+        val firstResult = state.typeHexDigit(0xA)
+        // First nibble is buffered, not committed — no poke yet, partial shown.
+        assertThat(firstResult, absent())
+        assertThat(state.pendingNibble, equalTo(0xA))
+
+        val secondResult = state.typeHexDigit(0x5)
+        // Second nibble completes the byte 0xA5 at the selected address.
+        assertThat(secondResult, present(equalTo(HexEditState.Poke(0x0076, 0xA5))))
+        // Pending clears so the next two digits start a fresh byte.
+        assertThat(state.pendingNibble, absent())
+    }
+
+    @Test
+    fun `a third digit starts a new byte's high nibble`() {
+        val state = HexEditState()
+        state.select(0x0076)
+        state.typeHexDigit(0x1)
+        assertThat(state.typeHexDigit(0x2), present(equalTo(HexEditState.Poke(0x0076, 0x12))))
+
+        // Third keystroke begins a new pending nibble, no poke.
+        assertThat(state.typeHexDigit(0xF), absent())
+        assertThat(state.pendingNibble, equalTo(0xF))
+    }
+
+    @Test
+    fun `typing with nothing selected is a no-op`() {
+        val state = HexEditState()
+        assertThat(state.typeHexDigit(0xA), absent())
+        assertThat(state.pendingNibble, absent())
+    }
+
+    @Test
+    fun `arrow navigation moves by columns and rows and clamps to the bus`() {
+        val state = HexEditState()
+        state.select(0x0010)
+
+        state.move(dCol = 1, dRow = 0)
+        assertThat(state.selectedAddress, equalTo(0x0011)) // right
+
+        state.move(dCol = -1, dRow = 0)
+        assertThat(state.selectedAddress, equalTo(0x0010)) // left
+
+        state.move(dCol = 0, dRow = 1)
+        assertThat(state.selectedAddress, equalTo(0x0020)) // down one row = +16
+
+        state.move(dCol = 0, dRow = -1)
+        assertThat(state.selectedAddress, equalTo(0x0010)) // up one row = -16
+    }
+
+    @Test
+    fun `move clamps at the bus boundaries instead of wrapping`() {
+        val state = HexEditState()
+
+        state.select(0x0000)
+        state.move(dCol = -1, dRow = 0) // would go to -1
+        assertThat(state.selectedAddress, equalTo(0x0000)) // clamped, no wrap
+
+        state.select(0xFFFF)
+        state.move(dCol = 1, dRow = 0) // would go to 0x10000
+        assertThat(state.selectedAddress, equalTo(0xFFFF)) // clamped, no wrap
+    }
+
+    @Test
+    fun `move abandons a pending nibble`() {
+        val state = HexEditState()
+        state.select(0x0010)
+        state.typeHexDigit(0xA)
+        assertThat(state.pendingNibble, equalTo(0xA))
+
+        state.move(dCol = 1, dRow = 0)
+        assertThat(state.pendingNibble, absent()) // navigating away discards the half-typed byte
+    }
+
+    @Test
+    fun `move with nothing selected is a no-op`() {
+        val state = HexEditState()
+        state.move(dCol = 1, dRow = 0)
+        assertThat(state.selectedAddress, absent())
+    }
+
+    @Test
+    fun `clearSelection resets selection and pending`() {
+        val state = HexEditState()
+        state.select(0x0010)
+        state.typeHexDigit(0xA)
+
+        state.clearSelection()
+        assertThat(state.selectedAddress, absent())
+        assertThat(state.pendingNibble, absent())
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/ui/MemoryEditorWindowTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ui/MemoryEditorWindowTest.kt
@@ -1,7 +1,9 @@
 package com.github.alondero.nestlin.ui
 
+import com.natpryce.hamkrest.absent
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import javafx.scene.input.KeyCode
 import org.junit.jupiter.api.Test
 
 /**
@@ -37,5 +39,28 @@ class MemoryEditorWindowTest {
         MemoryEditorWindow.formatRow(rowIndex = 0xFFF, peek = peek) // last row: $FFF0..$FFFF
 
         assertThat(peeked, equalTo((0xFFF0..0xFFFF).toList()))
+    }
+
+    // ---- hexDigit key mapping (issue #170) ----------------------------------
+
+    @Test
+    fun `hexDigit maps number-row and numpad digits to their value`() {
+        assertThat(MemoryEditorWindow.hexDigit(KeyCode.DIGIT0), equalTo(0))
+        assertThat(MemoryEditorWindow.hexDigit(KeyCode.DIGIT9), equalTo(9))
+        assertThat(MemoryEditorWindow.hexDigit(KeyCode.NUMPAD0), equalTo(0))
+        assertThat(MemoryEditorWindow.hexDigit(KeyCode.NUMPAD9), equalTo(9))
+    }
+
+    @Test
+    fun `hexDigit maps A-F to 10-15`() {
+        assertThat(MemoryEditorWindow.hexDigit(KeyCode.A), equalTo(0xA))
+        assertThat(MemoryEditorWindow.hexDigit(KeyCode.F), equalTo(0xF))
+    }
+
+    @Test
+    fun `hexDigit returns null for non-hex keys`() {
+        assertThat(MemoryEditorWindow.hexDigit(KeyCode.G), absent())
+        assertThat(MemoryEditorWindow.hexDigit(KeyCode.LEFT), absent())
+        assertThat(MemoryEditorWindow.hexDigit(KeyCode.ENTER), absent())
     }
 }


### PR DESCRIPTION
## What

Slice #170 of the Live Memory Editor (parent #167): inline hex editing. Click a byte cell to select it, type two hex digits to overwrite the byte, and the running game sees the new value on its next read. Arrow keys navigate between cells.

## How

- **`Memory.poke(addr, value)`** — a real write delegating to `set()` for full game-visible side effects (including mapper bank switches power users want), but silently dropping two catastrophic I/O registers: `$4014` (OAM DMA — 513-cycle CPU halt + OAM overwrite) and `$4016` (controller strobe reset). `$4017` (APU frame counter) is intentionally allowed. Surfaced to the UI as `Nestlin.pokeMemory`.
- **`HexEditState`** — a pure, JavaFX-free state machine for selection, pending-nibble accumulation, and arrow navigation (same testable-logic split as `MemorySnapshot`). A completed two-nibble edit is returned as a `Poke` for the caller to apply, so the I/O blacklist lives in exactly one place.
- **`MemoryEditorWindow`** — click-to-select, type-to-edit, arrow-navigate. The selected cell shows `A_` mid-edit and an amber selection ring. Arrow keys are intercepted with a capture-phase `KEY_PRESSED` event filter so the `ListView`'s own row navigation doesn't fight cell movement.

The selection ring is drawn with layered `-fx-background-color` + `-fx-background-insets` rather than `-fx-border-width`, so a selected cell stays the exact width of a bare byte — preserving the issue #169 no-reflow invariant (a border would add 2px and re-introduce the row-width-growth landmine).

## Testing

- `MemoryPokeTest` — RAM write-through, `$4014`/`$4016` blacklist no-ops, mapper bank-switch
- `HexEditStateTest` — select / move / clamp-at-bus-edges / two-nibble combine / abandon-pending-on-move
- `MemoryEditorWindowTest` — `hexDigit` key mapping (number row, numpad, A-F, non-hex)
- Full `./gradlew build` green. UI Stage/ListView wiring is manual-verify per the PRD; all extractable logic is unit-tested.

A high-effort multi-agent code review ran on the diff; the one substantive finding (selection border re-breaking the #169 width invariant) is fixed here via the background-insets ring.

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)