### PR TITLE
Rewind ring buffer with hold-Backspace scrub (#52)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ src/main/kotlin/com/github/alondero/nestlin/
 ├── apu/                    # channels, envelope, sweep, length, frame counter, resampler
 ├── gamepak/                # iNES header + Mapper0..69 dispatch (see MAPPER_SUPPORT.md)
 ├── input/                  # keyboard + JInput gamepad (config at ~/.config/nestlin/input.json)
+├── rewind/                 # RewindBuffer ring of per-frame savestates (hold-Backspace scrub, issue #52)
 ├── ui/                     # JavaFX Application (Canvas-based nearest-neighbour scaling), menus, scaling, fast-forward, screenshots
 ├── file/                   # .nes + .7z loading
 └── log/                    # CPU trace logger
@@ -131,7 +132,7 @@ testroms/                    # nestest.nes is the only ROM in git
 - Region: NTSC + PAL auto-detect (iNES header → NO-INTRO filename → user override).
 - Save state (`.nstl`, F5/F8 + menu) and save RAM (`.sav`, FCEUX-compatible).
 - Battery RAM persistence for mappers 1/4/5 (mappers with `$6000-$7FFF` PRG-RAM).
-- JavaFX UI: Canvas-based 1x/2x/3x/4x/Fit scaling, fullscreen (F11), hold-Tab fast-forward, pause (Ctrl+P), throttle toggle (Ctrl+T), screenshot (S), gamepad via JInput.
+- JavaFX UI: Canvas-based 1x/2x/3x/4x/Fit scaling, fullscreen (F11), hold-Tab fast-forward, hold-Backspace rewind (issue #52), pause (Ctrl+P), throttle toggle (Ctrl+T), screenshot (S), gamepad via JInput.
 
 **Known limits:**
 - Mapper 5 is a stub — Castlevania III not yet playable (needs bank-select decode rewrite, fill mode, multiplier output, scanline IRQ).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A Nintendo Entertainment System emulator written in Kotlin. Personal learning pr
 - **Save states** (`.nstl`) and **battery-backed save RAM** (`.sav`, FCEUX/Mesen-compatible).
 - **Input** — configurable keyboard and gamepad (via JInput); default keymap written to `~/.config/nestlin/input.json` on first run.
 - **Display** — 1×/2×/3×/4× integer scale, Fit-to-window, fullscreen, nearest-neighbour pixel scaling.
-- **Quality-of-life** — hold-Tab fast-forward, pause, speed-throttle toggle, screenshot capture, recent-ROMs menu.
+- **Quality-of-life** — hold-Tab fast-forward, hold-Backspace rewind, pause, speed-throttle toggle, screenshot capture, recent-ROMs menu.
 
 ---
 
@@ -120,6 +120,7 @@ The runnable fat JAR is at `build/libs/nestlin-all.jar` (built by `shadowJar`; t
 | Quick Save State | F5 | Save to `savestates/<rom>.quick.nstl`. |
 | Quick Load State | F8 | Load the matching quick-save slot. |
 | Fast-Forward | hold Tab | Disable throttling while held. |
+| Rewind | hold Backspace | Scrub backward through the last ~10 s at ~3× speed; release to resume. |
 | Screenshot | S | Save the current frame to `screenshots/`. |
 
 ### Default keyboard mapping (NES gamepad)

--- a/src/main/kotlin/com/github/alondero/nestlin/Apu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Apu.kt
@@ -30,6 +30,20 @@ class Apu(private val dmaPort: DmaPort) {
     private var cpuCycleCounter = 0
     private var frameIrq = false
 
+    /**
+     * When true, freshly mixed samples are discarded instead of being written to the
+     * output buffer (issue #52). The rewind feature sets this while scrubbing: each
+     * re-rendered frame would otherwise push ~735 forward-sounding samples per scrub
+     * step and produce audible crackle. Muting the producer lets the residual buffer
+     * drain to clean silence; the consumer (audio thread) simply underruns and idles.
+     *
+     * @Volatile: written by the JavaFX/emulation thread coordinating rewind, read by the
+     * emulation thread in [mixAndBuffer]. Not part of saveState — it is a transient
+     * playback concern, not machine state.
+     */
+    @Volatile
+    var outputMuted: Boolean = false
+
     private val SAMPLE_RATE = 44100.0
 
     /**
@@ -171,7 +185,9 @@ class Apu(private val dmaPort: DmaPort) {
 
         val sample = (mixed * 32767.0).toInt().coerceIn(-32768, 32767).toShort()
 
-        audioBuffer.write(sample)
+        // Drop samples while muted (rewind scrubbing) so the buffer drains to silence
+        // rather than replaying forward audio per re-rendered frame. See [outputMuted].
+        if (!outputMuted) audioBuffer.write(sample)
     }
 
     fun getAudioSamples(): ShortArray {

--- a/src/main/kotlin/com/github/alondero/nestlin/EmulatorConfig.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/EmulatorConfig.kt
@@ -38,7 +38,21 @@ data class EmulatorConfig(
      * from the ROM header/filename is used. Set to force NTSC or PAL regardless of
      * detection — surfaced via the UI's Emulation menu and the `--region` CLI flag.
      */
-    var regionOverride: Region? = null
+    var regionOverride: Region? = null,
+
+    /**
+     * Enable the rewind ring buffer (issue #52). When true, one savestate is captured
+     * per frame into a bounded buffer so the user can hold Backspace to scrub backward.
+     * Disable to remove the ~1 ms/frame capture cost entirely. Default: true.
+     */
+    var rewindEnabled: Boolean = true,
+
+    /**
+     * Rewind buffer depth in frames. 600 frames is ~10 seconds at 60 fps and, at roughly
+     * 10 KB per savestate, ~6 MB of retained history. Read once when the buffer is
+     * constructed (at Nestlin init), so changing it later has no effect this session.
+     */
+    var rewindCapacityFrames: Int = 600
 ) {
     /**
      * Target time per frame in nanoseconds.

--- a/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
@@ -4,7 +4,10 @@ import com.github.alondero.nestlin.cpu.Cpu
 import com.github.alondero.nestlin.file.load
 import com.github.alondero.nestlin.gamepak.GamePak
 import com.github.alondero.nestlin.ppu.Ppu
+import com.github.alondero.nestlin.rewind.RewindBuffer
 import com.github.alondero.nestlin.ui.FrameListener
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.OutputStream
 import java.nio.file.Files
@@ -33,6 +36,24 @@ class Nestlin {
     // and we emit one PPU tick per 10 credits: NTSC = exactly 3, PAL = 3,3,3,3,4 (avg 3.2).
     private var ppuDotCredit: Int = 0
 
+    // --- Rewind (issue #52) ---
+    // Ring buffer of per-frame savestates. Captured by a frame-completion listener during
+    // normal play; consumed (scrubbed backward) when [rewindActive] is set by the UI.
+    val rewindBuffer = RewindBuffer(config.rewindCapacityFrames)
+    // @Volatile: set by the JavaFX thread (hold/release Backspace), read by the emulation
+    // loop. A plain bool could be cached in the loop and never observe the release.
+    @Volatile
+    private var rewindActive = false
+    // Tracker of whether we are *currently* in a rewind pass, so the loop can run the one-shot
+    // enter/exit transitions (mute audio, reset throttle baseline). Written by the emulation
+    // thread; @Volatile because the JavaFX thread reads it via [isRewinding] each frame to drive
+    // the on-screen indicator, and would otherwise see a stale value.
+    @Volatile
+    private var rewinding = false
+    // Set while a rewind step re-renders a frame, so the capture listener doesn't record the
+    // re-simulated frames back into the buffer (which would corrupt the timeline being scrubbed).
+    private var suppressRewindCapture = false
+
     init {
         memory = Memory()
         cpu = Cpu(memory)
@@ -40,6 +61,9 @@ class Nestlin {
         ppu = Ppu(memory)
         apu = Apu(memory)
         memory.apu = apu
+        // One savestate per frame into the rewind ring. Registered on the long-lived PPU so it
+        // survives ROM loads/resets; fires on the emulation thread at a clean frame boundary.
+        ppu.addFrameCompletionListener { captureRewindSnapshot() }
     }
 
     fun getController1() = memory.controller1
@@ -50,6 +74,9 @@ class Nestlin {
         val displayName = romPath.fileName.toString().removeSuffix(".nes").removeSuffix(".7z")
         cpu.currentGame = data?.let { GamePak(it, displayName) }
         applyRegion()
+        // Rewind history is per-ROM: a snapshot made against ROM A can't be loaded into ROM B
+        // (the savestate ROM/mapper guard would reject it). Drop it on every ROM swap.
+        rewindBuffer.clear()
     }
 
     /** The region currently in effect (after override + detection). */
@@ -94,7 +121,26 @@ class Nestlin {
     fun powerReset() {
         cpu.reset()
         applyRegion()
+        // A power-cycle is a fresh timeline; any rewind history predates this boot. Clearing
+        // here also covers the Hard Reset path (resetRomForMovieSession -> load + powerReset).
+        rewindBuffer.clear()
     }
+
+    /**
+     * Engage or disengage rewind scrubbing (issue #52). Called from the UI thread on
+     * hold/release of the Backspace key. While active and [EmulatorConfig.rewindEnabled], the
+     * emulation loop walks backward through [rewindBuffer] at ~3× real-time, re-rendering each
+     * scrubbed frame and muting audio; on release it resumes normal play from the scrubbed point.
+     */
+    fun setRewindActive(active: Boolean) {
+        rewindActive = active
+    }
+
+    /** True while a rewind scrub pass is in progress (drives the on-screen indicator). */
+    fun isRewinding(): Boolean = rewinding
+
+    /** Number of frames currently retained in the rewind buffer (diagnostics/tests). */
+    fun rewindBufferSize(): Int = rewindBuffer.size
 
     /** Write the current emulator state to [out]. Caller is responsible for closing. */
     fun saveState(out: OutputStream) = SaveState.save(this, out)
@@ -179,6 +225,15 @@ class Nestlin {
                     ticksSinceLastSync = 0
                     continue
                 }
+                // Rewind scrubbing (issue #52): while Backspace is held, walk backward through
+                // the savestate ring instead of advancing the machine. Needs a game and the
+                // feature enabled — otherwise fall through to normal play.
+                if (rewindActive && config.rewindEnabled && cpu.currentGame != null) {
+                    if (!rewinding) enterRewind()
+                    stepRewind()
+                    continue
+                }
+                if (rewinding) exitRewind()
                 stepCpuCycle()
                 ticksSinceLastSync++
 
@@ -223,7 +278,118 @@ class Nestlin {
         }
     }
 
-    fun stop() {running = false}
+    // ---------------------------------------------------------------------------------------
+    // Rewind scrubbing internals (issue #52). All run on the emulation thread.
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Capture the just-completed frame into the rewind ring. Invoked by the PPU
+     * frame-completion listener. No-op when rewind is disabled, when no game is loaded, or
+     * while a rewind step is re-rendering (so re-simulated frames don't pollute the buffer).
+     */
+    private fun captureRewindSnapshot() {
+        if (!config.rewindEnabled) return
+        if (suppressRewindCapture) return
+        if (cpu.currentGame == null) return
+        try {
+            val out = ByteArrayOutputStream(INITIAL_SNAPSHOT_CAPACITY)
+            SaveState.save(this, out)
+            rewindBuffer.capture(out.toByteArray())
+        } catch (e: Throwable) {
+            // This runs on the emulation thread for EVERY frame, so an unhandled throw here
+            // (e.g. a mapper with an incomplete saveState, or OOM building the ~6 MB buffer)
+            // would kill the whole emulator and hang the UI on its join(). Rewind is a
+            // convenience feature, never worth crashing play for: log once, disable it, and
+            // free the partial history so the game keeps running.
+            System.err.println("[REWIND] Snapshot capture failed; disabling rewind: ${e.message}")
+            config.rewindEnabled = false
+            rewindBuffer.clear()
+        }
+    }
+
+    /** One-shot transition into a rewind pass: mute audio so scrubbing is silent, not crackly. */
+    private fun enterRewind() {
+        rewinding = true
+        apu.outputMuted = true
+    }
+
+    /** One-shot transition out of a rewind pass: unmute and reset the throttle baseline. */
+    private fun exitRewind() {
+        rewinding = false
+        apu.outputMuted = false
+        // The machine just resumed from a scrubbed point; don't let syncToWallClock treat the
+        // scrub duration as drift to "catch up" by sprinting through the next chunk of frames.
+        nextSyncDeadlineNanos = System.nanoTime()
+        ticksSinceLastSync = 0
+    }
+
+    /**
+     * Advance one rewind step: jump back [REWIND_FRAMES_PER_STEP] snapshots, load the snapshot
+     * now at the head, and re-render exactly one frame so the screen shows the rewound state
+     * (savestates carry no pixels). The re-render advances the machine one frame past the
+     * snapshot, but the next step reloads from the ring, so that drift never compounds.
+     * Paced to ~one display frame so the scrub reads as ~3× real-time backward.
+     */
+    private fun stepRewind() {
+        val snapshot = rewindBuffer.rewind(REWIND_FRAMES_PER_STEP)
+        if (snapshot == null) {
+            // Empty buffer (Backspace held before any frame was captured): nothing to scrub to,
+            // and capture only runs during normal play, so the buffer can never fill while we
+            // sit here. Sleep one frame UNCONDITIONALLY — paceRewindFrame would skip the sleep
+            // with throttling off, leaving the emulation thread spinning at 100% CPU for nothing.
+            try {
+                Thread.sleep(EMPTY_REWIND_PARK_MILLIS)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+            return
+        }
+        suppressRewindCapture = true
+        try {
+            SaveState.load(this, ByteArrayInputStream(snapshot))
+            runOneFrameForRender()
+        } finally {
+            suppressRewindCapture = false
+        }
+        paceRewindFrame()
+    }
+
+    /**
+     * Drive the emulator to the next frame boundary so the render listener fires and the
+     * canvas updates. Clears any stale frame-complete latch first, and bails if the emulator
+     * is stopped mid-pass.
+     */
+    private fun runOneFrameForRender() {
+        ppu.frameJustCompleted()  // consume any stale one-shot latch from normal play
+        while (running) {
+            stepCpuCycle()
+            if (ppu.frameJustCompleted()) return
+        }
+    }
+
+    /**
+     * Sleep ~one display frame between rewind steps so scrubbing runs at roughly display rate.
+     * Each step moves back [REWIND_FRAMES_PER_STEP] frames, so the apparent backward speed is
+     * ~3× real-time. Honors the throttle toggle: with throttling off (e.g. Tab fast-forward),
+     * scrubbing runs as fast as the host allows.
+     */
+    private fun paceRewindFrame() {
+        if (!config.speedThrottlingEnabled) return
+        val frameNanos = config.targetFrameTimeNanos
+        try {
+            Thread.sleep(frameNanos / 1_000_000, (frameNanos % 1_000_000).toInt())
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
+
+    fun stop() {
+        running = false
+        // Defensive: if we're stopped mid-rewind, make sure audio isn't left muted for the
+        // next start(). stop() runs on the UI thread; outputMuted is volatile so this is safe.
+        apu.outputMuted = false
+        rewinding = false
+    }
 
     companion object {
         // Sync to wall clock every ~1 ms of emulated time (1789 ticks at 1.79 MHz).
@@ -234,6 +400,15 @@ class Nestlin {
         private const val MIN_SLEEP_NANOS = 100_000L
         // If wall-clock is more than 100 ms ahead of emulation, give up trying to catch up.
         private const val MAX_DRIFT_NANOS = 100_000_000L
+        // Frames to walk back per rewind step. Paced at ~display rate (60 Hz), 3 frames/step
+        // gives ~3× real-time backward scrubbing (issue #52 acceptance criterion).
+        private const val REWIND_FRAMES_PER_STEP = 3
+        // Pre-size the per-frame snapshot stream to skip the early doubling reallocs. A typical
+        // savestate is ~10 KB; 16 KB covers most mappers' state without growing.
+        private const val INITIAL_SNAPSHOT_CAPACITY = 16 * 1024
+        // Idle sleep when rewind is held against an empty buffer — keeps the emulation thread
+        // off the CPU instead of busy-spinning (paceRewindFrame is skipped when throttling is off).
+        private const val EMPTY_REWIND_PARK_MILLIS = 16L
     }
 }
 

--- a/src/main/kotlin/com/github/alondero/nestlin/cli/BootCheck.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cli/BootCheck.kt
@@ -111,6 +111,8 @@ object BootCheck {
         val nestlin = try {
             Nestlin().apply {
                 config.speedThrottlingEnabled = false
+                // Headless boot check never rewinds — skip per-frame savestate capture.
+                config.rewindEnabled = false
                 load(opts.romPath)
                 powerReset()
             }

--- a/src/main/kotlin/com/github/alondero/nestlin/cli/ReplayCommand.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cli/ReplayCommand.kt
@@ -152,6 +152,8 @@ object ReplayCommand {
 
     private fun boot(romPath: Path): Nestlin = Nestlin().apply {
         config.speedThrottlingEnabled = false
+        // Headless replay never rewinds — skip the per-frame savestate capture overhead.
+        config.rewindEnabled = false
         load(romPath)
         powerReset()
     }

--- a/src/main/kotlin/com/github/alondero/nestlin/rewind/RewindBuffer.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/rewind/RewindBuffer.kt
@@ -1,0 +1,74 @@
+package com.github.alondero.nestlin.rewind
+
+/**
+ * A bounded ring buffer of emulator savestate snapshots backing the hold-Backspace
+ * rewind feature (issue #52).
+ *
+ * Each entry is an opaque savestate blob (`SaveState.save` output). One snapshot is
+ * captured per emulated frame; at 60 fps a 10-second window is 600 entries of ~10 KB,
+ * roughly 6 MB. When the buffer is full, the OLDEST snapshot is dropped to make room —
+ * standard ring behaviour, so the window always covers "the last N frames".
+ *
+ * ### Rewind semantics
+ *
+ * The newest snapshot sits at the *head* of the timeline. [rewind] walks the playhead
+ * backward by removing the newest snapshot(s) and returning the one now at the head — the
+ * caller loads that snapshot to move the machine into the past. The single oldest snapshot
+ * is a floor: [rewind] never removes it, so a user who holds Backspace past the start of
+ * the buffer simply parks on the oldest available state rather than running off the end.
+ *
+ * Capturing again after a rewind appends onto the (now shorter) timeline, which is exactly
+ * the "rewrote history" behaviour you want: frames the user scrubbed past are gone.
+ *
+ * ### Threading
+ *
+ * [capture] and [rewind] run on the emulation thread; [clear] runs on the JavaFX thread but
+ * only while the emulation thread is stopped (Load Game / Hard Reset go through
+ * `stopEmulation()` first). All methods are nonetheless `@Synchronized` so the structure is
+ * self-contained and safe even if a future caller relaxes that ordering.
+ */
+class RewindBuffer(val capacity: Int) {
+
+    init {
+        require(capacity > 0) { "Rewind buffer capacity must be positive, was $capacity" }
+    }
+
+    // Newest snapshot at the end (addLast), oldest at the start (index 0).
+    private val entries = ArrayDeque<ByteArray>()
+
+    /** Number of snapshots currently retained. */
+    val size: Int
+        @Synchronized get() = entries.size
+
+    /** True when at least two snapshots remain, i.e. [rewind] can still move further back. */
+    val canRewind: Boolean
+        @Synchronized get() = entries.size > 1
+
+    /** Append [state] as the newest snapshot, evicting the oldest if at [capacity]. */
+    @Synchronized
+    fun capture(state: ByteArray) {
+        if (entries.size >= capacity) entries.removeFirst()
+        entries.addLast(state)
+    }
+
+    /**
+     * Move the playhead back by up to [steps] snapshots and return the snapshot now at the
+     * head of the timeline (the most-recent survivor). Removes up to [steps] of the newest
+     * snapshots but never drops below the single oldest snapshot (the rewind floor).
+     *
+     * Returns `null` only when the buffer is empty.
+     */
+    @Synchronized
+    fun rewind(steps: Int = 1): ByteArray? {
+        repeat(steps) {
+            if (entries.size > 1) entries.removeLast()
+        }
+        return entries.lastOrNull()
+    }
+
+    /** Drop every snapshot. Called when the ROM identity changes (Load Game / Hard Reset). */
+    @Synchronized
+    fun clear() {
+        entries.clear()
+    }
+}

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
@@ -89,6 +89,16 @@ class NestlinApplication : FrameListener, Application() {
         strokeWidth = 1.0
         isVisible = false
     }
+    // Rewind scrub indicator (issue #52). Same crisp scene-node treatment as the fast-forward
+    // glyph; cyan "<<" pinned top-centre (fast-forward sits top-right, REC/PLAY top-left, so the
+    // three never collide). Toggled by the render loop while Backspace-scrubbing is active.
+    private val rewindIndicator = javafx.scene.text.Text("<<").apply {
+        font = javafx.scene.text.Font.font("Monospaced", javafx.scene.text.FontWeight.BOLD, 16.0)
+        fill = javafx.scene.paint.Color.web("#40E0FF")
+        stroke = javafx.scene.paint.Color.BLACK
+        strokeWidth = 1.0
+        isVisible = false
+    }
     // Save-state feedback toast (issue #129). Same scene-graph approach as
     // the fast-forward indicator — overlaid on canvasHolder rather than
     // pixels poked into frameImage, so it stays a crisp 18px no matter the
@@ -386,6 +396,11 @@ class NestlinApplication : FrameListener, Application() {
             StackPane.setAlignment(fastForwardIndicator, javafx.geometry.Pos.TOP_RIGHT)
             StackPane.setMargin(fastForwardIndicator, javafx.geometry.Insets(4.0, 6.0, 0.0, 0.0))
 
+            // Rewind indicator pinned top-centre (issue #52) — clear of the other two corners.
+            canvasHolder.children.add(rewindIndicator)
+            StackPane.setAlignment(rewindIndicator, javafx.geometry.Pos.TOP_CENTER)
+            StackPane.setMargin(rewindIndicator, javafx.geometry.Insets(4.0, 0.0, 0.0, 0.0))
+
             // Overlay the REC/PLAY indicator on top-LEFT so it doesn't collide with the
             // fast-forward indicator. Same Text-node pattern — crisp at any scale, hidden
             // when no movie session is active.
@@ -521,11 +536,26 @@ class NestlinApplication : FrameListener, Application() {
                         if (event.isShiftDown) handleSlotSave(slot) else handleSlotLoad(slot)
                         event.consume()
                     }
+                    // Backspace: hold to scrub backward through the rewind buffer (issue #52).
+                    // KEY_PRESSED auto-repeats while held; setRewindActive is idempotent so the
+                    // repeats are harmless. Released below in setOnKeyReleased.
+                    event.code == javafx.scene.input.KeyCode.BACK_SPACE -> {
+                        nestlin.setRewindActive(true)
+                        event.consume()
+                    }
                     // F11 is handled by the Fullscreen menu accelerator (see Settings menu).
                     else -> handleInput(event.code, true)
                 }
             }
-            scene.setOnKeyReleased { event -> handleInput(event.code, false) }
+            scene.setOnKeyReleased { event ->
+                // Release Backspace: stop scrubbing and resume play from the rewound point.
+                if (event.code == javafx.scene.input.KeyCode.BACK_SPACE) {
+                    nestlin.setRewindActive(false)
+                    event.consume()
+                } else {
+                    handleInput(event.code, false)
+                }
+            }
 
             // Tab is a focus-traversal key in JavaFX, so it must be intercepted in the
             // capturing phase (event filter) and consumed before the traversal engine
@@ -548,7 +578,12 @@ class NestlinApplication : FrameListener, Application() {
             // Tab is held, the OS stops delivering key events so KEY_RELEASED never fires.
             // Force-release on focus loss so fast-forward can't latch on indefinitely.
             focusedProperty().addListener { _, _, focused ->
-                if (!focused) fastForward.release()
+                if (!focused) {
+                    fastForward.release()
+                    // Same "stuck key" guard for rewind: if focus is lost while Backspace is
+                    // held, KEY_RELEASED never fires, so force the scrub off (issue #52).
+                    nestlin.setRewindActive(false)
+                }
             }
 
             // Window close (X button) goes through handleExit so battery RAM gets flushed.
@@ -588,6 +623,11 @@ class NestlinApplication : FrameListener, Application() {
                 // so toggling visibility is all that's needed — no per-frame drawing.
                 if (fastForwardIndicator.isVisible != fastForward.active) {
                     fastForwardIndicator.isVisible = fastForward.active
+                }
+                // Cheap-toggle the rewind indicator from the engine's live scrub state (issue #52).
+                val rewinding = nestlin.isRewinding()
+                if (rewindIndicator.isVisible != rewinding) {
+                    rewindIndicator.isVisible = rewinding
                 }
                 // Same cheap-toggle pattern for the REC/PLAY movie indicator.
                 refreshMovieIndicator()

--- a/src/test/kotlin/com/github/alondero/nestlin/rewind/RewindBufferTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/rewind/RewindBufferTest.kt
@@ -1,0 +1,127 @@
+package com.github.alondero.nestlin.rewind
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the rewind ring buffer (issue #52).
+ *
+ * The buffer is a pure data structure: it knows nothing about savestates beyond
+ * "a snapshot is an opaque [ByteArray]". The emulator-facing semantics it must honour:
+ *
+ *  - **capture** appends the newest snapshot; once full it drops the OLDEST (ring behaviour).
+ *  - **rewind(n)** walks the playhead back by up to n snapshots and returns the snapshot now
+ *    at the head, never dropping below the single oldest snapshot (the rewind floor).
+ *  - **clear** empties it (per-ROM reset on Load Game / Hard Reset).
+ *
+ * Snapshots here are 1-byte arrays whose single byte is a frame id, so assertions can read
+ * "which frame did we rewind to" directly.
+ */
+class RewindBufferTest {
+
+    private fun frame(id: Int) = byteArrayOf(id.toByte())
+    private fun ByteArray.id() = this[0].toInt() and 0xFF
+
+    @Test
+    fun `capacity must be positive`() {
+        assertThrows(IllegalArgumentException::class.java) { RewindBuffer(0) }
+        assertThrows(IllegalArgumentException::class.java) { RewindBuffer(-5) }
+    }
+
+    @Test
+    fun `a fresh buffer is empty and cannot rewind`() {
+        val buf = RewindBuffer(10)
+        assertThat(buf.size, equalTo(0))
+        assertThat(buf.canRewind, equalTo(false))
+        assertNull(buf.rewind())
+    }
+
+    @Test
+    fun `capture grows the buffer up to capacity`() {
+        val buf = RewindBuffer(3)
+        buf.capture(frame(0))
+        buf.capture(frame(1))
+        assertThat(buf.size, equalTo(2))
+        buf.capture(frame(2))
+        buf.capture(frame(3))  // overflow: drops frame 0
+        assertThat(buf.size, equalTo(3))
+    }
+
+    @Test
+    fun `overflow drops the oldest snapshot first`() {
+        val buf = RewindBuffer(3)
+        for (i in 0..5) buf.capture(frame(i))  // 0..5, capacity 3 -> keeps 3,4,5
+        // Rewinding from the newest (5) walks 5 -> 4 -> 3 (floor), never reaching 0/1/2.
+        assertThat(buf.rewind()!!.id(), equalTo(4))
+        assertThat(buf.rewind()!!.id(), equalTo(3))
+        assertThat(buf.rewind()!!.id(), equalTo(3))  // floored at oldest survivor
+    }
+
+    @Test
+    fun `rewind of one step walks back one snapshot at a time`() {
+        val buf = RewindBuffer(10)
+        for (i in 0..4) buf.capture(frame(i))  // [0,1,2,3,4]
+        // The live machine is just past frame 4, so the first step back lands on 3.
+        assertThat(buf.rewind(1)!!.id(), equalTo(3))
+        assertThat(buf.rewind(1)!!.id(), equalTo(2))
+        assertThat(buf.rewind(1)!!.id(), equalTo(1))
+        assertThat(buf.rewind(1)!!.id(), equalTo(0))
+    }
+
+    @Test
+    fun `rewind floors at the oldest snapshot and never returns null while non-empty`() {
+        val buf = RewindBuffer(10)
+        for (i in 0..2) buf.capture(frame(i))  // [0,1,2]
+        assertThat(buf.rewind(1)!!.id(), equalTo(1))
+        assertThat(buf.rewind(1)!!.id(), equalTo(0))
+        assertThat(buf.rewind(1)!!.id(), equalTo(0))  // stays put at the floor
+        assertThat(buf.canRewind, equalTo(false))     // only the floor snapshot remains
+    }
+
+    @Test
+    fun `multi-step rewind skips intermediate snapshots (3x scrub)`() {
+        val buf = RewindBuffer(100)
+        for (i in 0..9) buf.capture(frame(i))  // [0..9]
+        // 3x scrub: each step jumps back 3 snapshots.
+        assertThat(buf.rewind(3)!!.id(), equalTo(6))  // dropped 9,8,7 -> head 6
+        assertThat(buf.rewind(3)!!.id(), equalTo(3))  // dropped 6,5,4 -> head 3
+        assertThat(buf.rewind(3)!!.id(), equalTo(0))  // dropped 3,2,1 -> head 0
+        assertThat(buf.rewind(3)!!.id(), equalTo(0))  // floored
+    }
+
+    @Test
+    fun `multi-step rewind near the floor stops at the oldest survivor`() {
+        val buf = RewindBuffer(100)
+        for (i in 0..3) buf.capture(frame(i))  // [0,1,2,3]
+        // Asking for 3 steps with only enough room for 3 removals still keeps the floor.
+        assertThat(buf.rewind(3)!!.id(), equalTo(0))
+        assertThat(buf.size, equalTo(1))
+    }
+
+    @Test
+    fun `capturing after a rewind continues the timeline from the rewound head`() {
+        val buf = RewindBuffer(100)
+        for (i in 0..4) buf.capture(frame(i))  // [0,1,2,3,4]
+        buf.rewind(1)                           // head now 3, buffer [0,1,2,3]
+        buf.rewind(1)                           // head now 2, buffer [0,1,2]
+        // User releases at frame 2; forward play resumes and captures new frames.
+        buf.capture(frame(99))                  // buffer [0,1,2,99]
+        assertThat(buf.size, equalTo(4))
+        // The frames we rewound past (3,4) are gone — history was rewritten.
+        assertThat(buf.rewind(1)!!.id(), equalTo(2))
+        assertThat(buf.rewind(1)!!.id(), equalTo(1))
+    }
+
+    @Test
+    fun `clear empties the buffer`() {
+        val buf = RewindBuffer(10)
+        for (i in 0..4) buf.capture(frame(i))
+        buf.clear()
+        assertThat(buf.size, equalTo(0))
+        assertThat(buf.canRewind, equalTo(false))
+        assertNull(buf.rewind())
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/rewind/RewindCaptureTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/rewind/RewindCaptureTest.kt
@@ -1,0 +1,103 @@
+package com.github.alondero.nestlin.rewind
+
+import com.github.alondero.nestlin.Nestlin
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.nio.file.Paths
+
+/**
+ * Integration tests for the rewind capture path (issue #52) wired through the real
+ * frame-completion listener and the real savestate serializer. The pure ring mechanics
+ * live in [RewindBufferTest]; this proves Nestlin captures one valid, restartable snapshot
+ * per frame and clears the ring on the per-ROM lifecycle events.
+ */
+class RewindCaptureTest {
+
+    private fun newNestlinAtReset(): Nestlin {
+        val nes = Nestlin()
+        nes.load(Paths.get("testroms/nestest.nes"))
+        nes.powerReset()
+        return nes
+    }
+
+    /** Advance the emulator by exactly [n] full PPU frames, firing the capture listener each. */
+    private fun runFrames(nes: Nestlin, n: Int) {
+        repeat(n) {
+            while (true) {
+                nes.stepCpuCycle()
+                if (nes.ppu.frameJustCompleted()) break
+            }
+        }
+    }
+
+    private fun snapshot(nes: Nestlin): ByteArray =
+        ByteArrayOutputStream().also { nes.saveState(it) }.toByteArray()
+
+    @Test
+    fun `one snapshot is captured per frame`() {
+        val nes = newNestlinAtReset()
+        assertThat("buffer starts empty after reset", nes.rewindBufferSize(), equalTo(0))
+        runFrames(nes, 25)
+        assertThat("each completed frame captures exactly one snapshot",
+            nes.rewindBufferSize(), equalTo(25))
+    }
+
+    @Test
+    fun `disabling rewind suppresses capture entirely`() {
+        val nes = newNestlinAtReset()
+        nes.config.rewindEnabled = false
+        runFrames(nes, 25)
+        assertThat("no snapshots captured while rewind is disabled",
+            nes.rewindBufferSize(), equalTo(0))
+    }
+
+    @Test
+    fun `power reset clears the rewind buffer`() {
+        val nes = newNestlinAtReset()
+        runFrames(nes, 25)
+        assertTrue(nes.rewindBufferSize() > 0)
+        nes.powerReset()
+        assertThat("a power-cycle drops the prior boot's history",
+            nes.rewindBufferSize(), equalTo(0))
+    }
+
+    @Test
+    fun `loading a ROM clears the rewind buffer`() {
+        val nes = newNestlinAtReset()
+        runFrames(nes, 25)
+        assertTrue(nes.rewindBufferSize() > 0)
+        nes.load(Paths.get("testroms/nestest.nes"))
+        assertThat("swapping ROMs drops the previous ROM's history",
+            nes.rewindBufferSize(), equalTo(0))
+    }
+
+    @Test
+    fun `a snapshot pulled from the buffer is a valid restartable state`() {
+        // The strong property: a buffered snapshot, when loaded, deterministically continues
+        // the same as the original timeline did from that point. If the capture path missed any
+        // state, the two forward runs would diverge.
+        val nes = newNestlinAtReset()
+        runFrames(nes, 20)
+
+        // Scrub back ~5 frames and load that snapshot through the real loader.
+        val rewound = nes.rewindBuffer.rewind(5)!!
+        nes.loadState(ByteArrayInputStream(rewound))
+
+        // Path A: run 7 frames forward from the rewound state.
+        runFrames(nes, 7)
+        val pathA = snapshot(nes)
+
+        // Path B: reload the exact same snapshot, run the same 7 frames.
+        nes.loadState(ByteArrayInputStream(rewound))
+        runFrames(nes, 7)
+        val pathB = snapshot(nes)
+
+        assertArrayEquals(pathA, pathB,
+            "Running forward from a buffered rewind snapshot must be deterministic")
+    }
+}


### PR DESCRIPTION
## What & why

Implements issue #52: hold **Backspace** to scrub backward through the last ~10 seconds of play at ~3× real-time, release to resume from the scrubbed point.

## How it works

- **`rewind/RewindBuffer.kt`** — a pure, capacity-bounded ring of per-frame savestate blobs. `capture` drops the oldest on overflow; `rewind(steps)` walks the playhead back, floored at the single oldest snapshot. Fully unit-tested in isolation.
- **Capture** — one savestate per frame via the long-lived PPU frame-completion listener (same hook the movie recorder uses), so it fires on the emulation thread at a clean frame boundary. Wrapped in a guard: if `SaveState.save` ever throws, rewind disables itself and frees the buffer instead of crashing the emulation thread.
- **Scrubbing** — driven from the main emulation loop. Savestates carry **no pixels** (the PPU's rendered `Frame` isn't serialised), so each step loads an older snapshot and re-runs exactly one frame to regenerate the picture. This is why the memory budget is ~10 KB/frame, not ~250 KB.
- **No audio crackle** — `Apu.outputMuted` gates sample writes during scrub, so the residual buffer drains to clean silence rather than replaying forward audio per re-rendered frame.
- **Per-ROM** — the buffer is cleared on `load()` and `powerReset()`, covering Load Game and Hard Reset.
- **Config** — `EmulatorConfig.rewindEnabled` (default true) and `rewindCapacityFrames` (default 600 ≈ 10 s ≈ 6 MB). Headless `replay`/`bootcheck` CLIs disable it to avoid the per-frame capture cost.
- **UI** — hold-Backspace engage/release with focus-loss safety (parity with Tab fast-forward); a cyan `◀◀` indicator pinned top-centre.

## Acceptance criteria

- [x] Configurable ring (default 10 s = 600 frames ≈ 6 MB)
- [x] One savestate captured per frame
- [x] Hold Backspace: scrub backward at ~3× real-time
- [x] Release Backspace: resume from the scrubbed point
- [x] Buffer is per-ROM (cleared on Load Game / Hard Reset)
- [x] No audio crackle during rewind playback

## Tests

- `RewindBufferTest` — ring mechanics (capacity, overflow-drops-oldest, multi-step scrub, floor, rewrite-history-after-rewind, clear).
- `RewindCaptureTest` — capture-per-frame through the real serialiser, disable suppresses capture, clear-on-load/reset, and a determinism check proving a buffered snapshot is a valid restartable state.
- Full `./gradlew build` + `test` green.

## Review

Self-reviewed at high effort (8 finder angles). Fixes applied from the review: corrected the new files' line endings to CRLF (project policy), made the `rewinding` flag `@Volatile` (read cross-thread by the indicator), hardened the per-frame capture against a throwing `saveState`, and guarded an empty-buffer busy-spin when throttling is off.

> Note: the JavaFX UI could not be launched in the headless dev environment, so the on-screen scrub *feel* is covered by logic/tests rather than visual confirmation. `./gradlew run --args="<rom>"` + hold Backspace exercises it interactively.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)