### PR TITLE
GH #22: Eliminate Memory↔APU circular dependency

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/Memory.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Memory.kt
@@ -16,8 +16,23 @@ class Memory : DmaPort {
     val controller1 = Controller()
     val controller2 = Controller()
 
-    // Will be set by Nestlin after APU creation
-    var apu: Apu? = null
+    /**
+     * APU back-reference for dispatching $4000-$401F register writes/reads
+     * (issue #22). The two halves of Memory↔APU have a circular wiring:
+     * [Apu] takes a [DmaPort] for DMC sample reads, while [Memory] needs
+     * [Apu] to actually drive the channel/frame-counter state on a register
+     * access. The cycle is broken by [createWithApu] — the factory builds
+     * Memory first, hands it to Apu, then attaches Apu back here. Once the
+     * factory returns, [apu] is non-null for the lifetime of this Memory
+     * instance, so dispatch sites can read `apu.handleRegisterWrite(...)`
+     * directly with no null-check.
+     *
+     * Tests that only touch RAM / PPU / controller / DMA regions (i.e. never
+     * read or write $4000-$401F) can still `Memory()` standalone — the lateinit
+     * check fires only when the field is actually read.
+     */
+    lateinit var apu: Apu
+        private set
 
     // Will be set by Nestlin after CPU creation. Memory needs this back-reference
     // so it can halt the CPU for the 513 cycles an OAM DMA takes (NESdev: the CPU
@@ -54,8 +69,8 @@ class Memory : DmaPort {
         // wiring this cart's. Without the clear, swapping a Mapper-24 ROM out
         // for a Mapper-0 ROM would leave the previous VRC6 voices ticking
         // against the silent APU.
-        apu?.clearExpansionChannels()
-        m.expansionAudioChannels().forEach { apu?.registerExpansionChannel(it) }
+        apu.clearExpansionChannels()
+        m.expansionAudioChannels().forEach { apu.registerExpansionChannel(it) }
 
         // Wire CHR banking delegates to the mapper. PPU CHR reads also
         // update the system data-bus, since the PPU drives the shared
@@ -145,7 +160,7 @@ class Memory : DmaPort {
             }
             in 0x4000..0x401F -> {
                 apuAddressedMemory[address - 0x4000] = value
-                apu?.handleRegisterWrite(address - 0x4000, value)
+                apu.handleRegisterWrite(address - 0x4000, value)
             }
             in 0x4020..0xFFFF -> {
                 mapper?.cpuWrite(address, value)
@@ -166,7 +181,7 @@ class Memory : DmaPort {
             in 0x2000..0x3FFF -> ppuAddressedMemory[address % 8]
             0x4016 -> controller1.read()
             0x4017 -> controller2.read()
-            in 0x4000..0x401F -> apu?.handleRegisterRead(address - 0x4000) ?: apuAddressedMemory[address - 0x4000]
+            in 0x4000..0x401F -> apu.handleRegisterRead(address - 0x4000)
             in 0x4020..0xFFFF -> {
                 // Push the current data-bus value into the mapper BEFORE
                 // calling `cpuRead`, so mappers that opt into open-bus
@@ -213,7 +228,7 @@ class Memory : DmaPort {
         in 0x2000..0x3FFF -> ppuAddressedMemory.peek(address % 8)
         0x4016 -> controller1.peek()
         0x4017 -> controller2.peek()
-        in 0x4000..0x401F -> apu?.peekRegisterRead(address - 0x4000) ?: apuAddressedMemory[address - 0x4000]
+        in 0x4000..0x401F -> apu.peekRegisterRead(address - 0x4000)
         in 0x4020..0xFFFF -> mapper?.cpuPeek(address) ?: 0
         else -> 0
     }
@@ -263,4 +278,32 @@ class Memory : DmaPort {
     }
 
     fun resetVector() = this[0xFFFC, 0xFFFD]
+
+    companion object {
+        /**
+         * Build [Memory] and [Apu] together, breaking their circular wiring
+         * (issue #22).
+         *
+         * Why a factory: the two classes have a genuine mutual wiring dependency —
+         * Apu takes a [DmaPort] (which Memory implements) so the DMC channel can
+         * pull sample bytes, while Memory needs Apu to actually drive the channel
+         * / frame-counter state when a CPU write lands at $4000-$401F. There is no
+         * valid construction order where neither references the other, so Kotlin
+         * can't model it with a plain constructor chain. The factory builds Memory
+         * first, hands it to Apu, then attaches Apu back to Memory. From this point
+         * on `memory.apu` is non-null for the lifetime of the [Memory] instance,
+         * so dispatch sites read `apu.handleRegisterWrite(...)` directly with no
+         * null-check penalty.
+         *
+         * Tests that touch only RAM / PPU / controller / DMA regions (i.e. never
+         * read or write $4000-$401F) can keep using `Memory()` standalone — the
+         * [apu] lateinit check fires only when the field is actually accessed.
+         */
+        fun createWithApu(): Pair<Memory, Apu> {
+            val memory = Memory()
+            val apu = Apu(memory)
+            memory.apu = apu
+            return memory to apu
+        }
+    }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
@@ -55,12 +55,14 @@ class Nestlin {
     private var suppressRewindCapture = false
 
     init {
-        memory = Memory()
+        // Memory↔APU circular wiring goes through the factory (issue #22): the factory
+        // builds Memory, hands it to Apu (DmaPort for DMC), then attaches Apu back to
+        // Memory (for $4000-$401F register dispatch). After this, memory.apu is
+        // non-null and stays that way for the lifetime of the Memory instance.
+        Memory.createWithApu().also { (m, a) -> memory = m; apu = a }
         cpu = Cpu(memory)
         memory.cpu = cpu
         ppu = Ppu(memory)
-        apu = Apu(memory)
-        memory.apu = apu
         // One savestate per frame into the rewind ring. Registered on the long-lived PPU so it
         // survives ROM loads/resets; fires on the emulation thread at a clean frame boundary.
         ppu.addFrameCompletionListener { captureRewindSnapshot() }

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/Cpu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/Cpu.kt
@@ -276,7 +276,7 @@ class Cpu(var memory: Memory)
         // after the NMI.
         if (_nmiArmed) return false
         if (_processorStatus.interruptDisable) return false
-        if (memory.apu?.isIrqPending() != true && memory.mapper?.isIrqPending() != true) return false
+        if (!memory.apu.isIrqPending() && memory.mapper?.isIrqPending() != true) return false
 
         // Push PC (high byte first, then low byte)
         val pc = _registers.programCounter.toUnsignedInt()

--- a/src/test/kotlin/com/github/alondero/nestlin/ApuPeekTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ApuPeekTest.kt
@@ -14,9 +14,11 @@ import org.junit.jupiter.api.Test
 class ApuPeekTest {
 
     private fun apuWithFrameIrqPending(): Apu {
-        val memory = Memory()
-        val apu = Apu(memory)
-        memory.apu = apu
+        // Use the factory (issue #22): Memory and Apu are wired together so that
+        // memory.apu is non-null. Test scenarios below call apu.* directly anyway,
+        // but keeping the factory path means a future change to register dispatch
+        // through Memory won't break this helper.
+        val (_, apu) = Memory.createWithApu()
         // 4-step sequence, IRQ enabled (bit 7 = 0 mode, bit 6 = 0 inhibit).
         apu.handleRegisterWrite(0x17, 0)
         // Run the frame counter until it raises the frame IRQ (fires once per
@@ -55,9 +57,7 @@ class ApuPeekTest {
 
     @Test
     fun `peek of a non-status register returns the backing byte`() {
-        val memory = Memory()
-        val apu = Apu(memory)
-        memory.apu = apu
+        val (_, apu) = Memory.createWithApu()
         apu.handleRegisterWrite(0x03, 0xAB.toByte()) // pulse1 length/timer-high
 
         assertThat(apu.peekRegisterRead(0x03), equalTo(0xAB.toByte()))

--- a/src/test/kotlin/com/github/alondero/nestlin/MemoryOamDmaTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/MemoryOamDmaTest.kt
@@ -33,7 +33,9 @@ class MemoryOamDmaTest {
 
     @Test
     fun `OAM DMA halts the CPU for 513 cycles`() {
-        val memory = Memory()
+        // Factory (issue #22): wire Memory + Apu so cpu.memory.apu is non-null when
+        // the IRQ-check path reads it on every cpu.tick().
+        val (memory, _) = Memory.createWithApu()
         val cpu = Cpu(memory)
         memory.cpu = cpu
 
@@ -66,7 +68,7 @@ class MemoryOamDmaTest {
 
     @Test
     fun `multiple DMAs in a row each halt the CPU independently`() {
-        val memory = Memory()
+        val (memory, _) = Memory.createWithApu()
         val cpu = Cpu(memory)
         memory.cpu = cpu
 

--- a/src/test/kotlin/com/github/alondero/nestlin/MemoryPeekTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/MemoryPeekTest.kt
@@ -40,7 +40,9 @@ class MemoryPeekTest {
 
     @Test
     fun `peek does not update the data bus`() {
-        val memory = Memory()
+        // Use the factory (issue #22): $4015 peek dispatches to Apu, and
+        // Memory.apu is non-nullable after the factory wires the pair.
+        val (memory, _) = Memory.createWithApu()
         memory[0x0005] = 0x42
         memory.dataBus = 0x7E // sentinel
 
@@ -55,7 +57,9 @@ class MemoryPeekTest {
 
     @Test
     fun `peek of cartridge space matches the mapper read`() {
-        val memory = Memory()
+        // Factory (issue #22): readCartridge now dispatches mapper audio channels
+        // through Apu, so memory.apu must be wired before any readCartridge call.
+        val (memory, _) = Memory.createWithApu()
         memory.readCartridge(testGamePak { mapper = 0; prgKb = 16; chrKb = 8 })
         val mapper = memory.mapper!!
 

--- a/src/test/kotlin/com/github/alondero/nestlin/MemoryPokeTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/MemoryPokeTest.kt
@@ -38,7 +38,9 @@ class MemoryPokeTest {
 
     @Test
     fun `poke of 4014 does not trigger OAM DMA`() {
-        val memory = Memory()
+        // Factory (issue #22): keeps the Cpu construction pattern consistent with the
+        // other Memory tests; the IRQ-check path on cpu.tick() now needs apu non-null.
+        val (memory, _) = Memory.createWithApu()
         val cpu = Cpu(memory)
         memory.cpu = cpu
         // Seed a recognisable page so we'd notice if a DMA copied it into OAM.
@@ -83,7 +85,9 @@ class MemoryPokeTest {
 
     @Test
     fun `poke of a mapper register triggers the bank switch`() {
-        val memory = Memory()
+        // Factory (issue #22): readCartridge now dispatches mapper audio channels
+        // through Apu, so memory.apu must be wired before any readCartridge call.
+        val (memory, _) = Memory.createWithApu()
         // Mapper 2 (UNROM): $8000-$BFFF is the switchable 16KB PRG window, selected
         // by the low 3 bits of any $8000-$FFFF write. 128KB = 8 banks; stamp each
         // bank's first byte with its index so the mapped bank is directly readable.

--- a/src/test/kotlin/com/github/alondero/nestlin/apu/AudioPipelineTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/apu/AudioPipelineTest.kt
@@ -19,8 +19,9 @@ class AudioPipelineTest {
 
     @Test
     fun bufferFillsOverTimeWithoutThrottling() {
-        val memory = Memory()
-        val apu = Apu(memory)
+        // Factory (issue #22): Memory and Apu are wired so register writes through
+        // Memory dispatch to the APU rather than being silently dropped.
+        val (_, apu) = Memory.createWithApu()
 
         // Run for 60 frames worth of CPU cycles (no throttling)
         // Each frame is 29830 CPU cycles at 4-step mode
@@ -38,8 +39,7 @@ class AudioPipelineTest {
 
     @Test
     fun bufferLevelRemainsStableOverManyFrames() {
-        val memory = Memory()
-        val apu = Apu(memory)
+        val (_, apu) = Memory.createWithApu()
 
         val bufferLevels = mutableListOf<Int>()
 
@@ -71,8 +71,11 @@ class AudioPipelineTest {
 
     @Test
     fun mixingFormulaProducesConsistentOutputRange() {
-        val memory = Memory()
-        val apu = Apu(memory)
+        // Factory (issue #22): Memory and Apu are wired together so writes to
+        // $4000-$4015 actually configure the channels. Before the factory this
+        // test only saw silent output (apu?. was null); now it exercises the real
+        // pulse channel path.
+        val (memory, apu) = Memory.createWithApu()
 
         // Enable pulse channel 1 (square wave)
         memory[0x4000] = 0x50.toByte()  // Duty 12.5%, no envelope
@@ -103,9 +106,55 @@ class AudioPipelineTest {
     }
 
     @Test
+    fun `write to 4000 through Memory actually configures the APU pulse channel`() {
+        // Regression for issue #22: pre-factory, `Memory` had a nullable Apu and
+        // `apu?.handleRegisterWrite(...)` was a silent no-op when unwired, so a
+        // test that built `Memory()` + `Apu(memory)` WITHOUT setting `memory.apu = apu`
+        // (or the AudioPipelineTest pre-#22) wrote to `$4000` and saw the byte land
+        // in `Memory.apuAddressedMemory`, but the pulse channel driver never ran
+        // and `getAudioSamples()` returned all-zero buffers. Now the factory always
+        // wires the pair, so writing `$4000` through Memory MUST configure pulse1
+        // and the channel output MUST go non-zero. If anyone re-introduces a
+        // nullable Apu field (or accidentally restores `apu?.`), this test fails
+        // fast with a zero-output assertion.
+        val (memory, apu) = Memory.createWithApu()
+
+        // Enable pulse1 BEFORE the $4003 write so the length counter actually loads.
+        memory[0x4015] = 0x01.toByte()  // enable pulse1 (length counter now loads)
+        // 75% duty (bits 7-6 = 11 — duty bit is 1 at sequenceStep 0), length halt,
+        // constant volume=15. 75% duty is the only NES duty that has bit=1 at
+        // sequenceStep=0, so the channel output is non-zero IMMEDIATELY after
+        // write4003 resets the sequencer (no need to wait for the timer to wrap).
+        memory[0x4000] = 0xFF.toByte()
+        memory[0x4001] = 0x00.toByte()  // no sweep
+        memory[0x4002] = 0x08.toByte()  // timer low = 8
+        // lengthLoad=1 (NTSC table → 254 frames), timer high=0 → timerPeriod = 8.
+        // Period 8 = ~14 kHz at 1.79 MHz CPU clock, ticks pulse1 every other CPU
+        // cycle. Period >= 8 avoids the `timerPeriod < 8 → silenced` output gate.
+        memory[0x4003] = 0x08.toByte()
+
+        // Two CPU cycles is enough to clock pulse1 once (timer ticks on even
+        // cycles, period 8 → advances the sequence by 1). After that, pulse1.output()
+        // returns either 0 or 15 depending on the duty-cycle bit at the new step.
+        repeat(2) { apu.tick() }
+
+        // The wiring is exercised iff the channel state actually advanced.
+        // pulse1.output() returns 0 when isEnabled=false, lengthCounter=0,
+        // timerPeriod<8, or sweep-muted. With the writes above, all four should
+        // pass — pre-#22 the writes never reached the channel and output was
+        // ALWAYS 0 regardless of how many ticks elapsed.
+        val output = apu.pulse1Output()
+        assertThat(
+            "Memory.write($4000-$4003) must configure pulse1 via the factory wiring; " +
+                "pulse1.output() was $output — wiring regression (issue #22)",
+            output,
+            greaterThan(0)
+        )
+    }
+
+    @Test
     fun emptyBufferDoesNotCauseCrash() {
-        val memory = Memory()
-        val apu = Apu(memory)
+        val (_, apu) = Memory.createWithApu()
 
         // Get samples before any ticks (should return empty array)
         val initialSamples = apu.getAudioSamples()
@@ -121,8 +170,7 @@ class AudioPipelineTest {
 
     @Test
     fun frameCounterResetDoesNotCorruptCycleAccumulator() {
-        val memory = Memory()
-        val apu = Apu(memory)
+        val (_, apu) = Memory.createWithApu()
 
         // Track samples produced over multiple frames
         val samplesPerFrame = mutableListOf<Int>()

--- a/src/test/kotlin/com/github/alondero/nestlin/apu/ExpansionAudioChannelTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/apu/ExpansionAudioChannelTest.kt
@@ -30,7 +30,11 @@ class ExpansionAudioChannelTest {
 
     @Test
     fun `register and clear track the expansion channel list`() {
-        val apu = Apu(Memory())
+        // Factory (issue #22): Memory and Apu are wired so register dispatch
+        // through Memory is non-null. This test only exercises expansion-channel
+        // surface, but going through the factory keeps the construction pattern
+        // consistent.
+        val (_, apu) = Memory.createWithApu()
         val ch1 = NullExpansionChannel()
         val ch2 = NullExpansionChannel()
 
@@ -111,7 +115,7 @@ class ExpansionAudioChannelTest {
 
     @Test
     fun `clearing the expansion channel silences subsequent output`() {
-        val apu = Apu(Memory())
+        val (_, apu) = Memory.createWithApu()
         val ch = FakeSquareChannel(frequencyHz = 1000.0, cpuHz = ntscCpuHz)
         apu.registerExpansionChannel(ch)
         runCycles(apu, seconds = 0.05)
@@ -132,7 +136,7 @@ class ExpansionAudioChannelTest {
      * its own expansion channels before clocking begins.
      */
     private fun renderToSamples(seconds: Double, configure: (Apu) -> Unit): ShortArray {
-        val apu = Apu(Memory())
+        val (_, apu) = Memory.createWithApu()
         configure(apu)
         runCycles(apu, seconds)
         return apu.getAudioSamples()

--- a/src/test/kotlin/com/github/alondero/nestlin/apu/PalApuTimingTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/apu/PalApuTimingTest.kt
@@ -50,7 +50,9 @@ class PalApuTimingTest {
 
     @Test
     fun `setting Apu region cascades to the frame counter`() {
-        val apu = Apu(Memory())
+        // Factory (issue #22): Apu needs Memory as DmaPort for DMC; the factory
+        // builds both and wires memory.apu non-null.
+        val (_, apu) = Memory.createWithApu()
         apu.region = Region.PAL
         assertEquals(33254, apu.frameCounterMaxCycles())  // 4-step default, PAL
         // Audio output sample rate is fixed at 44.1 kHz regardless of region.

--- a/src/test/kotlin/com/github/alondero/nestlin/cpu/CpuTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cpu/CpuTest.kt
@@ -20,7 +20,9 @@ class CpuTest {
     fun startsNesTestRomInAutomationByProgramCounter0xC000() {
         val path = Paths.get("testroms/nestest.nes")
 
-        val cpu = Cpu(Memory()).apply {
+        // Factory (issue #22): wire Memory + Apu so cpu.memory.apu is non-null when
+        // the IRQ-check path reads it on every tick.
+        val cpu = Cpu(Memory.createWithApu().first).apply {
             this.currentGame = GamePak(Files.readAllBytes(path))
             this.reset()
         }
@@ -43,7 +45,7 @@ class CpuTest {
         // mapped), so it triggers the `?: run { logUndocumentedOpcode(...) }`
         // branch in tick(). Set the byte AFTER reset() because reset() calls
         // memory.clear() which would wipe it.
-        val cpu = Cpu(Memory()).apply {
+        val cpu = Cpu(Memory.createWithApu().first).apply {
             reset()
             this.memory[0] = 0xCB.toSignedByte()
         }

--- a/src/test/kotlin/com/github/alondero/nestlin/cpu/IdleLoopTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cpu/IdleLoopTest.kt
@@ -21,7 +21,9 @@ class IdleLoopTest {
 
     @Test
     fun branchToSelfStopsReExecutingTheInstruction() {
-        val cpu = Cpu(Memory()).apply {
+        // Factory (issue #22): wire Memory + Apu so cpu.memory.apu is non-null when
+        // the IRQ-check path reads it on every tick.
+        val cpu = Cpu(Memory.createWithApu().first).apply {
             reset()
             registers.programCounter = 0x0000.toSignedShort()
             // BEQ -2  (branches to its own opcode when the zero flag is set)
@@ -46,7 +48,7 @@ class IdleLoopTest {
 
     @Test
     fun jumpToSelfSetsIdle() {
-        val cpu = Cpu(Memory()).apply {
+        val cpu = Cpu(Memory.createWithApu().first).apply {
             reset()
             registers.programCounter = 0x0200.toSignedShort()
             // JMP $0200  (jumps to its own opcode — an unconditional spin loop)
@@ -63,7 +65,7 @@ class IdleLoopTest {
 
     @Test
     fun nmiBreaksOutOfTheIdleParkAndClearsTheFlag() {
-        val cpu = Cpu(Memory()).apply {
+        val cpu = Cpu(Memory.createWithApu().first).apply {
             currentGame = GamePak(spinLoopRom())
             reset()
         }

--- a/src/test/kotlin/com/github/alondero/nestlin/cpu/InterruptCounterTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cpu/InterruptCounterTest.kt
@@ -19,7 +19,9 @@ class InterruptCounterTest {
 
     @Test
     fun nmiCountIncrementsOncePerDispatchedNmi() {
-        val cpu = Cpu(Memory()).apply {
+        // Factory (issue #22): wire Memory + Apu so cpu.memory.apu is non-null when
+        // the IRQ-check path reads it on every tick.
+        val cpu = Cpu(Memory.createWithApu().first).apply {
             currentGame = GamePak(spinLoopRom())
             reset()
         }
@@ -47,7 +49,7 @@ class InterruptCounterTest {
 
     @Test
     fun armedButSuppressedNmiDoesNotCount() {
-        val cpu = Cpu(Memory()).apply {
+        val cpu = Cpu(Memory.createWithApu().first).apply {
             reset()
             registers.programCounter = 0x0000.toSignedShort()
             // A run of NOPs so there is always an in-flight instruction (no idle park),

--- a/src/test/kotlin/com/github/alondero/nestlin/cpu/OpcodeTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cpu/OpcodeTest.kt
@@ -9,7 +9,9 @@ import org.junit.jupiter.api.Test
 
 class OpcodeCMPTest {
 
-    val cpu = Cpu(Memory())
+    // Factory (issue #22): wire Memory + Apu so cpu.memory.apu is non-null when
+    // the IRQ-check path reads it on every tick.
+    val cpu = Cpu(Memory.createWithApu().first)
 
     init {
         with(cpu) {
@@ -55,7 +57,7 @@ class OpcodeCMPTest {
 }
 
 class OpcodePLATest() {
-    val cpu = Cpu(Memory())
+    val cpu = Cpu(Memory.createWithApu().first)
 
     init {
         with(cpu) {
@@ -87,7 +89,7 @@ class OpcodePLATest() {
 }
 
 class OpcodeJSRTest() {
-    val cpu = Cpu(Memory())
+    val cpu = Cpu(Memory.createWithApu().first)
 
     init {
         with(cpu) {

--- a/src/test/kotlin/com/github/alondero/nestlin/cpu/WorkCyclesLeftConsistencyTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cpu/WorkCyclesLeftConsistencyTest.kt
@@ -22,7 +22,9 @@ import org.junit.jupiter.api.Test
  */
 class WorkCyclesLeftConsistencyTest {
 
-    private fun freshCpu() = Cpu(Memory()).apply { reset() }
+    // Factory (issue #22): wire Memory + Apu so cpu.memory.apu is non-null when
+    // the IRQ-check path reads it on every tick.
+    private fun freshCpu() = Cpu(Memory.createWithApu().first).apply { reset() }
 
     @Test
     fun nopImpliedSetsTwoCycles() {

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Vrc6AudioTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Vrc6AudioTest.kt
@@ -233,7 +233,8 @@ class Vrc6AudioTest {
         // Saw divider clocks every other CPU cycle (2 CPU cycles per divider
         // tick). The 6-add-then-reset cycle gives 7 divider ticks per saw
         // period. So f_saw = CPU / (2 * 4096 * 7) ≈ 31.2 Hz.
-        val apu = com.github.alondero.nestlin.Apu(com.github.alondero.nestlin.Memory())
+        // Factory (issue #22): Memory and Apu are wired together so memory.apu is non-null.
+        val (_, apu) = com.github.alondero.nestlin.Memory.createWithApu()
         val saw = Vrc6Saw()
         saw.writeB000(b(0x20))           // rate = 32 → nonzero output
         saw.writeB001(b(0xFF))           // period low = 0xFF


### PR DESCRIPTION
## Summary

Eliminates the post-construction `memory.apu = apu` circular wiring between `Memory` and `Apu` (issue #22).

**Before:** `Memory.apu: Apu?` (nullable). Every APU register read paid a null-check; the per-cycle IRQ poll in `Cpu.checkAndHandleIrq` did `memory.apu?.isIrqPending() != true` on every CPU instruction.

**After:** `Memory.apu: Apu` (non-nullable, `lateinit var` with `private set`). All `apu?.` callsites became direct `apu.`. The per-cycle IRQ poll in `Cpu.kt:279` reads `memory.apu.isIrqPending()` directly with no null-check.

## How the cycle is broken

A new factory `Memory.createWithApu(): Pair<Memory, Apu>` on `Memory.Companion` builds both halves in dependency order:

```kotlin
fun createWithApu(): Pair<Memory, Apu> {
    val memory = Memory()
    val apu = Apu(memory)         // Apu gets Memory as DmaPort for DMC
    memory.apu = apu              // Memory gets Apu for $4000-$401F dispatch
    return memory to apu
}
```

This is the only sanctioned way to construct the pair — the Kotlin `lateinit var` field fires `UninitializedPropertyAccessException` if `memory.apu` is read before the factory runs. Standalone `Memory()` is still safe for tests that only touch RAM/PPU/controller/DMA regions and never call `readCartridge` or read `$4015`.

`Nestlin.init` now does `Memory.createWithApu().also { (m, a) -> memory = m; apu = a }` instead of the old `apu = Apu(memory); memory.apu = apu` post-construction stitch.

## Regression test added

`AudioPipelineTest > write to 4000 through Memory actually configures the APU pulse channel` writes to `$4000-$4003` via `Memory` and asserts `pulse1.output() > 0` after two ticks. The pre-#22 wiring let a write to `$4000` land in `Memory.apuAddressedMemory` while `apu?.handleRegisterWrite(...)` was a silent no-op, so this exact failure mode (write-through-Memory → APU channel driver) was previously unverified.

## Migration

13 test files that constructed `Memory()` / `Apu(Memory())` / `Cpu(Memory())` standalone were migrated to the factory. Pattern:

- Need only Memory: `val (memory, _) = Memory.createWithApu()`
- Need only Apu: `val (_, apu) = Memory.createWithApu()`
- Need both: `val (memory, apu) = Memory.createWithApu()` or `Cpu(Memory.createWithApu().first)`

## Verification

- `./gradlew test` — **815 tests pass, 0 failures, 0 errors, 6 skipped** (Mesen2 oracle lanes that need the binary on disk).
- `./gradlew bootcheck -Prom=…/kirby.nes -Pframes=120` — **BOOTCHECK VERDICT: PASS** (Mapper 4, 118 NMIs / 120 frames, 8 distinct PRG states, 0 IRQs, non-blank render).

## Diff stats

16 files changed, +169 / -49 lines. All production diff is in `Memory.kt` (factory + lateinit + comments), `Nestlin.kt` (factory call in init), `Cpu.kt` (one null-check removed). Test diff is mechanical migration.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)