### PR TITLE
Controller config: Save commits-and-exits; Close → Cancel

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/ui/ControllerConfigWindow.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/ControllerConfigWindow.kt
@@ -26,8 +26,16 @@ import javafx.scene.control.Button as FxButton
  * The Controller Configuration screen (Settings → Configure Controls…). Shows a picture of an
  * NES pad with a clickable hotspot over each of the eight buttons. Click a hotspot, then press a
  * keyboard key **or** a gamepad button — whichever fires first becomes that NES button's binding.
- * **Save** writes `input.json` and applies the new mapping live; **Reset to Default** restores the
- * shipped defaults (committed on the next Save). Player 1 only.
+ *
+ * The bottom button bar:
+ *   - **Save** writes `input.json`, applies the new mapping live, and closes the window — the
+ *     close *is* the "saved" confirmation.
+ *   - **Reset to Default** restores the shipped defaults **on-screen only** (no file write); press
+ *     Save to commit them, or Cancel to discard them.
+ *   - **Cancel** closes the window without writing — any in-progress bindings or pending reset are
+ *     discarded.
+ *
+ * Player 1 only.
  *
  * This class is a thin JavaFX shell — all the editing/listening/steal logic lives in the pure,
  * unit-tested [ControllerBindings] (mirroring how [MemoryEditorWindow] sits over [HexEditState]).
@@ -192,8 +200,8 @@ class ControllerConfigWindow(
     private fun buildButtonBar(): HBox {
         val save = FxButton("Save").apply { setOnAction { onSave() } }
         val reset = FxButton("Reset to Default").apply { setOnAction { onReset() } }
-        val close = FxButton("Close").apply { setOnAction { stage.hide() } }
-        return HBox(8.0, save, reset, close).apply {
+        val cancel = FxButton("Cancel").apply { setOnAction { stage.hide() } }
+        return HBox(8.0, save, reset, cancel).apply {
             alignment = Pos.CENTER_RIGHT
             padding = Insets(6.0)
         }
@@ -244,8 +252,9 @@ class ControllerConfigWindow(
         bindings.cancel()
         stopGamepadCapture()
         applyAndSave(bindings.toInputConfig(loadConfig()))
-        refresh()
-        promptLabel.text = "Saved to input.json."
+        // Save commits-and-exits: the window closing IS the "saved" confirmation.
+        // stage.hide() also triggers onHidden, which re-runs the cleanup above — idempotent.
+        stage.hide()
     }
 
     private fun onReset() {


### PR DESCRIPTION
## What

Three button-bar semantics on the Configure Controls screen:

- **Save** now writes `input.json`, applies the new mapping live, **and closes the window**. The close *is* the confirmation.
- **Reset to Default** is unchanged: restores defaults on-screen only; press Save to commit, Cancel to discard.
- **Close → Cancel** rename: same handler (exit without saving), label now matches the semantics.

## Why

UX feedback: the previous "Save → window stays open with a brief 'Saved to input.json.' label" required a second click (Close) to dismiss, and the word "Close" suggested "neutral exit" rather than "discard my changes". The user requested the conventional modal pattern: Save commits-and-exits, Cancel discards-and-exits, Reset is a local-only preview.

## How

- `buildButtonBar()`: `"Close"` → `"Cancel"`, local var `close` → `cancel`.
- `onSave()`: replaced `refresh()` + `promptLabel.text = "Saved to input.json."` with `stage.hide()`. The label text was invisible anyway (the window hides immediately) and `refresh()` was wasted work on a window about to hide. `stage.hide()` also fires `onHidden`, which re-runs `bindings.cancel()` + `stopGamepadCapture()` — both already called at the top of `onSave`, and both idempotent. No new edge case.
- Class KDoc: rewritten from a one-line description into a 3-bullet list of the button bar (Save / Reset to Default / Cancel) so the contract is self-documenting.

## Verification

- `./gradlew compileKotlin` — green.
- `./gradlew test` — green in 3m 55s.
- Code review (high-effort): one cluster of findings (no error path around `applyAndSave`) **refuted** — `InputConfig.save` already has `try/catch (e: Exception)` that swallows errors internally, and the rest of `applyInputConfig` is field assignments that can't throw. No bug to fix.
- No new tests added: `ControllerConfigWindow` has no existing test coverage (no `ControllerConfigWindowTest.kt` in `src/test/kotlin`), and JavaFX window lifecycle tests would require a TestFX toolkit — out of proportion for a 21-line UI behavior change. Pre-existing coverage gap, not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)