### PR TITLE
GH #198: Consolidate ChrMemory helpers (snapshotBytes + boolean-prefix fold)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/ChrMemory.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/ChrMemory.kt
@@ -29,10 +29,15 @@ import java.io.DataOutput
  *   - [peek] mirrors the project's existing `peek` precedent from
  *     `Memory.kt`. It defaults to [read] but a mapper that grows
  *     read-side-effect banking can override it without changing [read].
- *   - [serialize] / [deserialize] reserve the save-state seam so a future
- *     [ChrMemory] adapter (e.g. battery-backed CHR-RAM) can plug in
- *     without touching [DefaultChrMemory]. The mapper save-state refactor
- *     that uses these hooks is tracked separately from this issue.
+ *   - [serialize] / [deserialize] are the save-state seam: mappers call
+ *     these directly (no leading boolean prefix). ROM-backed adapters
+ *     write 0 bytes; RAM-backed adapters write N bytes — the byte count
+ *     is self-describing. A future [ChrMemory] adapter (e.g. battery-
+ *     backed CHR-RAM) can plug in without touching any mapper.
+ *   - [snapshotBytes] returns a fresh `ByteArray?` copy of the RAM for
+ *     the debug snapshot — null when ROM-backed. Its size tracks
+ *     [chrRamSize], so Mapper 19 N163's 12KB buffer just works without
+ *     a per-mapper special case.
  */
 interface ChrMemory {
     fun read(offset: Int): Byte
@@ -48,6 +53,20 @@ interface ChrMemory {
 
     /** Save-state hook — default no-op. Mirror of [serialize]. */
     fun deserialize(input: DataInput) {}
+
+    /**
+     * Fresh [ByteArray] copy of the CHR-RAM contents for the
+     * [MapperStateSnapshot.chrRam] debug-display field, or null when the
+     * backing is CHR-ROM (the ROM is reference-held by [com.github.alondero.nestlin.gamepak.GamePak]
+     * and not part of the mapper state).
+     *
+     * Uses [peek] so any future adapter that grows a read-side effect (none
+     * today) snapshots cleanly. The size tracks the underlying RAM — Mapper 19
+     * N163's 12KB buffer just works without a per-mapper special case.
+     *
+     * Default is null; [DefaultChrMemory] overrides.
+     */
+    fun snapshotBytes(): ByteArray? = null
 
     companion object {
         /**
@@ -92,4 +111,7 @@ class DefaultChrMemory(
     override fun deserialize(input: DataInput) {
         if (ram.isNotEmpty()) input.readFully(ram)
     }
+
+    override fun snapshotBytes(): ByteArray? =
+        if (ram.isNotEmpty()) ByteArray(ram.size) { i -> peek(i) } else null
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper1.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper1.kt
@@ -152,6 +152,8 @@ class Mapper1(private val gamePak: GamePak) : Mapper {
         }
     }
 
+    override val saveStateVersion: Int = 2
+
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         out.writeInt(shiftReg)
@@ -159,7 +161,6 @@ class Mapper1(private val gamePak: GamePak) : Mapper {
         out.writeInt(chrBank0)
         out.writeInt(chrBank1)
         out.writeInt(prgBank)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
         out.write(prgRam)
     }
@@ -171,7 +172,6 @@ class Mapper1(private val gamePak: GamePak) : Mapper {
         chrBank0 = input.readInt()
         chrBank1 = input.readInt()
         prgBank = input.readInt()
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
         input.readFully(prgRam)
     }
@@ -190,10 +190,8 @@ class Mapper1(private val gamePak: GamePak) : Mapper {
                 "shiftReg" to shiftReg
             ),
             irqState = null,
-            // Snapshot chrRam for debug display: extract via the peek seam
-            // (no public accessor for raw bytes; the snapshot is rare so
-            // per-byte copy is fine).
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null,
+            // Snapshot chrRam for debug display.
+            chrRam = chrMemory.snapshotBytes(),
             prgRam = prgRam.copyOf()
         )
     }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper11.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper11.kt
@@ -63,11 +63,12 @@ class Mapper11(private val gamePak: GamePak) : Mapper {
         }
     }
 
+    override val saveStateVersion: Int = 2
+
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         out.writeInt(chrBank)
         out.writeInt(prgBank)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
     }
 
@@ -75,7 +76,6 @@ class Mapper11(private val gamePak: GamePak) : Mapper {
         super.loadState(input)
         chrBank = input.readInt()
         prgBank = input.readInt()
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
     }
 
@@ -87,7 +87,7 @@ class Mapper11(private val gamePak: GamePak) : Mapper {
             registers = emptyMap(),
             irqState = null,
             // Snapshot chrRam for debug display: extract via the peek seam.
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null
+            chrRam = chrMemory.snapshotBytes()
         )
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper113.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper113.kt
@@ -150,12 +150,13 @@ class Mapper113(private val gamePak: GamePak) : Mapper {
         else Mapper.MirroringMode.HORIZONTAL
     }
 
+    override val saveStateVersion: Int = 2
+
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         out.writeInt(prgBank)
         out.writeInt(chrBank)
         out.writeBoolean(verticalMirroring)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
     }
 
@@ -164,7 +165,6 @@ class Mapper113(private val gamePak: GamePak) : Mapper {
         prgBank = input.readInt()
         chrBank = input.readInt()
         verticalMirroring = input.readBoolean()
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
     }
 
@@ -181,7 +181,7 @@ class Mapper113(private val gamePak: GamePak) : Mapper {
             ),
             irqState = null,
             // Snapshot chrRam for debug display: extract via the peek seam.
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null
+            chrRam = chrMemory.snapshotBytes()
         )
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper19.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper19.kt
@@ -384,14 +384,14 @@ class Mapper19(private val gamePak: GamePak) : Mapper {
                 "irqCounter" to irqCounter,
                 "irqPending" to if (irqPending) 1 else 0
             ),
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x3000) { i -> chrMemory.peek(i) } else null,
+            chrRam = chrMemory.snapshotBytes(),
             prgRam = prgRam.copyOf()
         )
     }
 
     // ---- Save state --------------------------------------------------------
 
-    override val saveStateVersion: Int = 2
+    override val saveStateVersion: Int = 3
 
     override fun saveState(out: DataOutput) {
         super.saveState(out)
@@ -406,7 +406,6 @@ class Mapper19(private val gamePak: GamePak) : Mapper {
         out.writeBoolean(prgRamGlobalWriteEnable)
         out.writeInt(prgRamPageWriteProtectMask)
         out.write(prgRam)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
         audio.saveState(out)
     }
@@ -424,7 +423,6 @@ class Mapper19(private val gamePak: GamePak) : Mapper {
         prgRamGlobalWriteEnable = input.readBoolean()
         prgRamPageWriteProtectMask = input.readInt()
         input.readFully(prgRam)
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
         audio.loadState(input)
     }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper2.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper2.kt
@@ -74,11 +74,12 @@ class Mapper2(private val gamePak: GamePak) : Mapper {
         }
     }
 
+    override val saveStateVersion: Int = 2
+
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         out.writeInt(prgBank)
         out.writeInt(chrBank)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
     }
 
@@ -86,7 +87,6 @@ class Mapper2(private val gamePak: GamePak) : Mapper {
         super.loadState(input)
         prgBank = input.readInt()
         chrBank = input.readInt()
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper206.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper206.kt
@@ -158,6 +158,8 @@ class Mapper206(private val gamePak: GamePak) : Mapper {
         }
     }
 
+    override val saveStateVersion: Int = 2
+
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         out.writeInt(prgBank6)
@@ -165,7 +167,6 @@ class Mapper206(private val gamePak: GamePak) : Mapper {
         for (b in chrBanks) out.writeInt(b)
         out.writeInt(bankSelect)
         out.write(prgRam)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
     }
 
@@ -176,7 +177,6 @@ class Mapper206(private val gamePak: GamePak) : Mapper {
         for (i in chrBanks.indices) chrBanks[i] = input.readInt()
         bankSelect = input.readInt()
         input.readFully(prgRam)
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
     }
 
@@ -199,7 +199,7 @@ class Mapper206(private val gamePak: GamePak) : Mapper {
             ),
             irqState = null,
             // Snapshot chrRam for debug display: extract via the peek seam.
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null,
+            chrRam = chrMemory.snapshotBytes(),
             prgRam = prgRam.copyOf()
         )
     }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper3.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper3.kt
@@ -51,7 +51,7 @@ class Mapper3(private val gamePak: GamePak) : Mapper {
         registers = emptyMap(),
         irqState = null,
         // Snapshot chrRam for debug display: extract via the peek seam.
-        chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null
+        chrRam = chrMemory.snapshotBytes()
     )
 
     override fun ppuRead(address: Int): Byte {
@@ -78,17 +78,17 @@ class Mapper3(private val gamePak: GamePak) : Mapper {
         }
     }
 
+    override val saveStateVersion: Int = 2
+
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         out.writeInt(chrBank)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
     }
 
     override fun loadState(input: DataInput) {
         super.loadState(input)
         chrBank = input.readInt()
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper33.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper33.kt
@@ -154,13 +154,14 @@ class Mapper33(private val gamePak: GamePak) : Mapper {
         else Mapper.MirroringMode.VERTICAL
     }
 
+    override val saveStateVersion: Int = 2
+
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         out.writeInt(prgBank0)
         out.writeInt(prgBank1)
         for (b in chrBanks) out.writeInt(b)
         out.writeBoolean(horizontalMirroring)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
     }
 
@@ -170,7 +171,6 @@ class Mapper33(private val gamePak: GamePak) : Mapper {
         prgBank1 = input.readInt()
         for (i in chrBanks.indices) chrBanks[i] = input.readInt()
         horizontalMirroring = input.readBoolean()
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
     }
 
@@ -195,7 +195,7 @@ class Mapper33(private val gamePak: GamePak) : Mapper {
             ),
             irqState = null,
             // Snapshot chrRam for debug display: extract via the peek seam.
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null
+            chrRam = chrMemory.snapshotBytes()
         )
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper34.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper34.kt
@@ -66,11 +66,12 @@ class Mapper34(private val gamePak: GamePak) : Mapper {
         }
     }
 
+    override val saveStateVersion: Int = 2
+
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         out.writeInt(prgBank)
         out.writeInt(chrBank)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
     }
 
@@ -78,7 +79,6 @@ class Mapper34(private val gamePak: GamePak) : Mapper {
         super.loadState(input)
         prgBank = input.readInt()
         chrBank = input.readInt()
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
     }
 
@@ -93,7 +93,7 @@ class Mapper34(private val gamePak: GamePak) : Mapper {
             registers = emptyMap(),
             irqState = null,
             // Snapshot chrRam for debug display: extract via the peek seam.
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null
+            chrRam = chrMemory.snapshotBytes()
         )
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper4.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper4.kt
@@ -290,6 +290,8 @@ open class Mapper4(private val gamePak: GamePak) : Mapper {
      */
     override fun isIrqPending(): Boolean = scanlineCounter.isIrqPending()
 
+    override val saveStateVersion: Int = 2
+
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         out.writeInt(prgBank6)
@@ -303,7 +305,6 @@ open class Mapper4(private val gamePak: GamePak) : Mapper {
         out.writeBoolean(prgMode)
         scanlineCounter.saveState(out)
         out.writeInt(mirroringOverride?.ordinal ?: -1)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
     }
 
@@ -321,7 +322,6 @@ open class Mapper4(private val gamePak: GamePak) : Mapper {
         scanlineCounter.loadState(input)
         val mirrorOrd = input.readInt()
         mirroringOverride = if (mirrorOrd < 0) null else Mapper.MirroringMode.values()[mirrorOrd]
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
     }
 
@@ -352,7 +352,7 @@ open class Mapper4(private val gamePak: GamePak) : Mapper {
                 "a12ToggleCount" to 0
             ),
             // Snapshot chrRam for debug display: extract via the peek seam.
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null,
+            chrRam = chrMemory.snapshotBytes(),
             prgRam = prgRam.copyOf()
         )
     }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper5.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper5.kt
@@ -300,6 +300,8 @@ class Mapper5(private val gamePak: GamePak) : Mapper {
 
     override fun isIrqPending(): Boolean = irqPending
 
+    override val saveStateVersion: Int = 2
+
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         out.writeInt(prgBank8000)
@@ -324,7 +326,6 @@ class Mapper5(private val gamePak: GamePak) : Mapper {
         out.writeBoolean(irqEnablePending)
         out.writeInt(multiplicand)
         out.writeInt(multiplier)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
     }
 
@@ -352,7 +353,6 @@ class Mapper5(private val gamePak: GamePak) : Mapper {
         irqEnablePending = input.readBoolean()
         multiplicand = input.readInt()
         multiplier = input.readInt()
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
     }
 
@@ -384,7 +384,7 @@ class Mapper5(private val gamePak: GamePak) : Mapper {
                 "irqPending" to irqPending
             ),
             // Snapshot chrRam for debug display: extract via the peek seam.
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null,
+            chrRam = chrMemory.snapshotBytes(),
             prgRam = prgRam.copyOf()
         )
     }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper64.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper64.kt
@@ -210,7 +210,7 @@ class Mapper64(private val gamePak: GamePak) : Mapper4(gamePak) {
                 "irqPending" to if (scanlineCounter.isIrqPending()) 1 else 0,
                 "a12ToggleCount" to 0
             ),
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null,
+            chrRam = chrMemory.snapshotBytes(),
             prgRam = null   // No PRG-RAM on real hardware.
         )
     }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper65.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper65.kt
@@ -203,6 +203,8 @@ class Mapper65(private val gamePak: GamePak) : Mapper {
         else Mapper.MirroringMode.VERTICAL
     }
 
+    override val saveStateVersion: Int = 2
+
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         for (b in prgBanks) out.writeInt(b)
@@ -212,7 +214,6 @@ class Mapper65(private val gamePak: GamePak) : Mapper {
         out.writeInt(irqCounter)
         out.writeInt(irqReloadValue)
         out.writeBoolean(irqPending)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
     }
 
@@ -225,7 +226,6 @@ class Mapper65(private val gamePak: GamePak) : Mapper {
         irqCounter = input.readInt()
         irqReloadValue = input.readInt()
         irqPending = input.readBoolean()
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
     }
 
@@ -256,7 +256,7 @@ class Mapper65(private val gamePak: GamePak) : Mapper {
                 "irqPending" to if (irqPending) 1 else 0
             ),
             // Snapshot chrRam for debug display: extract via the peek seam.
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null
+            chrRam = chrMemory.snapshotBytes()
         )
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper66.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper66.kt
@@ -77,14 +77,15 @@ class Mapper66(private val gamePak: GamePak) : Mapper {
         registers = emptyMap(),
         irqState = null,
         // Snapshot chrRam for debug display: extract via the peek seam.
-        chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null
+        chrRam = chrMemory.snapshotBytes()
     )
+
+    override val saveStateVersion: Int = 2
 
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         out.writeInt(prgBank)
         out.writeInt(chrBank)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
     }
 
@@ -92,7 +93,6 @@ class Mapper66(private val gamePak: GamePak) : Mapper {
         super.loadState(input)
         prgBank = input.readInt()
         chrBank = input.readInt()
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper69.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper69.kt
@@ -155,6 +155,8 @@ class Mapper69(private val gamePak: GamePak) : Mapper {
         }
     }
 
+    override val saveStateVersion: Int = 2
+
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         out.writeInt(command)
@@ -169,7 +171,6 @@ class Mapper69(private val gamePak: GamePak) : Mapper {
         out.writeBoolean(irqCounterEnable)
         out.writeBoolean(irqEnable)
         out.writeBoolean(irqPending)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
     }
 
@@ -188,7 +189,6 @@ class Mapper69(private val gamePak: GamePak) : Mapper {
         irqCounterEnable = input.readBoolean()
         irqEnable = input.readBoolean()
         irqPending = input.readBoolean()
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
     }
 
@@ -223,7 +223,7 @@ class Mapper69(private val gamePak: GamePak) : Mapper {
                 "irqPending" to if (irqPending) 1 else 0
             ),
             // Snapshot chrRam for debug display: extract via the peek seam.
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null,
+            chrRam = chrMemory.snapshotBytes(),
             prgRam = prgRam.copyOf()
         )
     }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper7.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper7.kt
@@ -86,7 +86,7 @@ class Mapper7(private val gamePak: GamePak) : Mapper {
             registers = emptyMap(),
             irqState = null,
             // Snapshot chrRam for debug display: extract via the peek seam.
-            chrRam = ByteArray(0x2000) { i -> chrMemory.peek(i) }
+            chrRam = chrMemory.snapshotBytes()
         )
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper71.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper71.kt
@@ -110,12 +110,13 @@ class Mapper71(private val gamePak: GamePak) : Mapper {
         }
     }
 
+    override val saveStateVersion: Int = 2
+
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         out.writeInt(prgBank)
         out.writeBoolean(bf9097Mode)
         out.writeBoolean(firehawkMirrorUpper == true)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
     }
 
@@ -124,7 +125,6 @@ class Mapper71(private val gamePak: GamePak) : Mapper {
         prgBank = input.readInt()
         bf9097Mode = input.readBoolean()
         firehawkMirrorUpper = if (input.readBoolean()) true else null
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
     }
 
@@ -143,7 +143,7 @@ class Mapper71(private val gamePak: GamePak) : Mapper {
             ),
             irqState = null,
             // Snapshot chrRam for debug display: extract via the peek seam.
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null
+            chrRam = chrMemory.snapshotBytes()
         )
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Vrc4.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Vrc4.kt
@@ -245,6 +245,8 @@ abstract class Vrc4(protected val gamePak: GamePak) : Mapper {
         }
     }
 
+    override val saveStateVersion: Int = 2
+
     override fun saveState(out: DataOutput) {
         super.saveState(out)
         out.writeInt(prg0)
@@ -261,7 +263,6 @@ abstract class Vrc4(protected val gamePak: GamePak) : Mapper {
         out.writeBoolean(irqEnabled)
         out.writeBoolean(irqEnableAfterAck)
         out.writeBoolean(irqPending)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
     }
 
@@ -281,7 +282,6 @@ abstract class Vrc4(protected val gamePak: GamePak) : Mapper {
         irqEnabled = input.readBoolean()
         irqEnableAfterAck = input.readBoolean()
         irqPending = input.readBoolean()
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
     }
 
@@ -321,7 +321,7 @@ abstract class Vrc4(protected val gamePak: GamePak) : Mapper {
                 "irqEnableAfterAck" to if (irqEnableAfterAck) 1 else 0,
                 "irqPending" to if (irqPending) 1 else 0
             ),
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null,
+            chrRam = chrMemory.snapshotBytes(),
             prgRam = prgRam.copyOf()
         )
     }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Vrc6.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Vrc6.kt
@@ -335,10 +335,12 @@ abstract class Vrc6(protected val gamePak: GamePak) : Mapper {
                 "irqEnableAfterAck" to if (irqEnableAfterAck) 1 else 0,
                 "irqPending" to if (irqPending) 1 else 0
             ),
-            chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null,
+            chrRam = chrMemory.snapshotBytes(),
             prgRam = prgRam.copyOf()
         )
     }
+
+    override val saveStateVersion: Int = 2
 
     override fun saveState(out: DataOutput) {
         super.saveState(out)
@@ -355,7 +357,6 @@ abstract class Vrc6(protected val gamePak: GamePak) : Mapper {
         out.writeBoolean(irqEnabled)
         out.writeBoolean(irqEnableAfterAck)
         out.writeBoolean(irqPending)
-        out.writeBoolean(chrRom.isEmpty())
         chrMemory.serialize(out)
         pulse1.saveState(out)
         pulse2.saveState(out)
@@ -378,7 +379,6 @@ abstract class Vrc6(protected val gamePak: GamePak) : Mapper {
         irqEnabled = input.readBoolean()
         irqEnableAfterAck = input.readBoolean()
         irqPending = input.readBoolean()
-        input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM
         chrMemory.deserialize(input)
         pulse1.loadState(input)
         pulse2.loadState(input)

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/ChrMemoryTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/ChrMemoryTest.kt
@@ -146,4 +146,54 @@ class ChrMemoryTest {
             mem.read(0x2000)
         }
     }
+
+    @Test
+    fun `snapshotBytes returns null when CHR-ROM is present`() {
+        val mem = ChrMemory.default(ByteArray(0x2000) { it.toByte() })
+        assertThat(mem.snapshotBytes(), equalTo(null as ByteArray?))
+    }
+
+    @Test
+    fun `snapshotBytes copies CHR-RAM contents at the configured size`() {
+        val mem = ChrMemory.default(chrRom = ByteArray(0), chrRamSize = 0x2000)
+        mem.write(0x0001, 0x11.toByte())
+        mem.write(0x1234, 0x22.toByte())
+        mem.write(0x1FFF, 0x33.toByte())
+
+        val snap = mem.snapshotBytes()
+        assertThat(snap!!.size, equalTo(0x2000))
+        assertThat(snap[0x0001], equalTo(0x11.toByte()))
+        assertThat(snap[0x1234], equalTo(0x22.toByte()))
+        assertThat(snap[0x1FFF], equalTo(0x33.toByte()))
+        assertThat(snap[0x0000], equalTo(0.toByte()))   // untouched byte stays zero
+    }
+
+    @Test
+    fun `snapshotBytes size tracks chrRamSize - Mapper 19 N163 12KB`() {
+        // The whole point of snapshotBytes vs an inline peek loop: the
+        // size follows the underlying buffer, so Mapper 19's 0x3000 case
+        // works without a per-mapper special case.
+        val mem = ChrMemory.default(chrRom = ByteArray(0), chrRamSize = 0x3000)
+        mem.write(0x2400, 0xCD.toByte())   // bank 9
+        mem.write(0x2FFF, 0xEF.toByte())   // bank 11 last byte
+
+        val snap = mem.snapshotBytes()
+        assertThat(snap!!.size, equalTo(0x3000))
+        assertThat(snap[0x2400], equalTo(0xCD.toByte()))
+        assertThat(snap[0x2FFF], equalTo(0xEF.toByte()))
+    }
+
+    @Test
+    fun `snapshotBytes returns a fresh array - mutating it does not affect backing`() {
+        // The snapshot is a debug-display copy. Mutating it must not
+        // mutate the ChrMemory's RAM.
+        val mem = ChrMemory.default(chrRom = ByteArray(0), chrRamSize = 0x10)
+        mem.write(0x05, 0x42.toByte())
+
+        val snap = mem.snapshotBytes()
+        snap!![0x05] = 0xFF.toByte()
+
+        assertThat(mem.read(0x05), equalTo(0x42.toByte()))
+        assertThat(snap[0x05], equalTo(0xFF.toByte()))
+    }
 }


### PR DESCRIPTION
## Context

Implementation of the ChrMemory interface ([#193](https://github.com/alondero/nestlin/issues/193), landed in PR [#197](https://github.com/alondero/nestlin/pull/197)) left a duplication that ADR-0002 deferred to a follow-up: the `saveState`/`loadState` 2-line pattern and the 1-line `snapshot` peek-loop repeated across 18 mappers. This is the simplification follow-up the ADR explicitly deferred.

## Slice 1 — `ChrMemory.snapshotBytes()` (additive, no save-format change)

- Add `ChrMemory.snapshotBytes(): ByteArray?` — fresh RAM copy for the debug snapshot, null when ROM-backed. Uses `peek()` so future read-side-effect adapters snapshot cleanly.
- **Size tracks `chrRamSize` automatically** — Mapper 19 N163's 0x3000 case works without a per-mapper special case.
- Replace 18 copies of `chrRam = if (chrRom.isEmpty()) ByteArray(0x2000) { i -> chrMemory.peek(i) } else null` (and the 0x3000 / always-allocate variants) with `chrRam = chrMemory.snapshotBytes()`.
- 4 new unit tests cover ROM null, RAM size + bytes, Mapper 19 12KB case, and mutation isolation.

## Slice 2 — Fold the boolean prefix into the save hooks (breaking save format)

- Remove `out.writeBoolean(chrRom.isEmpty())` and matching `input.readBoolean()    // hasChrRam — chrMemory knows whether it has RAM` from 17 mappers.
- The byte count is now self-describing: 0 bytes = ROM, N bytes = RAM.
- Bump `saveStateVersion` on affected mappers (most 1→2, Mapper19 2→3).
- **Inheritance payoff**: `saveStateVersion` is a polymorphic property; bumping it on `Mapper4` automatically bumps `Mapper64`, `Vrc4` → `Mapper21`/`23`/`25`, `Vrc6` → `Mapper24`/`26`. **One declaration covers the whole hierarchy** — exactly the consolidation payoff the issue was after.

## Cost

Existing `.nstl` save files for affected mappers no longer load — `super.loadState` rejects them with `IncompatibleSaveStateException`. Documented in the issue and intentional per ADR-0002's "negative / deferred" section, which this PR completes.

## Verification

- `./gradlew build` — BUILD SUCCESSFUL, 14 actionable tasks
- `./gradlew test --rerun-tasks` — **828 tests pass, 0 failures, 0 errors** (6 Mesen2-gated skipped)
- `./gradlew bootcheck -Prom=X:/src/nestlin/testroms/kirby.nes -Pframes=120` — **PASS** (Mapper 4 / MMC3, 120 frames, 118 NMIs)

## For new mappers

The entire ChrMemory surface a new mapper touches is now:

```kotlin
private val chrMemory = ChrMemory.default(chrRom, chrRamSize = 0x2000)  // or 0x3000 for N163
// ppuRead/ppuWrite:  chrMemory.read/write(address and 0x1FFF, ...)
// saveState:         chrMemory.serialize(out)
// loadState:         chrMemory.deserialize(input)
// snapshot:          chrRam = chrMemory.snapshotBytes()
```

**No booleans, no peek loops, no size literals.**

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)