### PR TITLE
GH #140: Implement Mapper 228 (Action 52 / Active Enterprises)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ testroms/                    # nestest.nes is the only ROM in git
 - CPU: all 151 opcodes including unofficial; `GoldenLogTest` is the regression bar.
 - PPU: full background + sprite rendering, sprite-0 hit, 8x16 sprites, A12 edge to mapper.
 - APU: 5 channels (Pulse×2, Triangle, Noise, DMC), PAL/NTSC tables, mixer.
-- Mappers: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 19, 24, 26, 33, 34, 64, 66, 68, 69, 153, 206.** Details + per-mapper game coverage in `MAPPER_SUPPORT.md`.
+- Mappers: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 19, 24, 26, 33, 34, 64, 66, 68, 69, 153, 206, 228.** Details + per-mapper game coverage in `MAPPER_SUPPORT.md`.
 - Region: NTSC + PAL auto-detect (iNES header → NO-INTRO filename → user override).
 - Save state (`.nstl`, F5/F8 + menu) and save RAM (`.sav`, FCEUX-compatible).
 - Battery RAM persistence for mappers 1/4/5 (mappers with `$6000-$7FFF` PRG-RAM).

--- a/MAPPER_SUPPORT.md
+++ b/MAPPER_SUPPORT.md
@@ -1,6 +1,6 @@
 # NES Mapper Support Status
 
-Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 24, 26, 33, 34, 64, 65, 66, 68, 69, 153, 206.**
+Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 24, 26, 33, 34, 64, 65, 66, 68, 69, 153, 206, 228.**
 
 ## Mapper 0 (NROM)
 **Status:** Working
@@ -909,6 +909,47 @@ Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 24, 26, 33, 34,
   write to the wrong bank; the 31 original unit tests passed only because they hand-rolled the same
   wrong formula. Lesson: assert mapper decode against the *spec value*, not a magic byte derived
   from the implementation.
+
+## Mapper 228 (Action 52 / Active Enterprises)
+**Status:** Working — boots to the game-selection menu (Added 2026-06-30, GH #140)
+
+- **Games:** *Action 52* (the infamous 52-game multicart) and *Cheetahmen II*.
+- **What makes it unique in Nestlin:** the written *value* contributes only 2 bits;
+  the *address* carries the PRG bank, CHR high nibble, PRG mode and mirroring. It is the
+  only mapper here where the bank-select is encoded in `addr` rather than `value`.
+- **Oracle:** Mesen2's `Core/NES/Mappers/Unlicensed/ActionEnterprises.h` (the nesdev wiki
+  page agrees on the bit layout). The GitHub issue's "chip-3 reads return open bus" prose
+  was self-contradictory — see the PRG note below.
+- **Register decode (`cpuWrite`, $8000-$FFFF):**
+  - `chipSelect = (addr >> 11) & 3` (A11-A12)
+  - `prgPage = ((addr >> 6) & 0x1F) | (chipForIndex << 5)` — 7-bit bank index 0-95
+  - `addr & 0x20` (A5): set → 32KB mode (same 16KB page in both windows); clear →
+    adjacent 16KB pair (`prgBank0 = page & 0xFE`, `prgBank1 = (page & 0xFE) + 1`)
+  - `chrBank = ((addr & 0x0F) << 2) | (value & 0x03)` — 4 bits from A0-A3 + 2 bits from value
+  - mirroring: `addr & 0x2000` (A13) → 1 = Horizontal, 0 = Vertical
+- **PRG — three chips, one hole.** Physically chip 0/1/3 exist (each 512KB); chip 2 is
+  absent. The .nes dump packs the three chips contiguously into 96 × 16KB banks (chip 3's
+  data at banks 64-95, file offset $100010). Mesen remaps `chipSelect 3 → 2` *for indexing*
+  so the third chip is reachable as banks 64-95 (the value real games write). Nestlin keeps
+  that remap **and** flags a literal `chipSelect == 2` write as open bus (a chip-2 *read*
+  returns the data bus, per the wiki/hardware). No real game selects chip 2, so this is
+  invisible to the Mesen2 state-diff yet honours both the wiki and the issue's open-bus
+  requirement — and, unlike the issue's prose, keeps every third-chip game playable.
+- **CHR:** single 8KB window at PPU $0000-$1FFF, 6-bit bank (0-63).
+- **Initial state:** Mesen's `InitMapper`/`Reset` both call `WriteRegister($8000, 0)`
+  (→ prgBank0=0, prgBank1=1, chrBank=0, vertical). Without it the menu hangs on black.
+  Replayed in `Mapper228`'s `init`; Nestlin has no per-mapper reset hook, so the soft-reset
+  replay isn't modelled (unnecessary for cold boot, which is where games depend on it).
+- **No PRG-RAM, no IRQ, no audio expansion.** Reads below $8000 are open bus. The disputed
+  16-bit "RAM" at $4020-$4023 noted on the wiki is not emulated (Nestopia omits it too).
+- **Verification:** `Mapper228Test` (17 cases) covers dispatch, address-only PRG banking
+  across all 96 banks in both modes, the chip-3→third-chip path, chip-2 open bus, address+value
+  CHR banking across all 64 banks, value-bit isolation (only bits 0-1 matter), mirroring bit 13,
+  initial state, sub-$8000 open bus, ignored sub-$8000 writes, and save/load round-trip.
+  `Mapper228RegressionTest` asserts a banking register moves during boot and (`@RequiresMesen2`)
+  byte-compares render output vs Mesen2 at the menu frame. Real-ROM gate: `./gradlew bootcheck`
+  on *Action 52 (USA) (Rev A)* returns **PASS** (rendering on by frame 34, 27.5% non-blank,
+  PRG+CHR banks moving, NMIs firing) — the game-selection menu renders.
 
 ## Adding New Mappers
 

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
@@ -158,6 +158,7 @@ class GamePak(data: ByteArray, displayName: String = "") {
         113 -> Mapper113(this)
         153 -> Mapper153(this)
         206 -> Mapper206(this)
+        228 -> Mapper228(this)
         else -> throw UnsupportedOperationException("Mapper ${header.mapper} not implemented")
     }
 

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper228.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper228.kt
@@ -1,0 +1,228 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.github.alondero.nestlin.toUnsignedInt
+import java.io.DataInput
+import java.io.DataOutput
+
+/**
+ * Mapper 228 (Action 52 / Active Enterprises "Cheetahmen").
+ *
+ * The infamous 52-game multicart. Three things make this board unlike every
+ * other mapper in Nestlin:
+ *
+ * 1. **The written value is almost ignored.** Only bits 0-1 of `value`
+ *    contribute (the low 2 bits of the CHR bank). Bits 2-7 are discarded.
+ * 2. **The address *is* the bank-select.** PRG bank, CHR bank high nibble,
+ *    PRG mode and mirroring are all decoded from `addr`, not `value`.
+ * 3. **Three PRG chips with a hole.** The cart has three 512KB PRG chips
+ *    wired as chip 0, 1 and **3** — chip 2 is physically absent. See the
+ *    PRG section below for how the dump packs around that hole.
+ *
+ * **Oracle.** Mesen2's `Core/NES/Mappers/Unlicensed/ActionEnterprises.h` is
+ * the canonical reference and it is *startlingly* short — the entire register
+ * decode is:
+ *
+ * ```cpp
+ * uint8_t chipSelect = (addr >> 11) & 0x03;
+ * if(chipSelect == 3) chipSelect = 2;
+ * uint8_t prgPage = ((addr >> 6) & 0x1F) | (chipSelect << 5);
+ * if(addr & 0x20) { SelectPrgPage(0, prgPage); SelectPrgPage(1, prgPage); }
+ * else            { SelectPrgPage(0, prgPage & 0xFE); SelectPrgPage(1, (prgPage & 0xFE) + 1); }
+ * SelectChrPage(0, ((addr & 0x0F) << 2) | (value & 0x03));
+ * SetMirroringType(addr & 0x2000 ? Horizontal : Vertical);
+ * ```
+ *
+ * **Register decode (`cpuWrite`, addresses $8000-$FFFF):**
+ *
+ *  | Source bits          | Field                                            |
+ *  |----------------------|--------------------------------------------------|
+ *  | `addr` A11-A12       | `chipSelect` (2 bits)                            |
+ *  | `addr` A6-A10        | PRG page within chip (5 bits)                    |
+ *  | `addr` A5 (0x20)     | PRG mode: 1 = 32KB (both windows = page), 0 = adjacent 16KB pair |
+ *  | `addr` A0-A3 (0x0F)  | CHR bank high 4 bits                             |
+ *  | `value` D0-D1        | CHR bank low 2 bits                              |
+ *  | `addr` A13 (0x2000)  | Mirroring: 1 = Horizontal, 0 = Vertical          |
+ *
+ * **PRG geometry — three chips, one hole, and why we deviate from Mesen by a hair.**
+ *
+ * Physically: chip 0 = first 512KB, chip 1 = second 512KB, chip 2 = *not
+ * present*, chip 3 = third 512KB. On real hardware a read while chip 2 is
+ * selected returns open bus. The .nes dump only stores the three chips that
+ * exist, contiguously: chip 0 at file offset $000010, chip 1 at $080010,
+ * chip 3 at $100010 — i.e. a flat 96 × 16KB PRG region with the third chip's
+ * data sitting in PRG banks 64-95 (where "chip 2" *would* index).
+ *
+ * Mesen reconciles the dump's packing with the hardware's hole by remapping
+ * `chipSelect 3 → 2` **before** computing the page. That makes both `chipSelect
+ * == 2` and `chipSelect == 3` resolve to `prgPage 64-95`, so the third chip's
+ * data (banks 64-95) is reachable via `chipSelect 3` — the value real games
+ * actually write. The cost is that Mesen returns that same third-chip data for
+ * a literal `chipSelect == 2`, where hardware would return open bus.
+ *
+ * Nestlin keeps Mesen's remap **for indexing** (so chip 3 reaches banks 64-95,
+ * keeping every game that lives on the third chip playable) but additionally
+ * flags a literal `chipSelect == 2` write as open bus, so a chip-2 *read*
+ * returns the data bus (hardware-faithful per the nesdev wiki). No real Action
+ * 52 game ever selects chip 2, so this is invisible to the Mesen2 state-diff
+ * regression (which only exercises the game's real accesses) yet honours both
+ * the wiki and the original issue's open-bus requirement. The issue's prose
+ * ("chip-3 reads return open bus") was self-contradictory — it would have
+ * orphaned the third chip and broken ~17 games; the source resolves it.
+ *
+ * PRG windows are 16KB: window 0 = $8000-$BFFF (page `prgBank0`), window 1 =
+ * $C000-$FFFF (page `prgBank1`).
+ *
+ * **CHR geometry:** one 8KB window at PPU $0000-$1FFF; 6-bit bank, 0-63.
+ *
+ * **Initial state.** Mesen's `InitMapper` *and* `Reset` both call
+ * `WriteRegister(0x8000, 0)`; without it the menu hangs on a black screen.
+ * We replay that in `init` (chip 0, page 0 → `prgBank0 = 0`, `prgBank1 = 1`,
+ * `chrBank = 0`, vertical mirroring). Nestlin has no per-mapper reset hook
+ * (`Nestlin.powerReset` resets only the CPU and does not reconstruct the
+ * mapper), so the soft-reset replay is not modelled — it is unnecessary for
+ * cold boot, which is where games depend on the $00 write.
+ *
+ * **No PRG-RAM, no IRQ, no audio expansion.** Reads below $8000 are open bus.
+ * The disputed 16-bit "RAM" at $4020-$4023 noted on the wiki is not emulated
+ * (Nestopia omits it too; a real cart has no such RAM).
+ */
+class Mapper228(private val gamePak: GamePak) : Mapper {
+
+    private val programRom = gamePak.programRom
+    private val chrRom = gamePak.chrRom
+
+    // CHR bus: backed by ROM when present (always, for Action 52's 512KB CHR),
+    // otherwise an 8KB CHR-RAM fallback so a malformed/CHR-less dump can't crash
+    // the PPU read path.
+    private val chrMemory: ChrMemory = ChrMemory.default(chrRom)
+
+    // PRG: two 16KB windows. prgBank0 -> $8000-$BFFF, prgBank1 -> $C000-$FFFF.
+    private var prgBank0 = 0
+    private var prgBank1 = 0
+
+    // True when the most recent register write selected the physically-absent
+    // chip 2 (literal chipSelect == 2). A chip-2 read returns open bus. Set/cleared
+    // on every register write; both windows share it because one write always
+    // selects one chip for the whole $8000-$FFFF space.
+    private var prgOpenBus = false
+
+    // CHR: single 8KB window, 6-bit bank.
+    private var chrBank = 0
+
+    // Mirroring latched from addr bit 13 on each register write. The real
+    // power-on value is set by init()'s cpuWrite($8000,0) (which decodes to
+    // vertical) before any read, so this is just a placeholder until that runs
+    // — the iNES header mirroring is irrelevant to this board.
+    private var horizontalMirroring = false
+
+    // Open-bus source. Memory sets this just before each cpuRead (see Memory.get);
+    // the default Mapper.dataBus getter returns 0, so a real field is required to
+    // capture it for chip-2 / sub-$8000 open-bus reads.
+    override var dataBus: Byte = 0
+
+    init {
+        // Mesen's InitMapper: establish default banking. Games depend on this.
+        cpuWrite(0x8000, 0)
+    }
+
+    override fun cpuRead(address: Int): Byte {
+        // No PRG-RAM and nothing mapped below $8000: open bus.
+        if (address < 0x8000) return dataBus
+        // Physically-absent chip 2 selected: open bus (no game does this).
+        if (prgOpenBus) return dataBus
+        // Defensive: a malformed 0-PRG dump (iNES byte 4 = 0) leaves programRom
+        // empty and would make the `% programRom.size` below divide by zero.
+        // Mirrors ppuRead's `chrRom.isEmpty()` guard — open bus is the safe read.
+        if (programRom.isEmpty()) return dataBus
+        return if (address and 0x4000 == 0) {
+            // $8000-$BFFF
+            programRom[(prgBank0 * 0x4000 + (address - 0x8000)) % programRom.size]
+        } else {
+            // $C000-$FFFF
+            programRom[(prgBank1 * 0x4000 + (address - 0xC000)) % programRom.size]
+        }
+    }
+
+    override fun cpuWrite(address: Int, value: Byte) {
+        if (address < 0x8000) return
+
+        val rawChip = (address ushr 11) and 0x03
+        // Literal chip 2 is the absent chip → reads become open bus.
+        prgOpenBus = (rawChip == 2)
+        // Remap 3 → 2 for INDEXING: the dump packs the third physical chip's data
+        // into PRG banks 64-95, the slot chip-index 2 addresses.
+        val chipForIndex = if (rawChip == 3) 2 else rawChip
+        val prgPage = ((address ushr 6) and 0x1F) or (chipForIndex shl 5)
+
+        if (address and 0x20 != 0) {
+            // 32KB mode: the same 16KB page in both windows.
+            prgBank0 = prgPage
+            prgBank1 = prgPage
+        } else {
+            // Adjacent-pair mode: even page low, odd page high.
+            prgBank0 = prgPage and 0xFE
+            prgBank1 = (prgPage and 0xFE) + 1
+        }
+
+        // CHR bank: 4 bits from addr A0-A3, low 2 bits from value D0-D1.
+        chrBank = ((address and 0x0F) shl 2) or (value.toUnsignedInt() and 0x03)
+
+        horizontalMirroring = (address and 0x2000) != 0
+    }
+
+    override fun ppuRead(address: Int): Byte {
+        val a = address and 0x1FFF
+        if (chrRom.isEmpty()) return chrMemory.read(a)
+        // 8KB CHR window. % chrRom.size keeps an out-of-range bank index (e.g. a
+        // test driving a bank past the ROM) from indexing off the end; on hardware
+        // the upper address bits would be open bus, but wrap is the safer fixture.
+        return chrRom[(chrBank * 0x2000 + a) % chrRom.size]
+    }
+
+    override fun ppuWrite(address: Int, value: Byte) {
+        if (chrRom.isEmpty()) chrMemory.write(address and 0x1FFF, value)
+    }
+
+    override fun currentMirroring(): Mapper.MirroringMode =
+        if (horizontalMirroring) Mapper.MirroringMode.HORIZONTAL
+        else Mapper.MirroringMode.VERTICAL
+
+    override val saveStateVersion: Int = 1
+
+    override fun saveState(out: DataOutput) {
+        super.saveState(out)
+        out.writeInt(prgBank0)
+        out.writeInt(prgBank1)
+        out.writeInt(chrBank)
+        out.writeBoolean(prgOpenBus)
+        out.writeBoolean(horizontalMirroring)
+        chrMemory.serialize(out)
+    }
+
+    override fun loadState(input: DataInput) {
+        super.loadState(input)
+        prgBank0 = input.readInt()
+        prgBank1 = input.readInt()
+        chrBank = input.readInt()
+        prgOpenBus = input.readBoolean()
+        horizontalMirroring = input.readBoolean()
+        chrMemory.deserialize(input)
+    }
+
+    override fun snapshot(): MapperStateSnapshot =
+        MapperStateSnapshot(
+            mapperId = 228,
+            type = "Action 52 / Active Enterprises",
+            banks = mapOf(
+                "prgBank0" to prgBank0,
+                "prgBank1" to prgBank1,
+                "chrBank" to chrBank
+            ),
+            registers = mapOf(
+                "horizontalMirroring" to if (horizontalMirroring) 1 else 0,
+                "prgOpenBus" to if (prgOpenBus) 1 else 0
+            ),
+            irqState = null,
+            chrRam = chrMemory.snapshotBytes()
+        )
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper228RegressionTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper228RegressionTest.kt
@@ -1,0 +1,75 @@
+package com.github.alondero.nestlin.compare
+
+import com.github.alondero.nestlin.Nestlin
+import com.github.alondero.nestlin.gamepak.Mapper228
+import com.github.alondero.nestlin.ppu.Frame
+import com.github.alondero.nestlin.ui.FrameListener
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+
+/**
+ * Structured-state regression test for issue #140 (Mapper 228 / Action 52).
+ *
+ * Two-pronged, following the `Mapper10RegressionTest` worked example:
+ *  1. A banking register moves during boot to the game-selection menu — proves
+ *     the address-decoded bank-select is wired and the chip isn't frozen at its
+ *     `InitMapper` state. Because Action 52's menu may page PRG *or* CHR, the
+ *     guard accepts movement in any of `prgBank0` / `prgBank1` / `chrBank`
+ *     (the Mapper33 multi-bank-guard idiom).
+ *  2. Render output is byte-identical to Mesen2 at the menu frame.
+ *
+ * The game-selection menu is the only meaningful oracle: the 52 games are
+ * mostly short and buggy on real hardware too, so per-game state isn't a stable
+ * target. The ROM lives only in the NO-INTRO library (not in git); override with
+ * `NESTLIN_ACTION52_ROM`. Skipped (not failed) when the ROM / Mesen2 is absent.
+ */
+class Mapper228RegressionTest : MapperRegressionTestBase() {
+
+    private val frameNumber = 120
+
+    private fun action52Rom(): Path = resolveRom(
+        "NESTLIN_ACTION52_ROM",
+        "S:/Media/Nintendo NES/Games/Action 52 (USA) (Rev A) (Unl).nes"
+    )
+
+    @Test
+    fun `action 52 banking moves during boot to the menu`() {
+        val rom = action52Rom()
+        val nestlin = Nestlin().apply {
+            config.speedThrottlingEnabled = false
+            load(rom)
+        }
+        nestlin.powerReset()
+        val mapper = nestlin.memory.mapper as? Mapper228
+            ?: error("Expected Mapper228 for Action 52; got ${nestlin.memory.mapper?.javaClass?.simpleName}")
+
+        val prg0Seen = linkedSetOf<Int>()
+        val prg1Seen = linkedSetOf<Int>()
+        val chrSeen = linkedSetOf<Int>()
+        var frameCount = 0
+        nestlin.addFrameListener(object : FrameListener {
+            override fun frameUpdated(frame: Frame) {
+                val banks = mapper.snapshot().banks
+                prg0Seen.add(banks["prgBank0"] ?: -1)
+                prg1Seen.add(banks["prgBank1"] ?: -1)
+                chrSeen.add(banks["chrBank"] ?: -1)
+                if (++frameCount >= frameNumber) nestlin.stop()
+            }
+        })
+        nestlin.start()
+
+        Assertions.assertTrue(
+            prg0Seen.size > 1 || prg1Seen.size > 1 || chrSeen.size > 1,
+            "Action 52 banking never changed during boot " +
+                "(prgBank0=$prg0Seen, prgBank1=$prg1Seen, chrBank=$chrSeen) — " +
+                "the address-decoded bank-select may not be wired."
+        )
+    }
+
+    @Test
+    @RequiresMesen2
+    fun `action 52 menu render output matches mesen2 at frame N`() {
+        assertRenderOutputMatchesMesen2(action52Rom(), frameNumber, "action-52")
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper228Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper228Test.kt
@@ -1,0 +1,251 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.github.alondero.nestlin.toUnsignedInt
+import com.github.alondero.nestlin.testutil.testGamePak
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+
+/**
+ * Unit tests for Mapper 228 (Action 52 / Active Enterprises).
+ *
+ * The defining trait of this board is that the *address* carries the bank
+ * selection and the written *value* contributes only 2 bits. The ROM is built
+ * at the real cart's geometry — 96 × 16KB PRG (1.5MB) and 64 × 8KB CHR (512KB)
+ * — with every PRG/CHR bank's first byte stamped with its own index, so a
+ * single read of a window's base address asserts exactly which bank is mapped
+ * there. Built via [testGamePak]/TestRomBuilder (raw hand-built iNES headers
+ * are forbidden — see HeaderConstructionLintTest).
+ */
+class Mapper228Test {
+
+    /** Real Action 52 geometry: chip 0/1/3 packed contiguous → 96 PRG banks. */
+    private fun newMapper(): Mapper228 {
+        val gamePak = testGamePak {
+            mapper = 228
+            prgKb = 96 * 16          // 96 × 16KB = 1.5MB
+            chrKb = 64 * 8           // 64 × 8KB  = 512KB
+            stampPrgBanks(windowKb = 16)
+            stampChrBanks(windowKb = 8)
+        }
+        return gamePak.createMapper() as Mapper228
+    }
+
+    /**
+     * Builds a register-write address from the fields the board decodes. A15 is
+     * always set so the write lands in $8000-$FFFF; A14, A4 are don't-cares.
+     */
+    private fun regAddr(
+        chip: Int,
+        page: Int,
+        mode32: Boolean,
+        chrHigh: Int = 0,
+        horiz: Boolean = false,
+    ): Int {
+        var a = 0x8000
+        a = a or ((chip and 0x03) shl 11)
+        a = a or ((page and 0x1F) shl 6)
+        if (mode32) a = a or 0x20
+        a = a or (chrHigh and 0x0F)
+        if (horiz) a = a or 0x2000
+        return a
+    }
+
+    private fun Mapper228.prgAt(window: Int) =
+        cpuRead(if (window == 0) 0x8000 else 0xC000).toUnsignedInt()
+
+    private fun Mapper228.chrBankByte() = ppuRead(0x0000).toUnsignedInt()
+
+    // ---- Dispatch ----
+
+    @Test
+    fun `createMapper returns Mapper228 for iNES mapper 228`() {
+        val m = newMapper()
+        assertThat(m.snapshot().mapperId, equalTo(228))
+        assertThat(m.snapshot().type, equalTo("Action 52 / Active Enterprises"))
+    }
+
+    // ---- Initial state (Mesen InitMapper: WriteRegister($8000,0)) ----
+
+    @Test
+    fun `initial state maps PRG bank 0 low and bank 1 high (split mode)`() {
+        val m = newMapper()
+        assertThat(m.prgAt(0), equalTo(0))   // $8000-$BFFF
+        assertThat(m.prgAt(1), equalTo(1))   // $C000-$FFFF
+    }
+
+    @Test
+    fun `initial CHR bank is 0`() {
+        assertThat(newMapper().chrBankByte(), equalTo(0))
+    }
+
+    @Test
+    fun `initial mirroring is vertical`() {
+        assertThat(newMapper().currentMirroring(), equalTo(Mapper.MirroringMode.VERTICAL))
+    }
+
+    // ---- PRG banking: address-only, 32KB mirror mode (bit 5 set) ----
+
+    @Test
+    fun `32KB mode maps the same page into both windows for every chip and page`() {
+        val m = newMapper()
+        for (chip in intArrayOf(0, 1, 3)) {
+            for (page in 0..31) {
+                m.cpuWrite(regAddr(chip, page, mode32 = true), 0)
+                val chipIndex = if (chip == 3) 2 else chip
+                val expected = page or (chipIndex shl 5)   // 0..95
+                assertThat("chip $chip page $page window0", m.prgAt(0), equalTo(expected))
+                assertThat("chip $chip page $page window1", m.prgAt(1), equalTo(expected))
+            }
+        }
+    }
+
+    // ---- PRG banking: adjacent-16KB-pair mode (bit 5 clear) ----
+
+    @Test
+    fun `pair mode maps even page low and odd page high for every chip and page`() {
+        val m = newMapper()
+        for (chip in intArrayOf(0, 1, 3)) {
+            for (page in 0..31) {
+                m.cpuWrite(regAddr(chip, page, mode32 = false), 0)
+                val chipIndex = if (chip == 3) 2 else chip
+                val prgPage = page or (chipIndex shl 5)
+                assertThat("chip $chip page $page window0", m.prgAt(0), equalTo(prgPage and 0xFE))
+                assertThat("chip $chip page $page window1", m.prgAt(1), equalTo((prgPage and 0xFE) + 1))
+            }
+        }
+    }
+
+    @Test
+    fun `chip 3 reaches the third 512KB chip (PRG banks 64-95)`() {
+        val m = newMapper()
+        // chip 3, top page, 32KB mode → bank 95 (last bank of the third chip).
+        m.cpuWrite(regAddr(chip = 3, page = 31, mode32 = true), 0)
+        assertThat(m.prgAt(0), equalTo(95))
+        assertThat(m.prgAt(1), equalTo(95))
+    }
+
+    // ---- Chip 2 (physically absent) → open bus ----
+
+    @Test
+    fun `selecting chip 2 makes PRG reads return the data bus (open bus)`() {
+        val m = newMapper()
+        m.cpuWrite(regAddr(chip = 2, page = 0, mode32 = true), 0)
+        m.dataBus = 0x5A.toByte()
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(0x5A))
+        assertThat(m.cpuRead(0xC000).toUnsignedInt(), equalTo(0x5A))
+        m.dataBus = 0xA5.toByte()
+        assertThat(m.cpuRead(0xBFFF).toUnsignedInt(), equalTo(0xA5))
+    }
+
+    @Test
+    fun `selecting a real chip after chip 2 clears the open-bus state`() {
+        val m = newMapper()
+        m.cpuWrite(regAddr(chip = 2, page = 5, mode32 = true), 0)
+        m.cpuWrite(regAddr(chip = 1, page = 5, mode32 = true), 0)  // chip 1 → bank 37
+        m.dataBus = 0x5A.toByte()
+        assertThat(m.prgAt(0), equalTo((1 shl 5) or 5))            // 37, not open bus
+    }
+
+    @Test
+    fun `reads below 0x8000 return the data bus (no PRG-RAM)`() {
+        val m = newMapper()
+        m.dataBus = 0x3C.toByte()
+        assertThat(m.cpuRead(0x6000).toUnsignedInt(), equalTo(0x3C))
+        assertThat(m.cpuRead(0x4020).toUnsignedInt(), equalTo(0x3C))
+    }
+
+    // ---- CHR banking: 4 bits from address + 2 bits from value ----
+
+    @Test
+    fun `CHR bank combines addr A0-A3 high nibble and value bits 0-1`() {
+        val m = newMapper()
+        for (chrHigh in 0..15) {
+            for (low in 0..3) {
+                m.cpuWrite(regAddr(chip = 0, page = 0, mode32 = true, chrHigh = chrHigh), low.toByte())
+                val expected = (chrHigh shl 2) or low   // 0..63
+                assertThat("chrHigh $chrHigh low $low", m.chrBankByte(), equalTo(expected))
+            }
+        }
+    }
+
+    @Test
+    fun `only value bits 0-1 affect the CHR bank — bits 2-7 are discarded`() {
+        val m = newMapper()
+        val addr = regAddr(chip = 0, page = 0, mode32 = true, chrHigh = 0x5)  // high nibble = 5
+        // 0x02 and 0xFE share bits 0-1 == 0b10; the high bits of 0xFE must not leak.
+        m.cpuWrite(addr, 0x02.toByte())
+        val withClean = m.chrBankByte()
+        m.cpuWrite(addr, 0xFE.toByte())
+        val withNoise = m.chrBankByte()
+        assertThat(withNoise, equalTo(withClean))
+        assertThat(withClean, equalTo((0x5 shl 2) or 0x2))  // 0x16
+    }
+
+    // ---- Mirroring: address bit 13 ----
+
+    @Test
+    fun `addr bit 13 set selects horizontal mirroring`() {
+        val m = newMapper()
+        m.cpuWrite(regAddr(chip = 0, page = 0, mode32 = true, horiz = true), 0)
+        assertThat(m.currentMirroring(), equalTo(Mapper.MirroringMode.HORIZONTAL))
+    }
+
+    @Test
+    fun `addr bit 13 clear selects vertical mirroring`() {
+        val m = newMapper()
+        m.cpuWrite(regAddr(chip = 0, page = 0, mode32 = true, horiz = true), 0)   // flip to H
+        m.cpuWrite(regAddr(chip = 0, page = 0, mode32 = true, horiz = false), 0)  // back to V
+        assertThat(m.currentMirroring(), equalTo(Mapper.MirroringMode.VERTICAL))
+    }
+
+    // ---- Writes below $8000 are ignored ----
+
+    @Test
+    fun `writes below 0x8000 do not change banking`() {
+        val m = newMapper()
+        m.cpuWrite(0x6000, 0xFF.toByte())
+        m.cpuWrite(0x4020, 0xFF.toByte())
+        assertThat(m.prgAt(0), equalTo(0))   // still the init state
+        assertThat(m.prgAt(1), equalTo(1))
+    }
+
+    // ---- Save / load round-trip ----
+
+    @Test
+    fun `save and load round-trips banking and mirroring`() {
+        val m = newMapper()
+        m.cpuWrite(regAddr(chip = 3, page = 12, mode32 = false, chrHigh = 0xA, horiz = true), 0x03.toByte())
+        val prg0 = m.prgAt(0); val prg1 = m.prgAt(1)
+        val chr = m.chrBankByte(); val mirror = m.currentMirroring()
+
+        val buf = ByteArrayOutputStream()
+        m.saveState(DataOutputStream(buf))
+
+        val restored = newMapper()
+        restored.loadState(DataInputStream(ByteArrayInputStream(buf.toByteArray())))
+
+        assertThat(restored.prgAt(0), equalTo(prg0))
+        assertThat(restored.prgAt(1), equalTo(prg1))
+        assertThat(restored.chrBankByte(), equalTo(chr))
+        assertThat(restored.currentMirroring(), equalTo(mirror))
+    }
+
+    @Test
+    fun `open-bus state survives save and load round-trip`() {
+        val m = newMapper()
+        m.cpuWrite(regAddr(chip = 2, page = 0, mode32 = true), 0)
+
+        val buf = ByteArrayOutputStream()
+        m.saveState(DataOutputStream(buf))
+        val restored = newMapper()
+        restored.loadState(DataInputStream(ByteArrayInputStream(buf.toByteArray())))
+
+        restored.dataBus = 0x77.toByte()
+        assertThat(restored.cpuRead(0x8000).toUnsignedInt(), equalTo(0x77))
+    }
+}


### PR DESCRIPTION
Implements the **Action 52** mapper (mapper 228) so the 52-game Active Enterprises multicart boots to its game-selection menu.

Closes #140

## What this board does differently
The written **value** contributes only 2 bits (CHR low); the **address** carries the PRG bank, CHR high nibble, PRG mode and mirroring. It's the only address-as-bank-select decode in the codebase.

Decode (matching Mesen2's `ActionEnterprises.h`, the oracle):
- `chipSelect = (addr >> 11) & 3`
- `prgPage = ((addr >> 6) & 0x1F) | (chip << 5)`
- `addr & 0x20` → 32KB-mirror vs adjacent-16KB pair
- `chrBank = ((addr & 0x0F) << 2) | (value & 3)`
- `addr & 0x2000` → mirroring (1=H, 0=V)
- `InitMapper` writes `$8000, 0` (without it the menu hangs black)

## The chip-2/chip-3 reconciliation (deliberate deviation from the issue prose)
The cart has three physical PRG chips wired as 0/1/**3** (chip 2 absent). The dump packs them contiguously into 96×16KB banks with chip-3 data at banks 64-95. Mesen remaps `chipSelect 3 → 2` *for indexing* so chip 3 reaches those banks. The issue text said "chip-3 reads return open bus," which is self-contradictory — it would orphan ~17 games.

This implementation keeps the remap for indexing **and** flags a *literal* `chipSelect == 2` write as open bus (the absent chip). No real game selects chip 2, so this matches Mesen for every real access while honouring the nesdev wiki's open-bus note and keeping all third-chip games playable. Documented in code + `MAPPER_SUPPORT.md`.

## Verification
- `Mapper228Test` (17 cases): dispatch, address-only PRG banking across all 96 banks in both modes, chip-3→third-chip path, chip-2 open bus, address+value CHR banking across all 64 banks, value-bit isolation, mirroring bit 13, initial state, sub-$8000 open bus, save/load round-trip.
- `Mapper228RegressionTest`: banking-moves-during-boot guard + `@RequiresMesen2` render compare vs Mesen2 at the menu frame.
- `./gradlew bootcheck` on *Action 52 (USA) (Rev A)* → **PASS** (rendering by frame 34, 27.5% non-blank, PRG+CHR banks moving, 86 NMIs).
- `./gradlew test` green (incl. `MapperCoverageLintTest`).

A high-effort code review ran on the branch; its one correctness finding (an unguarded `% programRom.size` div-by-zero on a malformed 0-PRG dump, asymmetric with `ppuRead`'s existing `chrRom.isEmpty()` guard) and three cleanup findings are fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)