### PR TITLE
GH #207: fix all 9 preserved quirks from #192 Opcodes sealed-class refactor

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/Addressing.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/Addressing.kt
@@ -78,35 +78,32 @@ data class ZeroPage(val x: Boolean = false, val y: Boolean = false) : Addressing
 
 /**
  * Absolute addressing: operand is a 16-bit address following the opcode.
- * Optionally indexed by X or Y (added in 16-bit space).
+ * Optionally indexed by X or Y (added in 16-bit space, then masked to
+ * 16 bits — real-6502 behaviour).
  * Cycles: abs=4, abs,X=4 (+1 on page cross), abs,Y=4 (+1 on page cross).
  * Page-cross +1 cycle is out of scope here (issue #172).
  *
- * **Preserved asymmetry:** the original `absolute()` (value-returning)
+ * **Issue #207 quirk fix.** The original `absolute()` (value-returning)
  * masked the indexed address to 16 bits, but `absoluteAdr()`
- * (address-returning) did not. Read-Modify-Write opcodes that need both
- * the read value and the write address must keep this distinction or
- * they diverge from the original — `Memory.get(addr)` silently returns 0
- * for any address > 0xFFFF, which would corrupt the writeback phase. We
- * preserve that quirk by computing the address once and exposing the
- * masked / unmasked variants via [effectiveAddress] / [address].
+ * (address-returning) did not. Read-Modify-Write opcodes that needed
+ * both the read value and the write address then relied on the unmasked
+ * address silently exceeding $FFFF and being dropped by `Memory.get` /
+ * `set` (out-of-range returns 0 / no-op). Real 6502 wraps to low
+ * memory. Now [address] consistently masks to 16 bits, matching
+ * hardware and aligning with [value].
  */
 data class Absolute(val x: Boolean = false, val y: Boolean = false) : Addressing() {
     override val isIndexed: Boolean get() = x || y
 
-    override fun value(cpu: Cpu): Byte = cpu.memory[effectiveAddress(cpu)]
+    override fun value(cpu: Cpu): Byte = cpu.memory[address(cpu)]
 
     override fun address(cpu: Cpu): Int {
-        // PRESERVED QUIRK: do NOT mask to 16 bits here. See class kdoc.
         val base = cpu.readShortAtPC().toUnsignedInt()
-        return if (x) base + cpu.registers.indexX.toUnsignedInt()
-               else if (y) base + cpu.registers.indexY.toUnsignedInt()
-               else base
+        val raw = if (x) base + cpu.registers.indexX.toUnsignedInt()
+                  else if (y) base + cpu.registers.indexY.toUnsignedInt()
+                  else base
+        return raw and 0xFFFF
     }
-
-    /** Masked-to-16-bits variant used by [value]. Equals [address] with
-     *  `and 0xFFFF` applied. */
-    private fun effectiveAddress(cpu: Cpu): Int = address(cpu) and 0xFFFF
 }
 
 /**

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/ControlFlow.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/ControlFlow.kt
@@ -29,11 +29,10 @@ class Jump(
 
 /**
  * JMP indirect (0x6C) — jump to the 16-bit address stored at a 16-bit
- * pointer. 5 cycles on real 6502; the previous implementation hardcoded
- * 3 cycles via the `jump` helper.
+ * pointer. 5 cycles on real 6502.
  *
- * **Preserved quirk.** The 3-cycle count is preserved (issue #192 is a
- * structural refactor; fixing this cycle count is out of scope).
+ * **Issue #207 quirk fixed.** Earlier dispatcher used 3 cycles (the
+ * `jump` helper hardcoded it). Now threads the real-6502 count of 5.
  *
  * **The 6502 page-boundary bug.** When the indirect pointer straddles a
  * page boundary (e.g., `$10FF` -> `$10FF, $1100`), the 6502 reads the
@@ -45,7 +44,7 @@ class Jump(
  */
 class JumpIndirect(
     override val mnemonic: String,
-) : Opcode(cycles = 3) {
+) : Opcode(cycles = 5) {
     override fun evaluate(cpu: Cpu) {
         val pcBefore = cpu.registers.programCounter
         val ptr = cpu.readShortAtPC().toUnsignedInt()
@@ -58,7 +57,7 @@ class JumpIndirect(
         if (cpu.registers.programCounter == (pcBefore - 1).toSignedShort()) {
             cpu.idle = true
         }
-        cpu.workCyclesLeft = 3
+        cpu.workCyclesLeft = 5
     }
 }
 

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/Opcode.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/Opcode.kt
@@ -32,11 +32,12 @@ import com.github.alondero.nestlin.toUnsignedInt
  * 2-cycle instruction leaves `workCyclesLeft == 1` after one tick — see
  * [OpcodeCycleTableTest] for the regression bar.
  *
- * **Preserved quirks.** Several opcodes carry intentional deviations from
- * real 6502 behaviour (LAX hardcodes 2 cycles, SAX hardcodes 4, JMP
- * indirect uses 3 instead of 5, AHX mask is 0x07). Each carries an inline
- * comment referencing the original `Opcodes.kt` line and a TODO for a
- * follow-up issue.
+ * **Preserved quirks (issue #207).** Several opcodes still carry
+ * intentional deviations from real 6502 behaviour; the ones that survived
+ * the #207 cleanup are documented inline in the relevant subclass.
+ * Fixed in #207: LAX/SAX per-mode cycle counts, JMP indirect cycle
+ * count, AHX mask, 0x9B dispatch (now TAS), 0xE3 dispatch (now DCP),
+ * SHY/SHX registration, KIL halt behaviour, Absolute address masking.
  */
 sealed class Opcode(val cycles: Int) {
     /**

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/Opcodes.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/Opcodes.kt
@@ -20,21 +20,23 @@ import com.github.alondero.nestlin.toUnsignedInt
 object OpcodesRefactor {
 
     /**
-     * The dispatch table: 250 mapped opcodes (6 unmapped: 0x0B, 0x2B,
-     * 0x8B, 0x9C, 0x9E, 0xCB). See [com.github.alondero.nestlin.cpu.OpcodeDispatchCompletenessTest]
+     * The dispatch table: 252 mapped opcodes (4 unmapped: 0x0B, 0x2B,
+     * 0x8B, 0xCB). See [com.github.alondero.nestlin.cpu.OpcodeDispatchCompletenessTest]
      * for the regression bar.
      *
-     * **Cycle-count quirk preservation.** Several opcodes carry intentional
-     * deviations from real 6502 behaviour, marked with `[quirk: ...]`
-     * inline comments in the Opcodes.kt source:
-     *  - LAX hardcodes 2 cycles (real: 6/3/4/5/4/4)
-     *  - SAX hardcodes 4 cycles (real: 6/3/4/4)
-     *  - JMP indirect uses 3 cycles (real: 5)
-     *  - AHX mask is 0x07 (looks like a typo)
-     *  - 0x9B is XAA (canonical: TAS)
-     *  - 0xE3/0xF3 are ISC, not DCP (silent overwrite)
-     *  - KIL doesn't actually halt
-     * Each quirk is preserved by the [OpcodeCycleTableTest] baseline.
+     * **Quirks fixed in issue #207.** The following were preserved as
+     * known anomalies by the #192 sealed-class refactor; #207 fixed them:
+     *  - LAX now uses per-mode cycle counts (real: 6/3/4/5/4/4)
+     *  - SAX now uses per-mode cycle counts (real: 6/3/4/4)
+     *  - JMP indirect uses 5 cycles (real 6502; was 3)
+     *  - AHX mask is now A AND X (the old `and 0x07` was a typo)
+     *  - 0x9B is now TAS abs,Y (was XAA)
+     *  - 0xE3 is now DCP (ind,X) (was ISC, silent overwrite of DCP)
+     *  - 0x9C (SHY) and 0x9E (SHX) are now registered
+     *  - KIL now actually halts the CPU
+     *  - [Absolute.address] now masks to 16 bits
+     * See [Issue207QuirkFixesTest] for behaviour-level regressions and
+     * [OpcodeCycleTableTest] for cycle-count regressions.
      */
     val map: Map<Int, Opcode> = buildMap {
         // ===== Branch (8) =================================================
@@ -259,49 +261,55 @@ object OpcodesRefactor {
         // (6 NOP implied)
         listOf(0x1A, 0x3A, 0x5A, 0x7A, 0xDA, 0xFA).forEach { put(it, NopImplied()) }
 
-        // ===== LAX (6) — quirky cycle counts ==============================
-        put(0xA3, Lax(IndirectX, "LAX (ind,X)"))
-        put(0xA7, Lax(ZeroPage(), "LAX zp"))
-        put(0xAF, Lax(Absolute(), "LAX abs"))
-        put(0xB3, Lax(IndirectY, "LAX (ind),Y"))
-        put(0xB7, Lax(ZeroPage(y = true), "LAX zp,Y"))
-        put(0xBF, Lax(Absolute(y = true), "LAX abs,Y"))
+        // ===== LAX (6) — real-6502 cycle counts (issue #207) ===============
+        put(0xA3, Lax(IndirectX, 6, "LAX (ind,X)"))
+        put(0xA7, Lax(ZeroPage(), 3, "LAX zp"))
+        put(0xAF, Lax(Absolute(), 4, "LAX abs"))
+        put(0xB3, Lax(IndirectY, 5, "LAX (ind),Y"))
+        put(0xB7, Lax(ZeroPage(y = true), 4, "LAX zp,Y"))
+        put(0xBF, Lax(Absolute(y = true), 4, "LAX abs,Y"))
 
-        // ===== SAX (4) — quirky cycle counts ==============================
-        put(0x83, Sax(IndirectX, "SAX (ind,X)"))
-        put(0x87, Sax(ZeroPage(), "SAX zp"))
-        put(0x8F, Sax(Absolute(), "SAX abs"))
-        put(0x97, Sax(ZeroPage(y = true), "SAX zp,Y"))
+        // ===== SAX (4) — real-6502 cycle counts (issue #207) ===============
+        put(0x83, Sax(IndirectX, 6, "SAX (ind,X)"))
+        put(0x87, Sax(ZeroPage(), 3, "SAX zp"))
+        put(0x8F, Sax(Absolute(), 4, "SAX abs"))
+        put(0x97, Sax(ZeroPage(y = true), 4, "SAX zp,Y"))
 
-        // ===== AHX (2) — quirky mask ======================================
+        // ===== AHX (2) — issue #207 quirk fixed: mask now A AND X =======
         put(0x93, Ahx(IndirectY, "AHX (ind),Y"))
         put(0x9F, Ahx(Absolute(y = true), "AHX abs,Y"))
 
-        // ===== XAA (2) — canonical 0x9B should be TAS ====================
-        put(0x9B, Xaa())
+        // ===== SHX / SHY (issue #207 quirk fix) =========================
+        // 0x9C = SHY abs,X (was unmapped), 0x9E = SHX abs,Y (was unmapped).
+        // Classes existed in UnofficialLoadStore.kt but were not registered.
+        put(0x9C, Shy(Absolute(x = true), 5, "SHY abs,X"))
+        put(0x9E, Shx(Absolute(y = true), 5, "SHX abs,Y"))
+
+        // ===== XAA / TAS (issue #207 quirk fix) =========================
+        // Canonical 6502: 0x9B = TAS abs,Y, 0xAB = XAA. Previously both
+        // were XAA (no operand fetch); now 0x9B dispatches to TAS.
+        put(0x9B, Tas(Absolute(y = true), 5, "TAS abs,Y"))
         put(0xAB, Xaa())
 
         // ===== LAS (1) ====================================================
         put(0xBB, Las(Absolute(y = true), "LAS abs,Y"))
 
-        // ===== DCP (6 unique) — 0xE3/0xF3 are ISC, see below ==============
+        // ===== DCP (7) — issue #207 quirk fix: 0xE3 is DCP, not ISC =====
         put(0xC7, Dcp(ZeroPage(), "DCP zp"))
         put(0xD7, Dcp(ZeroPage(x = true), "DCP zp,X"))
         put(0xCF, Dcp(Absolute(), "DCP abs"))
         put(0xDF, Dcp(Absolute(x = true), "DCP abs,X"))
         put(0xDB, Dcp(ZeroPage(y = true), "DCP zp,Y"))
         put(0xD3, Dcp(IndirectX, "DCP (ind,X)"))
+        put(0xE3, Dcp(IndirectX, "DCP (ind,X)"))
 
-        // ===== ISC (7) — including 0xE3/0xF3 silent overwrite ============
+        // ===== ISC (6) — 0xF3 stays ISC; 0xE3 moved to DCP ==============
         put(0xE7, Isc(ZeroPage(), "ISC zp"))
         put(0xF7, Isc(ZeroPage(x = true), "ISC zp,X"))
         put(0xEF, Isc(Absolute(), "ISC abs"))
         put(0xFF, Isc(Absolute(x = true), "ISC abs,X"))
         put(0xFB, Isc(ZeroPage(y = true), "ISC zp,Y"))
-        put(0xE3, Isc(IndirectX, "ISC (ind,X)"))
-        put(0xF3, Isc(IndirectY, "ISC (ind),Y"))
-        // ↑ Original Opcodes.kt:441,442,450,451 maps 0xE3/0xF3 first to
-        // DCP then overwrites with ISC. Preserved here.
+        put(0xF3, Isc(IndirectY, "ISC (ind),Y)"))
 
         // ===== RLA (7) ====================================================
         put(0x27, Rla(ZeroPage(), "RLA zp"))

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/UnofficialCombined.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/UnofficialCombined.kt
@@ -37,10 +37,11 @@ class Dcp(
 /**
  * ISC — INC then SBC. 6/6 cycles for all addressing modes (preserved).
  *
- * **Preserved quirk:** in the original dispatcher, `0xE3` and `0xF3` are
- * first assigned to DCP, then overwritten by ISC (Opcodes.kt:441, 442,
- * 450, 451). The ISC writes come last and win. Preserved here — the
- * dispatch table registers ISC for these bytes, not DCP.
+ * **Issue #207 quirk fix.** In the original dispatcher, `0xE3` and
+ * `0xF3` were both assigned to ISC (0xE3 had a DCP put-then-ISC-overwrite
+ * pattern at Opcodes.kt:441, 442, 450, 451). Canonical 6502 says 0xE3 is
+ * DCP, 0xF3 is ISC. Now `0xE3` dispatches to [Dcp] and only `0xF3`
+ * dispatches here.
  * Original Opcodes.kt:859-874.
  */
 class Isc(

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/UnofficialLoadStore.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/UnofficialLoadStore.kt
@@ -7,52 +7,55 @@ import com.github.alondero.nestlin.toUnsignedInt
 /**
  * LAX — Load A and X combined. 6 opcodes.
  *
- * **Preserved quirk:** the original `lax` helper (Opcodes.kt:770-778)
- * hardcodes `workCyclesLeft = 2` for ALL six addressing modes. Real 6502
- * cycles are 6, 3, 4, 5, 4, 4. Preserving here; out of scope for #192.
- * Original Opcodes.kt:409-414.
+ * Per-mode cycle counts (issue #207, real 6502): (ind,X)=6, zp=3, abs=4,
+ * (ind),Y=5, zp,Y=4, abs,Y=4. (The original `lax` helper hardcoded 2 for
+ * all six; that quirk is now fixed and the per-mode count is threaded
+ * through via [cycles].)
+ * Original Opcodes.kt:409-414, 770-778.
  */
 class Lax(
     val addressing: Addressing,
+    cycles: Int,
     override val mnemonic: String,
-) : Opcode(cycles = 2) {
+) : Opcode(cycles) {
     override fun evaluate(cpu: Cpu) {
         val value = addressing.value(cpu)
         cpu.registers.accumulator = value
         cpu.registers.indexX = value
         cpu.processorStatus.resolveZeroAndNegativeFlags(value)
-        cpu.workCyclesLeft = 2
+        cpu.workCyclesLeft = cycles
     }
 }
 
 /**
  * SAX — Store A AND X. 4 opcodes.
  *
- * **Preserved quirk:** the original `sax` helper (Opcodes.kt:780-785)
- * hardcodes `workCyclesLeft = 4` for ALL four addressing modes. Real 6502
- * cycles: zp=3, abs=4, (ind,X)=6, zp,Y=4. Preserved.
- * Original Opcodes.kt:417-420.
+ * Per-mode cycle counts (issue #207, real 6502): (ind,X)=6, zp=3, abs=4,
+ * zp,Y=4. (The original `sax` helper hardcoded 4 for all four; that
+ * quirk is now fixed.)
+ * Original Opcodes.kt:417-420, 780-785.
  */
 class Sax(
     val addressing: Addressing,
+    cycles: Int,
     override val mnemonic: String,
-) : Opcode(cycles = 4) {
+) : Opcode(cycles) {
     override fun evaluate(cpu: Cpu) {
         val addr = addressing.address(cpu)
         cpu.memory[addr] =
             (cpu.registers.accumulator.toUnsignedInt() and
              cpu.registers.indexX.toUnsignedInt()).toSignedByte()
-        cpu.workCyclesLeft = 4
+        cpu.workCyclesLeft = cycles
     }
 }
 
 /**
- * AHX — Store A AND X AND H. 2 opcodes.
+ * AHX — Store A AND X. 2 opcodes.
  *
- * **Preserved quirk:** the original `ahx` helper (Opcodes.kt:787-793)
- * uses a high-byte mask of `0x07`, which looks like a typo for the real
- * 6502 mask (typically `0xFF` or the address high byte + 1). Preserved
- * here; out of scope for #192.
+ * **Issue #207 quirk fixed.** The original `ahx` helper (Opcodes.kt:787-793)
+ * used a high-byte mask of `0x07` — clearly a typo for the real 6502
+ * mask (typically `0xFF`, since `(A AND X)` is already 8-bit). Now
+ * stores `A AND X` directly with no spurious mask.
  * Original Opcodes.kt:423-424.
  */
 class Ahx(
@@ -61,7 +64,7 @@ class Ahx(
 ) : Opcode(cycles = 4) {
     override fun evaluate(cpu: Cpu) {
         val value = (cpu.registers.accumulator.toUnsignedInt() and
-                     cpu.registers.indexX.toUnsignedInt() and 0x07).toSignedByte()
+                     cpu.registers.indexX.toUnsignedInt()).toSignedByte()
         cpu.memory[addressing.address(cpu)] = value
         cpu.workCyclesLeft = 4
     }
@@ -70,8 +73,9 @@ class Ahx(
 /**
  * XAA / ANE — A = A AND X AND immediate operand. 2 cycles.
  *
- * **Preserved quirk:** 0x9B is canonical 6502 TAS, but is mapped to XAA
- * in this codebase (Opcodes.kt:427-428). 0xAB is canonical XAA.
+ * **Issue #207 quirk fix.** Previously 0x9B was also mapped to XAA, but
+ * canonical 6502 says 0x9B is TAS abs,Y. Now 0x9B dispatches to [Tas];
+ * 0xAB remains XAA.
  * Original Opcodes.kt:795-800.
  */
 class Xaa : Opcode(cycles = 2) {
@@ -103,47 +107,52 @@ class Las(
 }
 
 /**
- * TAS / SHX / SHY — Unofficial store ops. 4 cycles each.
+ * TAS / SHX / SHY — Unofficial store ops. 5 cycles each.
  *
- * **Preserved quirk:** the original `tas()`, `shx()`, `shy()` factory
- * methods (Opcodes.kt:802-826) exist but are NOT registered in the
- * dispatch table. The classes are kept here so a future follow-up issue
- * can register them without re-deriving the bit math.
+ * **Issue #207 quirk fix.** The original `tas()`, `shx()`, `shy()`
+ * factory methods (Opcodes.kt:802-826) exist but were NOT registered in
+ * the dispatch table. Now registered:
+ *  - 0x9B = TAS abs,Y
+ *  - 0x9C = SHY abs,X
+ *  - 0x9E = SHX abs,Y
  */
 class Tas(
     val addressing: Addressing,
+    cycles: Int,
     override val mnemonic: String,
-) : Opcode(cycles = 4) {
+) : Opcode(cycles) {
     override fun evaluate(cpu: Cpu) {
         cpu.registers.stackPointer = cpu.registers.accumulator
         // Original helper ignored the address value; we replicate that.
         @Suppress("UNUSED_VARIABLE") val addr = addressing.address(cpu)
-        cpu.workCyclesLeft = 4
+        cpu.workCyclesLeft = cycles
     }
 }
 
 class Shx(
     val addressing: Addressing,
+    cycles: Int,
     override val mnemonic: String,
-) : Opcode(cycles = 5) {
+) : Opcode(cycles) {
     override fun evaluate(cpu: Cpu) {
         val addr = addressing.address(cpu)
         val highByte = ((addr shr 8) + 1) and 0xFF
         cpu.memory[addr] =
             (cpu.registers.indexX.toUnsignedInt() and highByte).toSignedByte()
-        cpu.workCyclesLeft = 5
+        cpu.workCyclesLeft = cycles
     }
 }
 
 class Shy(
     val addressing: Addressing,
+    cycles: Int,
     override val mnemonic: String,
-) : Opcode(cycles = 5) {
+) : Opcode(cycles) {
     override fun evaluate(cpu: Cpu) {
         val addr = addressing.address(cpu)
         val highByte = ((addr shr 8) + 1) and 0xFF
         cpu.memory[addr] =
             (cpu.registers.indexY.toUnsignedInt() and highByte).toSignedByte()
-        cpu.workCyclesLeft = 5
+        cpu.workCyclesLeft = cycles
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/UnofficialNop.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/UnofficialNop.kt
@@ -58,17 +58,18 @@ class NopImm : Opcode(cycles = 2) {
 /**
  * KIL — unofficial "halt" opcode (13 variants).
  *
- * **Preserved quirk:** the original `kil` helper (Opcodes.kt:828-833) does
- * NOT actually halt the CPU — it just consumes 2 cycles and advances PC
- * by one byte (the KIL opcode itself). So a stream of KIL bytes walks
- * through them one per 2 cycles indefinitely. Preserving here; making a
- * true halt is out of scope for #192.
+ * **Issue #207 quirk fix.** The original `kil` helper (Opcodes.kt:828-833)
+ * did NOT actually halt the CPU — it just consumed 2 cycles and either
+ * walked the PC through a stream of KIL bytes or (in the sealed-class
+ * port) just sat in a 2-cycle loop. Real 6502 behaviour freezes the
+ * CPU until RESET. Now we set [Cpu.idle] — the existing parking
+ * mechanism in [Cpu.tick] skips opcode dispatch but still ticks
+ * PPU/APU and the [InterruptController] (so NMI/IRQ can still wake
+ * the CPU; RESET is the only thing that can recover a true KIL).
  */
 class Kil : Opcode(cycles = 2) {
     override val mnemonic = "KIL"
     override fun evaluate(cpu: Cpu) {
-        // No-op: don't advance PC, but set workCyclesLeft so the scheduler
-        // decrements normally. Mirrors the original behaviour.
-        cpu.workCyclesLeft = 2
+        cpu.idle = true
     }
 }

--- a/src/test/kotlin/com/github/alondero/nestlin/cpu/Issue207QuirkFixesTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cpu/Issue207QuirkFixesTest.kt
@@ -1,0 +1,286 @@
+package com.github.alondero.nestlin.cpu
+
+import com.github.alondero.nestlin.Memory
+import com.github.alondero.nestlin.testutil.FakeInterruptController
+import com.github.alondero.nestlin.toSignedByte
+import com.github.alondero.nestlin.toSignedShort
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Issue #207 — fix preserved quirks from #192 Opcodes sealed-class refactor.
+ *
+ * Each test below pins the NEW (correct) behaviour for one of the 9
+ * preserved quirks. The cycle-count dimension is covered by
+ * [OpcodeCycleTableTest]; this file covers the semantic dimension
+ * (what the opcode DOES, not just how long it takes).
+ *
+ * The 9 quirks, mapped to test names:
+ *  - LAX per-mode cycle counts           → `laxLoadsBothRegisters`
+ *  - SAX per-mode cycle counts           → `saxStoresAAndX`
+ *  - JMP indirect uses 5 cycles          → `jmpIndirectUsesFiveCycles`
+ *  - AHX mask is 0xFF, not 0x07          → `ahxPreservesHighBits`
+ *  - 0x9B is TAS, not XAA                → `opcode9bIsTasNotXaa`
+ *  - 0xE3 is DCP, not ISC                → `opcodeE3IsDcpNotIsc`
+ *  - 0x9C (SHY) and 0x9E (SHX) registered → `shyShxAreRegistered`
+ *  - KIL actually halts                  → `kilHaltsTheCpu`
+ *  - Absolute.address() masks to 16 bits → `absoluteAddressWrapsAtFFFF`
+ */
+class Issue207QuirkFixesTest {
+
+    private fun freshCpu() = Cpu(Memory.createWithApu().first).apply { reset() }
+
+    // ===== LAX per-mode cycle counts (quirk 1) ==========================
+
+    @Test
+    fun laxLoadsBothRegisters() {
+        val cpu = freshCpu()
+        // LAX zp: A=0, X=$55, [$0042] = $AB -> both A and X become $AB.
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0xA7.toSignedByte() // LAX $zp
+        cpu.memory[0x0001] = 0x42.toSignedByte()
+        cpu.memory[0x0042] = 0xAB.toSignedByte()
+        cpu.registers.accumulator = 0x00.toSignedByte()
+        cpu.registers.indexX = 0x55.toSignedByte()
+
+        cpu.tick()
+
+        // Per-mode cycles: zp = 3 (post-tick = 2).
+        assertThat(cpu.workCyclesLeft, equalTo(2))
+        // Both A and X are loaded with the same value.
+        assertThat(cpu.registers.accumulator, equalTo(0xAB.toSignedByte()))
+        assertThat(cpu.registers.indexX, equalTo(0xAB.toSignedByte()))
+        // Z and N flags resolve from the loaded value (0xAB: negative, not zero).
+        assertThat(cpu.processorStatus.negative, equalTo(true))
+        assertThat(cpu.processorStatus.zero, equalTo(false))
+    }
+
+    // ===== SAX per-mode cycle counts (quirk 2) ==========================
+
+    @Test
+    fun saxStoresAAndX() {
+        val cpu = freshCpu()
+        // SAX zp: A=$F0, X=$0F -> [$0042] = A AND X = $00.
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x87.toSignedByte() // SAX $zp
+        cpu.memory[0x0001] = 0x42.toSignedByte()
+        cpu.registers.accumulator = 0xF0.toSignedByte()
+        cpu.registers.indexX = 0x0F.toSignedByte()
+
+        cpu.tick()
+
+        // Per-mode cycles: zp = 3 (post-tick = 2).
+        assertThat(cpu.workCyclesLeft, equalTo(2))
+        // A AND X = 0xF0 AND 0x0F = 0x00.
+        assertThat(cpu.memory[0x0042], equalTo(0x00.toSignedByte()))
+    }
+
+    // ===== JMP indirect cycle count (quirk 3) ===========================
+
+    @Test
+    fun jmpIndirectUsesFiveCycles() {
+        val cpu = freshCpu()
+        // JMP ($0200) where [$0200] = $1234.
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x6C.toSignedByte() // JMP (ind)
+        cpu.memory[0x0001] = 0x00.toSignedByte()
+        cpu.memory[0x0002] = 0x02.toSignedByte() // -> pointer at $0200
+        cpu.memory[0x0200] = 0x34.toSignedByte()
+        cpu.memory[0x0201] = 0x12.toSignedByte()
+
+        cpu.tick()
+
+        // Real-6502 indirect JMP is 5 cycles (post-tick = 4). The old code
+        // used 3 cycles — the +1 delta is the regression bar.
+        assertThat(cpu.workCyclesLeft, equalTo(4))
+        assertThat(cpu.registers.programCounter, equalTo(0x1234.toSignedShort()))
+    }
+
+    // ===== AHX mask (quirk 4) ===========================================
+
+    @Test
+    fun ahxPreservesHighBits() {
+        val cpu = freshCpu()
+        // AHX abs,Y: A=$F0, X=$F0, Y=0 -> [$0500] = A AND X = $F0.
+        // The old 0x07 mask would have produced $00 instead.
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x9F.toSignedByte() // AHX abs,Y
+        cpu.memory[0x0001] = 0x00.toSignedByte()
+        cpu.memory[0x0002] = 0x05.toSignedByte() // -> $0500
+        cpu.registers.accumulator = 0xF0.toSignedByte()
+        cpu.registers.indexX = 0xF0.toSignedByte()
+        cpu.registers.indexY = 0x00.toSignedByte()
+
+        cpu.tick()
+
+        // The 0x07 mask quirk would have written $00 (0xF0 & 0x07 = 0).
+        // The fix: write A AND X = 0xF0.
+        assertThat(cpu.memory[0x0500], equalTo(0xF0.toSignedByte()))
+    }
+
+    // ===== 0x9B is TAS, not XAA (quirk 5) ==============================
+
+    @Test
+    fun opcode9bIsTasNotXaa() {
+        val cpu = freshCpu()
+        // 0x9B (TAS abs,Y): sets S=A, "stores" nothing to the address.
+        // Operand bytes are the absolute-Y target address.
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x9B.toSignedByte() // TAS abs,Y
+        cpu.memory[0x0001] = 0x00.toSignedByte()
+        cpu.memory[0x0002] = 0x05.toSignedByte() // -> $0500
+        cpu.registers.accumulator = 0x42.toSignedByte()
+        cpu.registers.indexY = 0x00.toSignedByte()
+        // Mark S distinctly so we can see it change.
+        cpu.registers.stackPointer = 0x00.toSignedByte()
+
+        cpu.tick()
+
+        // TAS sets S = A; it does NOT do A AND X (which is what XAA would do).
+        assertThat(cpu.registers.stackPointer, equalTo(0x42.toSignedByte()))
+        // A is unchanged (TAS does not modify A).
+        assertThat(cpu.registers.accumulator, equalTo(0x42.toSignedByte()))
+        // Real-6502 TAS is 5 cycles (post-tick = 4).
+        assertThat(cpu.workCyclesLeft, equalTo(4))
+    }
+
+    // ===== 0xE3 is DCP, not ISC (quirk 6) ==============================
+
+    @Test
+    fun opcodeE3IsDcpNotIsc() {
+        val cpu = freshCpu()
+        // 0xE3 (DCP (ind,X)): DEC then CMP. C=set, A=$10, [$0042]=$05.
+        //  After DEC: [$0042]=$04. A - $04 = $10 - $04 = $0C, no borrow,
+        //  so C is set after the operation.
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0xE3.toSignedByte() // DCP (ind,X)
+        cpu.memory[0x0001] = 0x40.toSignedByte() // zp base
+        cpu.registers.indexX = 0x02.toSignedByte()
+        cpu.memory[0x0042] = 0x40.toSignedByte() // low byte of pointer
+        cpu.memory[0x0043] = 0x02.toSignedByte() // high byte of pointer
+        cpu.memory[0x0240] = 0x05.toSignedByte() // operand at $0240
+        cpu.registers.accumulator = 0x10.toSignedByte()
+        // Set C so that ISC would NOT borrow (giving an ambiguous result
+        // wouldn't help us). We want to assert the DCP-vs-ISC difference.
+        cpu.processorStatus.carry = true
+
+        cpu.tick()
+
+        // DCP: [$0240] = 0x05 - 1 = 0x04, then CMP A=$10 vs 0x04.
+        // CMP: $10 - $04 = $0C, no borrow -> C remains set.
+        assertThat(cpu.memory[0x0240], equalTo(0x04.toSignedByte()))
+        assertThat(cpu.processorStatus.carry, equalTo(true))
+        // If 0xE3 were ISC (the old behaviour), the result would be
+        // A = $10 - $05 - !C = $10 - $05 - 0 = $0B, NOT 0x10.
+        // With DCP, A is unchanged.
+        assertThat(cpu.registers.accumulator, equalTo(0x10.toSignedByte()))
+    }
+
+    // ===== SHY / SHX registered (quirk 7) ==============================
+
+    @Test
+    fun shyShxAreRegistered() {
+        // 0x9C (SHY abs,X): stores Y AND ((addr + 1) hi byte).
+        val cpu = freshCpu()
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x9C.toSignedByte() // SHY abs,X
+        cpu.memory[0x0001] = 0x00.toSignedByte()
+        cpu.memory[0x0002] = 0x05.toSignedByte() // -> $0500
+        cpu.registers.indexX = 0x00.toSignedByte()
+        cpu.registers.indexY = 0xF0.toSignedByte()
+
+        cpu.tick()
+
+        // SHY at $0500: high-byte = ($05 + 1) = $06, so Y AND $06 = $F0 AND $06 = $00.
+        assertThat(cpu.memory[0x0500], equalTo(0x00.toSignedByte()))
+    }
+
+    // ===== KIL actually halts (quirk 8) =================================
+
+    @Test
+    fun kilHaltsTheCpu() {
+        val cpu = freshCpu()
+        // KIL at $0000 with a NOP at $0001 — after KIL, PC should NOT
+        // advance; cpu.idle should be true.
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x02.toSignedByte() // KIL
+        cpu.memory[0x0001] = 0xEA.toSignedByte() // NOP (would run if CPU didn't halt)
+
+        cpu.tick()
+
+        // KIL sets cpu.idle = true; the Cpu.tick() path then skips opcode
+        // dispatch on the next call, so PC stays at the KIL byte.
+        assertThat(cpu.idle, equalTo(true))
+        // Work cycles were never set by KIL (no workCyclesLeft assignment),
+        // so the post-decrement is a no-op (0 -> 0).
+        assertThat(cpu.workCyclesLeft, equalTo(0))
+    }
+
+    @Test
+    fun kilLetsNmiWakeTheCpu() {
+        // The NMI-armed flag in the FakeInterruptController survives idle
+        // (it lives in the controller, not the CPU). Once the controller
+        // sees a NMI armed, the next tick should break out of idle and
+        // dispatch the NMI.
+        //
+        // Note: writes to 0xFFFA/0xFFFB are routed to the mapper, and a
+        // no-mapper test CPU drops them — the vector reads back as 0 by
+        // default. That's fine for this test: we only need the NMI to
+        // actually fire (asserted via nmiCount, not via the redirect
+        // target). The presence of the diagnostic counter increment
+        // proves the NMI was dispatched, which is the only thing this
+        // quirk-fix test cares about.
+        val fakeController = FakeInterruptController()
+        val cpu = Cpu(Memory.createWithApu().first, fakeController).apply { reset() }
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x02.toSignedByte() // KIL
+
+        // Arm the NMI BEFORE ticking (1-instruction latency model).
+        fakeController.armNmi()
+
+        // Tick 1: KIL runs, sets cpu.idle = true. The 1-instruction
+        // latency arms the NMI but does not deliver it.
+        cpu.tick()
+        assertThat(cpu.idle, equalTo(true))
+        assertThat(cpu.nmiCount, equalTo(0))  // NMI armed but not yet fired
+
+        // Tick 2: idle path would normally skip dispatch, but the
+        // interrupt controller is checked BEFORE the idle short-circuit,
+        // so the armed NMI fires anyway. nmiCount bumps to 1; the
+        // 7-cycle NMI cost is visible post-decrement.
+        cpu.tick()
+        assertThat(cpu.nmiCount, equalTo(1))  // NMI fired → broke KIL halt
+        assertThat(cpu.workCyclesLeft, equalTo(6))  // 7 - 1 = 6
+        assertThat(cpu.idle, equalTo(false))  // NMI also cleared the idle flag
+    }
+
+    // ===== Absolute.address() masks to 16 bits (quirk 9) ===============
+
+    @Test
+    fun absoluteAddressWrapsAtFFFF() {
+        // An absolute-X instruction at $FFFF with X=1 should compute
+        // address = ($FFFF + 1) AND 0xFFFF = $0000, NOT $10000.
+        //
+        // Place the instruction at $0100 (RAM, not page zero) so the
+        // writeback at $0000 can't clobber the opcode. We use a marker
+        // value at $0000 (pre-tick) and assert the STA overwrites it
+        // with the accumulator value.
+        val cpu = freshCpu()
+        cpu.registers.programCounter = 0x0100.toSignedShort()
+        cpu.memory[0x0100] = 0x9D.toSignedByte() // STA abs,X
+        cpu.memory[0x0101] = 0xFF.toSignedByte()
+        cpu.memory[0x0102] = 0xFF.toSignedByte() // -> $FFFF base
+        cpu.registers.indexX = 0x01.toSignedByte()
+        cpu.registers.accumulator = 0xAB.toSignedByte()
+
+        // Pre-load $0000 with a marker so the test can detect the wrap.
+        cpu.memory[0x0000] = 0x55.toSignedByte()
+
+        cpu.tick()
+
+        // STA abs,X at $FFFF + X=1 should write to $0000 (wrapped),
+        // not silently drop the write (the old unmasked behaviour).
+        assertThat(cpu.memory[0x0000], equalTo(0xAB.toSignedByte()))
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/cpu/OpcodeCrossValidationTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cpu/OpcodeCrossValidationTest.kt
@@ -23,11 +23,13 @@ import org.junit.jupiter.api.Test
 class OpcodeCrossValidationTest {
 
     @Test
-    fun `new dispatcher covers the canonical 250-byte set`() {
+    fun `new dispatcher covers the canonical 252-byte set`() {
         // After Phase 3 the new dispatcher IS the production dispatcher.
         // This is a sanity check that the byte set matches the baseline
-        // locked in by OpcodeDispatchCompletenessTest.
-        assertThat(OpcodesRefactor.map.size, equalTo(250))
+        // locked in by OpcodeDispatchCompletenessTest. Issue #207
+        // registered SHY (0x9C) and SHX (0x9E), bringing the count from
+        // 250 to 252.
+        assertThat(OpcodesRefactor.map.size, equalTo(252))
     }
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/cpu/OpcodeCycleTableTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cpu/OpcodeCycleTableTest.kt
@@ -298,18 +298,15 @@ class OpcodeCycleTableTest {
             rows += OpcodeRow(0xBA, 1, mnemonic = "TSX")
 
             // ===== Inline-implied opcodes (17) ==============================
-            // BRK (7), JSR (6), JMP abs (3), JMP ind (3 — known quirk; real
-            // 6502 is 5 but `jump` helper hardcodes 3), NOP implied (2),
+            // BRK (7), JSR (6), JMP abs (3), JMP ind (5), NOP implied (2),
             // Accumulator shift/rotate (2 each), RTS (6), PLA (4),
             // INY/INY/DEX/DEY (2), PLP (4), RTI (6).
             rows += OpcodeRow(0x00, 6, mnemonic = "BRK")
             rows += OpcodeRow(0x20, 5, listOf(b(0x00), b(0x05)), mnemonic = "JSR")
             rows += OpcodeRow(0x4C, 2, listOf(b(0x00), b(0x05)), mnemonic = "JMP abs")
-            // JMP indirect — KNOWN QUIRK: jump helper sets workCyclesLeft=3
-            // for both abs AND indirect, but real 6502 indirect is 5 cycles.
-            // Preserve until a follow-up fixes the helper.
-            rows += OpcodeRow(0x6C, 2, listOf(b(0x00), b(0x05)),
-                jmpIndirectPointer(), "JMP (ind) [quirk: 3 cycles; real 6502 = 5]")
+            // JMP indirect — real 6502 = 5 cycles (issue #207 fixed).
+            rows += OpcodeRow(0x6C, 4, listOf(b(0x00), b(0x05)),
+                jmpIndirectPointer(), "JMP (ind)")
             rows += OpcodeRow(0xEA, 1, mnemonic = "NOP implied")
             rows += OpcodeRow(0x0A, 1, mnemonic = "ASL A")
             rows += OpcodeRow(0x2A, 1, mnemonic = "ROL A")
@@ -369,59 +366,59 @@ class OpcodeCycleTableTest {
             rows += OpcodeRow(0xDA, 1, mnemonic = "NOP implied")
             rows += OpcodeRow(0xFA, 1, mnemonic = "NOP implied")
 
-            // ===== LAX (6) — KNOWN QUIRK ====================================
-            // The `lax` helper hardcodes workCyclesLeft = 2 for ALL addressing
-            // modes. Real 6502 cycles are 6, 3, 4, 5, 4, 4. Preserve current
-            // behaviour; out of scope to fix in #192.
-            rows += OpcodeRow(0xA3, 1, listOf(b(POINTER_BASE and 0xFF)),
-                indirectXPointer(), "LAX (ind,X) [quirk: 2 cycles; real 6502 = 6]")
-            rows += OpcodeRow(0xA7, 1, listOf(b(0x42)),
-                { /* zp */ }, "LAX zp [quirk: 2 cycles; real 6502 = 3]")
-            rows += OpcodeRow(0xAF, 1, listOf(b(0x00), b(0x05)),
-                { /* abs */ }, "LAX abs [quirk: 2 cycles; real 6502 = 4]")
-            rows += OpcodeRow(0xB3, 1, listOf(b(POINTER_BASE and 0xFF)),
-                indirectYPointer(), "LAX (ind),Y [quirk: 2 cycles; real 6502 = 5]")
-            rows += OpcodeRow(0xB7, 1, listOf(b(0x42)),
-                { it.registers.indexY = 0x00 }, "LAX zp,Y [quirk: 2 cycles; real 6502 = 4]")
-            rows += OpcodeRow(0xBF, 1, listOf(b(0x00), b(0x05)),
-                { it.registers.indexY = 0x00 }, "LAX abs,Y [quirk: 2 cycles; real 6502 = 4]")
+            // ===== LAX (6) — real-6502 cycle counts (issue #207) ===========
+            // (ind,X)=6, zp=3, abs=4, (ind),Y=5, zp,Y=4, abs,Y=4.
+            rows += OpcodeRow(0xA3, 5, listOf(b(POINTER_BASE and 0xFF)),
+                indirectXPointer(), "LAX (ind,X)")
+            rows += OpcodeRow(0xA7, 2, listOf(b(0x42)),
+                { /* zp */ }, "LAX zp")
+            rows += OpcodeRow(0xAF, 3, listOf(b(0x00), b(0x05)),
+                { /* abs */ }, "LAX abs")
+            rows += OpcodeRow(0xB3, 4, listOf(b(POINTER_BASE and 0xFF)),
+                indirectYPointer(), "LAX (ind),Y")
+            rows += OpcodeRow(0xB7, 3, listOf(b(0x42)),
+                { it.registers.indexY = 0x00 }, "LAX zp,Y")
+            rows += OpcodeRow(0xBF, 3, listOf(b(0x00), b(0x05)),
+                { it.registers.indexY = 0x00 }, "LAX abs,Y")
 
-            // ===== SAX (4) — KNOWN QUIRK ====================================
-            // The `sax` helper hardcodes workCyclesLeft = 4 for ALL
-            // addressing modes. Real 6502 cycles: zp=3, abs=4, (ind,X)=6,
-            // zp,Y=4. Preserve current behaviour; out of scope to fix in
-            // #192 (same shape as the LAX=2 quirk above).
-            rows += OpcodeRow(0x83, 3, listOf(b(POINTER_BASE and 0xFF)),
-                indirectXPointer(), "SAX (ind,X) [quirk: 4 cycles; real 6502 = 6]")
-            rows += OpcodeRow(0x87, 3, listOf(b(0x42)),
-                { /* zp */ }, "SAX zp [quirk: 4 cycles; real 6502 = 3]")
+            // ===== SAX (4) — real-6502 cycle counts (issue #207) ===========
+            // (ind,X)=6, zp=3, abs=4, zp,Y=4.
+            rows += OpcodeRow(0x83, 5, listOf(b(POINTER_BASE and 0xFF)),
+                indirectXPointer(), "SAX (ind,X)")
+            rows += OpcodeRow(0x87, 2, listOf(b(0x42)),
+                { /* zp */ }, "SAX zp")
             rows += OpcodeRow(0x8F, 3, listOf(b(0x00), b(0x05)),
-                { /* abs */ }, "SAX abs [quirk: 4 cycles; real 6502 = 4]")
+                { /* abs */ }, "SAX abs")
             rows += OpcodeRow(0x97, 3, listOf(b(0x42)),
-                { it.registers.indexY = 0x00 }, "SAX zp,Y [quirk: 4 cycles; real 6502 = 4]")
+                { it.registers.indexY = 0x00 }, "SAX zp,Y")
 
-            // ===== AHX (2) — KNOWN QUIRK =====================================
-            // `ahx` helper uses mask `0x07` for the high byte (looks like a
-            // typo for `0xFF`). Preserve; out of scope to fix in #192.
+            // ===== AHX (2) — mask fixed in issue #207 =======================
+            // 0x07 mask was a typo; now stores A AND X with no spurious mask.
             rows += OpcodeRow(0x93, 3, listOf(b(POINTER_BASE and 0xFF)),
-                indirectYPointer(), "AHX (ind),Y [quirk: mask=0x07; real 6502 = 0xFF]")
+                indirectYPointer(), "AHX (ind),Y")
             rows += OpcodeRow(0x9F, 3, listOf(b(0x00), b(0x05)),
-                { it.registers.indexY = 0x00 }, "AHX abs,Y [quirk: mask=0x07; real 6502 = 0xFF]")
+                { it.registers.indexY = 0x00 }, "AHX abs,Y")
 
-            // ===== XAA (2) ==================================================
-            // Both 0x9B and 0xAB are mapped to XAA. NESdev canonical says
-            // 0x9B is TAS, 0xAB is XAA. Preserve the current mapping.
-            rows += OpcodeRow(0x9B, 1, mnemonic = "XAA [0x9B canonical=TAS]")
+            // ===== SHX / SHY (issue #207 quirk fix) ========================
+            // 0x9C = SHY abs,X (newly registered); 0x9E = SHX abs,Y (newly
+            // registered). 5 cycles each. Operand is the absolute address.
+            rows += OpcodeRow(0x9C, 4, listOf(b(0x00), b(0x05)),
+                { it.registers.indexX = 0x00 }, "SHY abs,X [issue #207: registered]")
+            rows += OpcodeRow(0x9E, 4, listOf(b(0x00), b(0x05)),
+                { it.registers.indexY = 0x00 }, "SHX abs,Y [issue #207: registered]")
+
+            // ===== XAA / TAS (issue #207 quirk fix) ========================
+            // 0x9B is now TAS abs,Y (5 cycles); 0xAB remains XAA (2 cycles).
+            // 0x9B's operand bytes are the absolute-Y target address.
+            rows += OpcodeRow(0x9B, 4, listOf(b(0x00), b(0x05)),
+                { it.registers.indexY = 0x00 }, "TAS abs,Y")
             rows += OpcodeRow(0xAB, 1, mnemonic = "XAA")
 
             // ===== LAS (1) ==================================================
             rows += OpcodeRow(0xBB, 3, listOf(b(0x00), b(0x05)),
                 { it.registers.indexY = 0x00 }, "LAS abs,Y")
 
-            // ===== DCP (6 unique) ===========================================
-            // 0xE3 and 0xF3 are also ISC entries — see below. The ISC writes
-            // come AFTER the DCP writes in Opcodes.kt:441-451, so the
-            // dispatch table has ISC for both bytes (the silent overwrite).
+            // ===== DCP (7) — issue #207 quirk fix: 0xE3 is DCP, not ISC ==
             rows += OpcodeRow(0xC7, 5, listOf(b(0x42)), mnemonic = "DCP zp")
             rows += OpcodeRow(0xD7, 5, listOf(b(0x42)),
                 { it.registers.indexX = 0x00 }, "DCP zp,X")
@@ -432,10 +429,10 @@ class OpcodeCycleTableTest {
                 { it.registers.indexY = 0x00 }, "DCP zp,Y")
             rows += OpcodeRow(0xD3, 5, listOf(b(POINTER_BASE and 0xFF)),
                 indirectXPointer(), "DCP (ind,X)")
+            rows += OpcodeRow(0xE3, 5, listOf(b(POINTER_BASE and 0xFF)),
+                indirectXPointer(), "DCP (ind,X) [issue #207: 0xE3 is DCP]")
 
-            // ===== ISC (7 — including the 0xE3/0xF3 silent overwrite) =======
-            // 0xE3 and 0xF3 are mapped to ISC (the ISC assignment overwrites
-            // the earlier DCP assignment in Opcodes.kt:441,442,450,451).
+            // ===== ISC (6) — 0xF3 stays ISC; 0xE3 moved to DCP =============
             rows += OpcodeRow(0xE7, 5, listOf(b(0x42)), mnemonic = "ISC zp")
             rows += OpcodeRow(0xF7, 5, listOf(b(0x42)),
                 { it.registers.indexX = 0x00 }, "ISC zp,X")
@@ -444,10 +441,8 @@ class OpcodeCycleTableTest {
                 { it.registers.indexX = 0x00 }, "ISC abs,X")
             rows += OpcodeRow(0xFB, 5, listOf(b(0x42)),
                 { it.registers.indexY = 0x00 }, "ISC zp,Y")
-            rows += OpcodeRow(0xE3, 5, listOf(b(POINTER_BASE and 0xFF)),
-                indirectXPointer(), "ISC (ind,X) [0xE3: ISC wins over DCP]")
             rows += OpcodeRow(0xF3, 5, listOf(b(POINTER_BASE and 0xFF)),
-                indirectYPointer(), "ISC (ind),Y [0xF3: ISC wins over DCP]")
+                indirectYPointer(), "ISC (ind),Y")
 
             // ===== RLA (7) ==================================================
             rows += OpcodeRow(0x27, 4, listOf(b(0x42)), mnemonic = "RLA zp")
@@ -509,22 +504,23 @@ class OpcodeCycleTableTest {
             rows += OpcodeRow(0x4B, 1, listOf(b(0x00)), mnemonic = "ALR #imm")
             rows += OpcodeRow(0x6B, 1, listOf(b(0x00)), mnemonic = "ARR #imm")
 
-            // ===== KIL (13) =================================================
-            // Does NOT actually halt — consumes 2 cycles and advances PC by
-            // one byte per tick. Preserve; out of scope to make a true halt.
-            rows += OpcodeRow(0x02, 1, mnemonic = "KIL [quirk: doesn't halt]")
-            rows += OpcodeRow(0x12, 1, mnemonic = "KIL")
-            rows += OpcodeRow(0x22, 1, mnemonic = "KIL")
-            rows += OpcodeRow(0x32, 1, mnemonic = "KIL")
-            rows += OpcodeRow(0x42, 1, mnemonic = "KIL")
-            rows += OpcodeRow(0x52, 1, mnemonic = "KIL")
-            rows += OpcodeRow(0x62, 1, mnemonic = "KIL")
-            rows += OpcodeRow(0x72, 1, mnemonic = "KIL")
-            rows += OpcodeRow(0x92, 1, mnemonic = "KIL")
-            rows += OpcodeRow(0xB2, 1, mnemonic = "KIL")
-            rows += OpcodeRow(0xC3, 1, mnemonic = "KIL")
-            rows += OpcodeRow(0xD2, 1, mnemonic = "KIL")
-            rows += OpcodeRow(0xF2, 1, mnemonic = "KIL")
+            // ===== KIL (13) — issue #207 quirk fix: now actually halts ====
+            // KIL sets cpu.idle = true; Cpu.tick() then skips opcode dispatch
+            // and PPU/APU keep advancing. The post-tick `workCyclesLeft` is
+            // 0 because we never set it (the tick decrements 0→0, no-op).
+            rows += OpcodeRow(0x02, 0, mnemonic = "KIL [issue #207: now halts CPU]")
+            rows += OpcodeRow(0x12, 0, mnemonic = "KIL")
+            rows += OpcodeRow(0x22, 0, mnemonic = "KIL")
+            rows += OpcodeRow(0x32, 0, mnemonic = "KIL")
+            rows += OpcodeRow(0x42, 0, mnemonic = "KIL")
+            rows += OpcodeRow(0x52, 0, mnemonic = "KIL")
+            rows += OpcodeRow(0x62, 0, mnemonic = "KIL")
+            rows += OpcodeRow(0x72, 0, mnemonic = "KIL")
+            rows += OpcodeRow(0x92, 0, mnemonic = "KIL")
+            rows += OpcodeRow(0xB2, 0, mnemonic = "KIL")
+            rows += OpcodeRow(0xC3, 0, mnemonic = "KIL")
+            rows += OpcodeRow(0xD2, 0, mnemonic = "KIL")
+            rows += OpcodeRow(0xF2, 0, mnemonic = "KIL")
 
             // ===== Sanity: every row's opcode must actually be mapped =======
             // This catches typos in the table — if a row's byte isn't in the

--- a/src/test/kotlin/com/github/alondero/nestlin/cpu/OpcodeDispatchCompletenessTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cpu/OpcodeDispatchCompletenessTest.kt
@@ -22,25 +22,26 @@ import org.junit.jupiter.api.Test
 class OpcodeDispatchCompletenessTest {
 
     @Test
-    fun `dispatch table covers exactly the 250 currently-mapped opcodes`() {
+    fun `dispatch table covers exactly the 252 currently-mapped opcodes`() {
         val mapped = OpcodesRefactor.map.keys.toSet()
         assertThat(
             "OpcodesRefactor.map size — if this changes, the test was wrong about the baseline",
-            mapped.size, equalTo(250),
+            mapped.size, equalTo(252),
         )
     }
 
     @Test
-    fun `the 6 unmapped opcodes match the expected set`() {
+    fun `the 4 unmapped opcodes match the expected set`() {
         val mapped = OpcodesRefactor.map.keys.toSet()
         val unmapped = (0..0xFF).filter { it !in mapped }.toSet()
-        // The 6 unmapped opcodes, derived empirically from the original
-        // Opcodes.kt init block. If a refactor changes this set, decide
-        // explicitly whether to update the test or the dispatcher.
+        // The 4 unmapped opcodes after issue #207's TAS/SHX/SHY registration
+        // (previously 250 mapped / 6 unmapped; SHY 0x9C and SHX 0x9E were
+        // unregistered but their classes existed). If a refactor changes
+        // this set, decide explicitly whether to update the test or the
+        // dispatcher.
         //   0x0B = AAC (unofficial); 0x2B = AAC; 0x8B = unknown/very unstable
-        //   0x9C = SHY unhooked variant; 0x9E = SHX unhooked variant
         //   0xCB = very unstable SBC+DEC combo
-        val expectedUnmapped = setOf(0x0B, 0x2B, 0x8B, 0x9C, 0x9E, 0xCB)
+        val expectedUnmapped = setOf(0x0B, 0x2B, 0x8B, 0xCB)
         assertThat(unmapped, equalTo(expectedUnmapped))
     }
 
@@ -48,7 +49,7 @@ class OpcodeDispatchCompletenessTest {
     fun `expectedUnmapped constant matches the derived set`() {
         val mapped = OpcodesRefactor.map.keys.toSet()
         val unmapped = (0..0xFF).filter { it !in mapped }.toSet()
-        val expectedUnmapped = setOf(0x0B, 0x2B, 0x8B, 0x9C, 0x9E, 0xCB)
+        val expectedUnmapped = setOf(0x0B, 0x2B, 0x8B, 0xCB)
         assertThat(unmapped, equalTo(expectedUnmapped))
     }
 }


### PR DESCRIPTION
## Summary

Each quirk is documented inline in the new `cpu/opcode/` package; this PR addresses them collectively as a single focused fix. Individual fixes are isolated in `Issue207QuirkFixesTest` so they could be split if preferred.

### Per-mode cycle counts
- **LAX** now uses 6/3/4/5/4/4 (real 6502; was hardcoded 2)
- **SAX** now uses 6/3/4/4 (real 6502; was hardcoded 4)
- **JMP indirect** uses 5 cycles (real 6502; was 3)

### Dispatch corrections
- **AHX mask** removed (the `0x07` was a typo for `0xFF`; `A AND X` is already 8-bit)
- **0x9B** is now **TAS abs,Y** (was XAA)
- **0xE3** is now **DCP (ind,X)** (was ISC, silent overwrite of DCP)
- **0x9C (SHY)** and **0x9E (SHX)** are now registered
- Dispatch byte set grows **250 → 252 mapped** (4 unmapped: 0x0B, 0x2B, 0x8B, 0xCB)

### Semantics
- **KIL** now actually halts the CPU via `cpu.idle = true` (the existing parking mechanism; interrupt controller still checked first, so NMI/IRQ can wake the CPU)
- **`Absolute.address()`** now masks to 16 bits (was an asymmetry vs `value()`; real 6502 wraps to low memory)

## Tests

- New `Issue207QuirkFixesTest`: 10 behaviour-level regressions, one per quirk plus a KIL/NMI-wake interaction test
- `OpcodeCycleTableTest`: 17 rows updated to reflect new (correct) cycle counts; `[quirk: ...]` markers removed
- `OpcodeDispatchCompletenessTest` + `OpcodeCrossValidationTest`: byte set 250 → 252, unmapped set 6 → 4

## Verification

- `./gradlew test` — **1204 tests, 0 failures, 5 skipped** (Mesen2 oracle tests skip without Mesen2 on path)
- `./gradlew bootcheck -Prom=X:/src/nestlin/testroms/kirby.nes -Pframes=60` — **BOOTCHECK VERDICT: PASS** (60 frames, 58 NMI, 41 distinct frame PCs)

## Notes

- The `Opcode.kt` sealed class kdoc and each class kdoc have been updated to document the fix. Search for `Issue #207` to find them all.
- KIL halt is a one-liner: `cpu.idle = true`. The existing `Cpu.tick()` parking mechanism was already designed to handle this (the interrupt controller is checked before the idle early-return), so the fix is minimal.
- `Absolute.address()` previously relied on `Memory.get` returning 0 / `Memory.set` no-op'ing for out-of-range addresses; this worked because no real RMW op lands in the $10000+ range, but it diverged from hardware. Now it wraps consistently with `value()`.

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)
