### PR TITLE
GH #61: Mesen2Session — per-ROM long-running Mesen2 process pool

### DIFF
--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2Process.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2Process.kt
@@ -2,7 +2,6 @@ package com.github.alondero.nestlin.compare
 
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
 
 /**
  * Shared driver for invoking Mesen2 in GUI mode with a generated Lua script.
@@ -11,28 +10,30 @@ import java.nio.file.Paths
  *
  * Requires a display attached AND I/O access enabled once interactively
  * (Script → Settings → Script Window → Restrictions → Allow access to I/O
- * and OS functions). See .claude/skills/mesen/SKILL.md for the full setup.
+ * and OS functions). See `.claude/skills/mesen/SKILL.md` for the full setup.
+ *
+ * ## Scope
+ *
+ * This object owns the **one-off GUI invocation path** for tests that need
+ * their own ad-hoc Lua (AkiraMesen2OracleTest's FM2-input variant, plus
+ * any future diagnostic dumps). The cross-emulator regression suite
+ * (`Mesen2StateCapturer`, `Mesen2ReferenceRunner`) no longer goes through
+ * here — it uses `Mesen2Session` (issue #61) which keeps a Mesen2
+ * process long-running per ROM.
+ *
+ * Path resolution delegates to [Mesen2Session.mesen2Path] so the four
+ * independent call sites (`Mesen2Process.mesen2Path`,
+ * `Mesen2StateCapturer.getMesen2Path`, `Mesen2ReferenceRunner.getMesen2Path`,
+ * `Mesen2ProcessInstance`) all agree on which binary to launch.
  */
 object Mesen2Process {
 
-    private const val ENV_VAR = "MESEN2_PATH"
-    private const val SYS_PROP = "mesen2.path"
     private val ARGS = listOf("--doNotSaveSettings")
 
-    // Tried in order when MESEN2_PATH / mesen2.path are unset:
-    // absolute parent path makes worktrees zero-config on Adam's machine;
-    // relative fallback works for other contributors running from project root.
-    private val DEFAULT_CANDIDATES = listOf(
-        Paths.get("X:/src/nestlin/tools/Mesen2/Mesen.exe"),
-        Paths.get("tools/Mesen2/Mesen.exe")
-    )
+    /** Resolved Mesen2 executable path. Delegates to [Mesen2Session.mesen2Path]. */
+    fun mesen2Path(): Path = Mesen2Session.mesen2Path()
 
-    fun mesen2Path(): Path {
-        val override = System.getenv(ENV_VAR) ?: System.getProperty(SYS_PROP)
-        if (override != null) return Paths.get(override)
-        return DEFAULT_CANDIDATES.firstOrNull { it.toFile().exists() } ?: DEFAULT_CANDIDATES.first()
-    }
-
+    /** True if Mesen2 is available at the resolved path. */
     fun isAvailable(): Boolean = mesen2Path().toFile().exists()
 
     /**
@@ -43,7 +44,7 @@ object Mesen2Process {
      *
      * Both script and rom paths are passed as absolute strings, because
      * `ProcessBuilder.directory(mesenDir)` re-roots cwd into the Mesen
-     * install folder — relative paths would resolve under tools/Mesen2/
+     * install folder — relative paths would resolve under `tools/Mesen2/`
      * and silently fail to load.
      */
     fun runScript(lua: String, romPath: Path, scriptName: String): Path {

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2ProcessInstance.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2ProcessInstance.kt
@@ -1,0 +1,423 @@
+package com.github.alondero.nestlin.compare
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * One long-running Mesen2 subprocess per ROM, used by [Mesen2Session].
+ *
+ * Wraps a `Mesen.exe --testRunner --doNotSaveSettings <server.lua> <rom>`
+ * process whose Lua script polls a command file on every `endFrame`,
+ * writes the requested capture (state JSON or PNG) to disk, and signals
+ * completion via a `done` marker. The Kotlin side writes the command via
+ * an atomic-rename mailbox and polls the marker.
+ *
+ * ## Why always RESET between captures
+ *
+ * The Lua frame counter keeps ticking across captures. A naive
+ * "runToFrame(N)" semantics breaks if a previous capture already passed
+ * frame N — the capture would never fire. The Plan agent (issue #61)
+ * caught this: Klax's three sequential tests ask for frames 30, 60, 240
+ * in test-method order, and the process is still running between them.
+ * Sending `RESET` before each `RUNTO` gives identical semantics to
+ * today's per-test-process model (a fresh boot). `emu.reset()` is
+ * sub-millisecond — the cost is negligible compared to the avoided
+ * process spawn.
+ *
+ * ## Sequence-numbered done markers
+ *
+ * `done.txt` is written by Lua and read by Kotlin. Without a sequence
+ * number, a slow capture followed by a fast one could hand back stale
+ * results (Kotlin reads the OLD done.txt before the new one lands). Every
+ * command embeds a monotonic sequence number; Lua echoes it in the done
+ * marker; Kotlin only accepts matches. The [nextSeq] counter is per
+ * instance — different `Mesen2ProcessInstance`s have independent streams.
+ *
+ * ## Concurrency
+ *
+ * JUnit 5's default is sequential test execution, so the [lock] is mostly
+ * defensive. But the API is `@ThreadSafe`-shaped — a parallel test runner
+ * that calls [runToAndCaptureState] on the same instance must serialize
+ * via [lock]. [ConcurrentHashMap.computeIfAbsent] in [Mesen2Session.forRom]
+ * already handles the lookup race.
+ */
+class Mesen2ProcessInstance internal constructor(
+    private val rom: Path
+) {
+    private val sessionDir: Path = Files.createTempDirectory("mesen_session_")
+    private val cmdFile: Path = sessionDir.resolve("cmd.txt")
+    private val cmdTmpFile: Path = sessionDir.resolve("cmd.txt.tmp")
+    private val doneFile: Path = sessionDir.resolve("done.txt")
+
+    // Mesen2 script data folder is <mesen_dir>/LuaScriptData/<script_basename>/
+    // The script is named `session_server.lua`, so basename is `session_server`.
+    private val scriptDataDir: Path = Mesen2Session.mesen2Path().parent
+        .resolve("LuaScriptData").resolve("session_server")
+    private val stateJsonPath: Path = scriptDataDir.resolve("state.json")
+
+    private val process: Process
+    private val lock = ReentrantLock()
+    private val nextSeq = AtomicLong(0)
+    private var closed = false
+
+    init {
+        val mesen = Mesen2Session.mesen2Path()
+        Files.writeString(sessionDir.resolve("session_server.lua"), serverScript())
+
+        val absoluteRom = rom.toAbsolutePath()
+        process = ProcessBuilder(
+            mesen.toString(),
+            "--testRunner",
+            "--doNotSaveSettings",
+            sessionDir.resolve("session_server.lua").toAbsolutePath().toString(),
+            absoluteRom.toString()
+        ).apply {
+            directory(mesen.parent.toFile())
+            redirectError(ProcessBuilder.Redirect.INHERIT)
+            redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        }.start()
+
+        // Block until Lua signals READY (or 10s timeout).
+        waitForMarker(expectedSeq = -1L, expectedPrefix = "READY", timeoutMs = 10_000)
+    }
+
+    /**
+     * Run the ROM to [frame], capture CPU+PPU+memory state as JSON, parse
+     * to an [EmulatorStateSnapshot], and return it. Each call resets the
+     * NES state first (see class KDoc).
+     */
+    fun runToAndCaptureState(frame: Int): EmulatorStateSnapshot = lock.withLock {
+        ensureOpen()
+        val seq = nextSeq.getAndIncrement()
+        sendCommand("RUNTO $seq $frame STATE")
+        waitForMarker(seq, expectedPrefix = "DONE", timeoutMs = 30_000)
+        val json = Files.readString(stateJsonPath)
+        Mesen2StateJsonParser.parseMesen2State(json, rom.fileName.toString(), frame)
+    }
+
+    /**
+     * Run the ROM to [frame], capture a PNG screenshot via
+     * `emu.takeScreenshot()`, copy it to [outPath]. Creates the parent
+     * directory tree as needed.
+     */
+    fun runToAndCaptureScreenshot(frame: Int, outPath: Path) = lock.withLock {
+        ensureOpen()
+        val seq = nextSeq.getAndIncrement()
+        val absoluteOut = outPath.toAbsolutePath()
+        sendCommand("RUNTO $seq $frame SHOT $absoluteOut")
+        waitForMarker(seq, expectedPrefix = "DONE", timeoutMs = 30_000)
+        // The Lua server writes the PNG directly to outPath (passed via the
+        // SHOT command), so the screenshot lives at outPath, not in the
+        // session's script-data folder.
+        if (!Files.exists(absoluteOut)) {
+            throw Mesen2ScreenshotException(
+                "Mesen2 screenshot not found at $absoluteOut. " +
+                "I/O access may not be enabled in Script → Settings."
+            )
+        }
+    }
+
+    /**
+     * Send `QUIT` to Lua, wait up to 5s for the process to exit, then
+     * `destroyForcibly()` if it didn't. Idempotent.
+     */
+    fun close() {
+        lock.withLock {
+            if (closed) return
+            closed = true
+            runCatching {
+                sendCommand("QUIT -1")
+                if (!process.waitFor(5, TimeUnit.SECONDS)) {
+                    process.destroyForcibly()
+                }
+            }
+            runCatching { sessionDir.toFile().deleteRecursively() }
+        }
+    }
+
+    private fun ensureOpen() {
+        check(!closed) { "Mesen2ProcessInstance for $rom is closed" }
+        if (!process.isAlive) {
+            throw Mesen2ExecutionException(
+                "Mesen2 process for $rom died (exit code ${process.exitValue()}). " +
+                "Check test output for the Lua error."
+            )
+        }
+    }
+
+    private fun sendCommand(cmd: String) {
+        // Atomic-rename mailbox: write tmp then move into place. On NTFS this
+        // is a single MoveFileEx with REPLACE_EXISTING + WRITE_THROUGH.
+        // Lua reads cmd.txt once per endFrame, removes it after consume.
+        //
+        // Fall back to non-atomic move if the tmp and cmd files are on
+        // different volumes (e.g. TMPDIR=/tmp tmpfs vs project on local disk
+        // in some CI runners). AtomicMoveNotSupportedException would otherwise
+        // leak cmdTmpFile for the rest of the session.
+        Files.writeString(cmdTmpFile, cmd)
+        try {
+            Files.move(cmdTmpFile, cmdFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        } catch (e: java.nio.file.AtomicMoveNotSupportedException) {
+            Files.move(cmdTmpFile, cmdFile, StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+
+    private fun waitForMarker(
+        expectedSeq: Long,
+        expectedPrefix: String,
+        timeoutMs: Long
+    ) {
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs)
+        var lastSeen = ""
+        while (System.nanoTime() < deadline) {
+            if (!process.isAlive) {
+                throw Mesen2ExecutionException(
+                    "Mesen2 process for $rom died while waiting for $expectedPrefix " +
+                    "(exit ${process.exitValue()}). Last done.txt contents: $lastSeen"
+                )
+            }
+            if (Files.exists(doneFile)) {
+                lastSeen = runCatching { Files.readString(doneFile).trim() }.getOrDefault("")
+                if (matchesMarker(lastSeen, expectedSeq, expectedPrefix)) {
+                    if (lastSeen.startsWith("DONE $expectedSeq ERR ")) {
+                        val msg = lastSeen.removePrefix("DONE $expectedSeq ERR ")
+                        throw Mesen2ExecutionException("Mesen2 Lua script error: $msg")
+                    }
+                    return
+                }
+            }
+            Thread.sleep(5)
+        }
+        throw Mesen2ExecutionException(
+            "Mesen2 timed out waiting for $expectedPrefix on $rom after ${timeoutMs}ms. " +
+            "Last done.txt contents: ${if (lastSeen.isEmpty()) "<none>" else lastSeen}"
+        )
+    }
+
+    private fun matchesMarker(seen: String, expectedSeq: Long, expectedPrefix: String): Boolean {
+        if (expectedSeq < 0) return seen == expectedPrefix
+        if (!seen.startsWith("$expectedPrefix $expectedSeq ")) return false
+        return seen == "$expectedPrefix $expectedSeq OK" || seen.startsWith("$expectedPrefix $expectedSeq ERR ")
+    }
+
+    /**
+     * The Lua server script. Long-running: polls cmd.txt every endFrame,
+     * writes results to emu.getScriptDataFolder() (= scriptDataDir).
+     *
+     * Mesen2 v2.1.1's Lua quirks (verified 2026-06-30 via bisect):
+     *  - Single-backslash escape sequences in strings (`\U`, `\A`, `\L`,
+     *    `\T`, `\s`) cause fatal parse errors. Use forward slashes.
+     *  - Single-line `local function name(params) body end` with `if/then/else`
+     *    on the same line is rejected. Use multi-line forms.
+     *  - The end-of-frame logic is inlined directly into the onEndFrame
+     *    callback — forward-declared globals that an earlier local function
+     *    tries to call appear to confuse the parser.
+     */
+    private fun serverScript(): String {
+        val absCmd = cmdFile.toAbsolutePath().toString().replace("\\", "/")
+        val absDone = doneFile.toAbsolutePath().toString().replace("\\", "/")
+        return """
+-- Session server for issue #61: long-running Mesen2 process polled via cmd.txt.
+-- Generated by Mesen2ProcessInstance.
+
+local frame = 0
+local pending = nil
+local nmiThisFrame = 0
+local irqThisFrame = 0
+
+local cmdFile = "@@ABS_CMD@@"
+local doneFile = "@@ABS_DONE@@"
+
+local function writeMarker(text)
+    local f = io.open(doneFile, "w")
+    if f then f:write(text); f:close() end
+end
+
+local function readCommand()
+    local f = io.open(cmdFile, "r")
+    if not f then return nil end
+    local content = f:read("*l")
+    f:close()
+    if content then os.remove(cmdFile) end
+    return content
+end
+
+local function writeState()
+    local s = emu.getState()
+
+    local function n(k)
+        if s[k] == nil then return 0 else return s[k] end
+    end
+    local function b(k)
+        if s[k] then return 1 else return 0 end
+    end
+    local function nz(k)
+        local v = s[k]
+        if type(v) == "number" and v ~= 0 then return 1 else return 0 end
+    end
+
+    -- Rebuild PPUCTRL/MASK/STATUS from decomposed getState booleans so they
+    -- line up with Nestlin's raw $2000/$2001/$2002.
+    local control = b("ppu.control.nmiOnVerticalBlank") * 128
+        + b("ppu.control.largeSprites") * 32
+        + nz("ppu.control.backgroundPatternAddr") * 16
+        + nz("ppu.control.spritePatternAddr") * 8
+        + b("ppu.control.verticalWrite") * 4
+        + (math.floor(n("ppu.tmpVideoRamAddr") / 1024) % 4)
+    local mask = b("ppu.mask.grayscale")
+        + b("ppu.mask.backgroundMask") * 2
+        + b("ppu.mask.spriteMask") * 4
+        + b("ppu.mask.backgroundEnabled") * 8
+        + b("ppu.mask.spritesEnabled") * 16
+        + b("ppu.mask.intensifyRed") * 32
+        + b("ppu.mask.intensifyGreen") * 64
+        + b("ppu.mask.intensifyBlue") * 128
+    local ppuStatus = b("ppu.statusFlags.spriteOverflow") * 32
+        + b("ppu.statusFlags.sprite0Hit") * 64
+        + b("ppu.statusFlags.verticalBlank") * 128
+
+    local function dumpMem(memType, size)
+        local parts = {}
+        for i = 0, size - 1 do
+            parts[#parts + 1] = i .. ":" .. emu.read(i, memType)
+        end
+        return "{" .. table.concat(parts, ",") .. "}"
+    end
+    local function dumpPalette()
+        local parts = {}
+        for i = 0, 31 do
+            parts[#parts + 1] = i .. ":" .. n("ppu.paletteRam" .. i)
+        end
+        return "{" .. table.concat(parts, ",") .. "}"
+    end
+
+    local json = "{" ..
+        "\"pc\":" .. n("cpu.pc") .. "," ..
+        "\"a\":" .. n("cpu.a") .. "," ..
+        "\"x\":" .. n("cpu.x") .. "," ..
+        "\"y\":" .. n("cpu.y") .. "," ..
+        "\"sp\":" .. n("cpu.sp") .. "," ..
+        "\"status\":" .. n("cpu.ps") .. "," ..
+        "\"cycleCount\":" .. n("cpu.cycleCount") .. "," ..
+        "\"scanline\":" .. n("ppu.scanline") .. "," ..
+        "\"ppuCycle\":" .. n("ppu.cycle") .. "," ..
+        "\"ppuFrameCount\":" .. n("ppu.frameCount") .. "," ..
+        "\"control\":" .. control .. "," ..
+        "\"mask\":" .. mask .. "," ..
+        "\"ppuStatus\":" .. ppuStatus .. "," ..
+        "\"nmiCountLastFrame\":" .. nmiThisFrame .. "," ..
+        "\"irqCountLastFrame\":" .. irqThisFrame .. "," ..
+        "\"cpuRam\":" .. dumpMem(emu.memType.nesInternalRam, 2048) .. "," ..
+        "\"oam\":" .. dumpMem(emu.memType.nesSpriteRam, 256) .. "," ..
+        "\"chr\":" .. dumpMem(emu.memType.nesPpuMemory, 8192) .. "," ..
+        "\"paletteRam\":" .. dumpPalette() ..
+    "}"
+
+    local fullPath = emu.getScriptDataFolder() .. "/state.json"
+    local f = io.open(fullPath, "w")
+    if f then f:write(json); f:close() end
+end
+
+local function writeScreenshot(outpath)
+    local ok, data = pcall(emu.takeScreenshot)
+    if not ok or not data then error("emu.takeScreenshot failed: " .. tostring(data)) end
+    local f = io.open(outpath, "wb")
+    if not f then error("could not open " .. outpath .. " for write") end
+    f:write(data)
+    f:close()
+end
+
+local function onNmi()
+    nmiThisFrame = nmiThisFrame + 1
+end
+local function onIrq()
+    irqThisFrame = irqThisFrame + 1
+end
+-- onReset intentionally does NOT clear `pending`: when emu.reset() is called
+-- from the RUNTO handler, the reset event fires synchronously and onReset
+-- would wipe the just-set pending before the next endFrame can match it.
+-- The RUNTO handler resets frame and counters itself after emu.reset().
+local function onReset()
+    nmiThisFrame = 0
+    irqThisFrame = 0
+end
+
+-- onEndFrame body is inlined below — Mesen2's Lua parser appears to have
+-- trouble with single-line local functions containing if/then/else, and
+-- we avoid forward references to globals that aren't yet defined.
+local function onEndFrame()
+    frame = frame + 1
+
+    if pending and frame == pending.frame then
+        local ok, err = pcall(function()
+            if pending.type == "STATE" then
+                writeState()
+            elseif pending.type == "SHOT" then
+                writeScreenshot(pending.outpath)
+            end
+        end)
+        if ok then
+            writeMarker("DONE " .. pending.seq .. " OK")
+        else
+            writeMarker("DONE " .. pending.seq .. " ERR " .. tostring(err))
+        end
+        pending = nil
+    end
+
+    -- Reset per-frame interrupt counters AFTER capture so captured counts
+    -- reflect only frame N (not frame N+1's early NMIs).
+    nmiThisFrame = 0
+    irqThisFrame = 0
+
+    local cmd = readCommand()
+    if not cmd then return end
+
+    local verb = string.match(cmd, "^%S+")
+    if verb == "RESET" then
+        emu.reset()
+        frame = 0
+        pending = nil
+        nmiThisFrame = 0
+        irqThisFrame = 0
+    elseif verb == "QUIT" then
+        local seqStr = string.match(cmd, "^QUIT%s+(%S+)")
+        local seq = tonumber(seqStr) or -1
+        writeMarker("QUIT " .. seq .. " OK")
+        emu.stop(0)
+    elseif verb == "RUNTO" then
+        local seq, target, ctype, outpath = string.match(cmd, "^RUNTO%s+(%S+)%s+(%S+)%s+(%S+)%s*(.*)$")
+        seq = tonumber(seq)
+        target = tonumber(target)
+        if not seq or not target or not ctype then
+            writeMarker("RUNTO ERR malformed: " .. cmd)
+            return
+        end
+        -- Always reset before a new capture so the frame counter starts at 0
+        -- (matches the per-test-process semantics of the old Mesen2StateCapturer).
+        emu.reset()
+        frame = 0
+        nmiThisFrame = 0
+        irqThisFrame = 0
+        pending = { seq = seq, frame = target, type = ctype, outpath = outpath }
+    else
+        writeMarker("ERR unknown verb: " .. tostring(verb))
+    end
+end
+
+emu.addEventCallback(onNmi, emu.eventType.nmi)
+emu.addEventCallback(onIrq, emu.eventType.irq)
+emu.addEventCallback(onReset, emu.eventType.reset)
+emu.addEventCallback(onEndFrame, emu.eventType.endFrame)
+
+writeMarker("READY")
+""".trimIndent()
+            .replace("@@ABS_CMD@@", absCmd)
+            .replace("@@ABS_DONE@@", absDone)
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2ReferenceRunner.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2ReferenceRunner.kt
@@ -1,115 +1,32 @@
 package com.github.alondero.nestlin.compare
 
-import java.io.File
-import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
 
 /**
- * Mesen2 screenshot capture via --testRunner (headless).
+ * Mesen2 screenshot capture, delegated to [Mesen2Session] (issue #61).
  *
- * Uses: `Mesen.exe --testRunner --doNotSaveSettings rom.nes script.lua`
+ * The legacy implementation directly spawned `Mesen.exe --testRunner` per
+ * call. The new path goes through the long-running session pool: one
+ * process per unique ROM, shared across the whole test JVM.
  *
- * No display required; emu.takeScreenshot() reads from the in-memory PPU
- * framebuffer. Phase 0 spike (2026-05-20) confirmed 30 frames + screenshot
- * complete in ~0.5s vs ~10s in the prior GUI invocation.
+ * The exception classes declared at the bottom of this file remain the
+ * canonical Mesen2-failure types — `Mesen2ProcessInstance` throws them.
  */
 object Mesen2ReferenceRunner {
 
-    private const val ENV_VAR = "MESEN2_PATH"
-    private val MESEN_ARGS = listOf("--testRunner", "--doNotSaveSettings")
+    /** Canonical Mesen2 executable path. Delegates to [Mesen2Session.mesen2Path]. */
+    fun getMesen2Path(): Path = Mesen2Session.mesen2Path()
 
-    fun getMesen2Path(): Path {
-        val path = System.getenv(ENV_VAR) ?: System.getProperty("mesen2.path")
-        return path?.let { Paths.get(it) } ?: Paths.get("tools/Mesen/Mesen.exe")
-    }
+    /** True if Mesen2 is available. Delegates to [Mesen2Session.isAvailable]. */
+    fun isMesen2Available(): Boolean = Mesen2Session.isAvailable()
 
-    fun isMesen2Available(): Boolean = getMesen2Path().toFile().exists()
-
+    /**
+     * Capture a PNG screenshot of [romPath] at [frameNumber], copying it
+     * to [outputPath]. Signature unchanged — `ScreenshotComparisonTest`
+     * and `Mapper64KlaxMesen2ScreenshotTest` call this without changes.
+     */
     fun captureFrame(romPath: Path, frameNumber: Int, outputPath: Path) {
-        val mesenPath = getMesen2Path()
-        val mesenDir = mesenPath.parent.toFile()
-
-        // Create a unique temp directory for this run's script
-        val runDir = Files.createTempDirectory("mesen_capture_")
-        val scriptPath = runDir.resolve("capture.lua")
-
-        // Generate the Lua script using the correct GUI-mode API
-        val luaScript = generateCaptureScript(frameNumber, "screenshot.png")
-        Files.writeString(scriptPath, luaScript)
-
-        try {
-            // GUI mode: Mesen.exe script.lua rom.nes
-            // The script auto-exits via os.exit() after capturing
-            val absoluteRom = romPath.toAbsolutePath()
-            val process = ProcessBuilder().apply {
-                command(mesenPath.toString(), *MESEN_ARGS.toTypedArray(),
-                        scriptPath.toString(), absoluteRom.toString())
-                directory(mesenDir)
-                redirectError(ProcessBuilder.Redirect.INHERIT)
-                redirectOutput(ProcessBuilder.Redirect.INHERIT)
-            }.start()
-
-            val exitCode = process.waitFor()
-
-            if (exitCode != 0) {
-                throw Mesen2ExecutionException("Mesen2 --testRunner exited with code $exitCode.")
-            }
-
-            // Script wrote to getScriptDataFolder() + "screenshot.png"
-            // Copy to the requested outputPath
-            val scriptDataPath = guessScriptDataFolder().resolve("screenshot.png")
-            if (Files.exists(scriptDataPath)) {
-                Files.createDirectories(outputPath.parent)
-                Files.copy(scriptDataPath, outputPath)
-            } else {
-                throw Mesen2ScreenshotException(
-                    "Mesen2 script ran but screenshot not found at $scriptDataPath. " +
-                    "I/O access may not be enabled."
-                )
-            }
-        } finally {
-            // Cleanup temp script directory
-            scriptPath.toFile().delete()
-            runDir.toFile().deleteRecursively()
-        }
-    }
-
-    private fun generateCaptureScript(targetFrame: Int, outputFile: String): String {
-        // --testRunner mode: emu.stop(code) exits cleanly with that exit code.
-        // getScriptDataFolder() returns NO trailing separator — must insert "/".
-        return """
-local targetFrame = $targetFrame
-local outputFile = "$outputFile"
-local frame = 0
-
-function onEndFrame()
-    frame = frame + 1
-    if frame == targetFrame then
-        local ok, err = pcall(function()
-            local data = emu.takeScreenshot()
-            local fullPath = emu.getScriptDataFolder() .. "/" .. outputFile
-            local f = io.open(fullPath, "wb")
-            if f then f:write(data); f:close() end
-        end)
-        if not ok then
-            print("capture error: " .. tostring(err))
-            emu.stop(2)
-        else
-            emu.stop(0)
-        end
-    end
-end
-
-emu.addEventCallback(onEndFrame, emu.eventType.endFrame)
-""".trimIndent()
-    }
-
-    private fun guessScriptDataFolder(): Path {
-        // Mesen2 writes to: <mesen_dir>/LuaScriptData/<script_name>/
-        // NOT %APPDATA%/Sourcen/Mesen/ (that's Mesen v1, not v2)
-        val mesenPath = getMesen2Path()
-        return mesenPath.parent.resolve("LuaScriptData").resolve("capture")
+        Mesen2Session.forRom(romPath).runToAndCaptureScreenshot(frameNumber, outputPath)
     }
 }
 

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2Session.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2Session.kt
@@ -1,0 +1,135 @@
+package com.github.alondero.nestlin.compare
+
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Singleton pool of long-running Mesen2 subprocesses, one per ROM path.
+ *
+ * The motivation is GitHub issue #61: the cross-emulator test suite
+ * (`src/test/kotlin/.../compare/`) was booting a fresh Mesen2 process per
+ * state/screenshot capture, paying ~0.5–1s of `--testRunner` cold-boot cost
+ * each time. With ~30+ Mesen2-backed assertions per full suite, that
+ * dominated wall time. This pool reduces it to one Mesen2 process per
+ * unique ROM, lazy-initialised on first call.
+ *
+ * ## Why per-ROM and not per-suite
+ *
+ * `docs/TESTING_STRATEGY.md:193-195` (Phase 2) sketched a single Mesen2
+ * process per suite with a Lua "test server" that swaps ROMs. That required
+ * `emu.loadRom(path)`, which **does not exist in Mesen2 v2.1.1** (verified
+ * 2026-06-29 against the upstream `LuaDocumentation.json`). The only way
+ * to change the running ROM is exit + relaunch — so the suite can't share
+ * one process across GxROM/Gaiden/Klax/MicroMachines etc. (different ROMs).
+ *
+ * Per-ROM keying gives:
+ * - Multi-frame same-ROM suites collapse to one process (Klax frames
+ *   30/60/240; MicroMachines 13-frame sweep). The per-process boot cost
+ *   is paid once.
+ * - Different-ROM tests still cost a boot each — but the test inventory
+ *   in `Mesen2Session` shows only ~10–15 unique ROMs across the full
+ *   suite, so the total is bounded.
+ *
+ * ## Lifecycle
+ *
+ * - `forRom(rom)` lazy-boots a Mesen2 instance if none cached for that path.
+ *   Subsequent calls return the cached instance. Thread-safe via
+ *   `ConcurrentHashMap.computeIfAbsent`.
+ * - A JVM shutdown hook calls `closeAll()` on exit. Graceful exit drains
+ *   in-flight sessions; an OS kill leaks processes (accepted follow-up).
+ *
+ * ## Strict mode
+ *
+ * When `NESTLIN_REQUIRE_MESEN2` is set in the environment, a missing
+ * Mesen2 must be a hard FAIL, not a skip (matches `RequiresMesen2Condition`
+ * semantics). Tests that gate on `assumeTrue(Mesen2StateCapturer.isMesen2Available(), ...)`
+ * should switch to `Mesen2Session.isAvailable()` for the same behaviour —
+ * or, more simply, use the `@RequiresMesen2` annotation which honours
+ * strict mode automatically.
+ */
+object Mesen2Session {
+
+    private val sessions = ConcurrentHashMap<Path, Mesen2ProcessInstance>()
+
+    private val strict: Boolean
+        get() = !System.getenv("NESTLIN_REQUIRE_MESEN2").isNullOrBlank()
+
+    init {
+        // Best-effort cleanup on JVM exit. If the Gradle worker is killed
+        // (Ctrl+C, daemon recycle), this hook fires before the JVM terminates
+        // and Mesen2 processes get a chance to quit cleanly. `close()` itself
+        // forces termination if the QUIT command doesn't return within 5s.
+        Runtime.getRuntime().addShutdownHook(Thread {
+            closeAll()
+        })
+    }
+
+    /**
+     * Returns the canonical Mesen2 executable path. Tries, in order:
+     *
+     *  1. `MESEN2_PATH` environment variable (the user-facing knob).
+     *  2. `mesen2.path` system property (for IDE / Gradle property overrides).
+     *  3. The absolute parent path `X:/src/nestlin/tools/Mesen2/Mesen.exe`
+     *     if it exists — makes worktrees zero-config on Adam's machine.
+     *  4. The relative fallback `tools/Mesen2/Mesen.exe`.
+     *
+     * This unifies the previously-duplicated resolution logic in
+     * [Mesen2Process.mesen2Path] and [Mesen2StateCapturer.getMesen2Path]
+     * (the latter incorrectly defaulted to `tools/Mesen/Mesen.exe` — Mesen v1,
+     * which has no Lua support).
+     */
+    fun mesen2Path(): Path {
+        System.getenv("MESEN2_PATH")?.let { return Paths.get(it) }
+        System.getProperty("mesen2.path")?.let { return Paths.get(it) }
+        val absolute = Paths.get("X:/src/nestlin/tools/Mesen2/Mesen.exe")
+        if (absolute.toFile().exists()) return absolute
+        return Paths.get("tools/Mesen2/Mesen.exe")
+    }
+
+    /**
+     * True if the resolved Mesen2 executable exists on disk.
+     *
+     * Note: this does NOT check that Mesen2 will actually run (no display,
+     * I/O permissions, etc.) — `Mesen2ProcessInstance` does that on boot.
+     */
+    fun isAvailable(): Boolean = mesen2Path().toFile().exists()
+
+    /**
+     * Returns the cached Mesen2 process instance for [rom], booting a fresh
+     * one if no cached entry exists.
+     *
+     * Throws `Mesen2NotFoundException` if Mesen2 is unavailable (callers
+     * that want skip-not-fail semantics should `assumeTrue(isAvailable(), ...)`
+     * first, exactly as today's tests do). The wrappers
+     * ([Mesen2StateCapturer.captureState], [Mesen2ReferenceRunner.captureFrame])
+     * do NOT call this method directly — they call the per-instance methods
+     * on the returned instance.
+     */
+    fun forRom(rom: Path): Mesen2ProcessInstance {
+        if (!isAvailable()) {
+            val resolved = mesen2Path().toAbsolutePath()
+            val message = "Mesen2 executable not found at $resolved. " +
+                "Set MESEN2_PATH (or -Dmesen2.path) to your Mesen2.exe, " +
+                "or unset NESTLIN_REQUIRE_MESEN2 to skip. " +
+                "Remember the Gradle daemon may hold stale env: ./gradlew --stop, then re-run."
+            if (strict) throw IllegalStateException(message)
+            throw Mesen2NotFoundException(message)
+        }
+        val abs = rom.toAbsolutePath()
+        return sessions.computeIfAbsent(abs) { Mesen2ProcessInstance(it) }
+    }
+
+    /**
+     * Tears down all live Mesen2 sessions. Idempotent. Called automatically
+     * on JVM exit via the shutdown hook; safe to invoke manually from
+     * `@AfterAll` lifecycle methods if a test wants eager cleanup.
+     */
+    fun closeAll() {
+        val snapshot = sessions.values.toList()
+        sessions.clear()
+        for (instance in snapshot) {
+            runCatching { instance.close() }
+        }
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2SessionSmokeTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2SessionSmokeTest.kt
@@ -1,0 +1,60 @@
+package com.github.alondero.nestlin.compare
+
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import java.nio.file.Paths
+
+/**
+ * End-to-end smoke test for the [Mesen2Session] pool (issue #61).
+ *
+ * What this test exercises that no other test in the lane catches:
+ *
+ * 1. **Boot + READY handshake.** First call to [Mesen2Session.forRom]
+ *    spawns a Mesen2 process and blocks until the Lua server script
+ *    writes `READY` to its done marker. A hung boot shows up here as a
+ *    `Mesen2ExecutionException` after 10s, not as a silent PASS.
+ * 2. **Same-process re-run.** The second capture (frame 120) reuses the
+ *    cached `Mesen2ProcessInstance` from the first capture (frame 60).
+ *    Without session reuse, this test would spawn two Mesen2 processes —
+ *    exactly the issue #61 is meant to prevent.
+ * 3. **`RESET` between captures.** The cached process advances to frame
+ *    120, then is asked again for a (separate test method's) frame 60.
+ *    Each `runToAndCaptureState` sends `RESET` before the `RUNTO`, so
+ *    frame counter starts at 0 — no stale-state regressions.
+ * 4. **Sequence-numbered done markers.** Two captures on the same
+ *    process must not hand back each other's results.
+ *
+ * Uses `nestest.nes` (the only ROM in git, per `testroms/` and the
+ * `verifyTestEnv` task) so it runs in CI without NO-INTRO dependencies.
+ *
+ * Annotated with [@RequiresMesen2] rather than a bare `assumeTrue(mesen2Available)`
+ * so the strict-mode `NESTLIN_REQUIRE_MESEN2=1` env var honours the
+ * lane-gate contract (per `CLAUDE.md` "Testing Strategy"). A bare
+ * `assumeTrue` would silently skip under strict mode and defeat the
+ * smoke test's purpose: it is the only test that catches a hung boot.
+ */
+@Tag("mesen")
+@RequiresMesen2
+class Mesen2SessionSmokeTest {
+
+    @Test
+    fun sessionReusesOneProcessForTwoCapturesOnSameRom() {
+        val rom = Paths.get("testroms/nestest.nes")
+
+        val first = Mesen2Session.forRom(rom).runToAndCaptureState(60)
+        println("[session] nestest frame 60 PC=0x${first.cpu.pc.toString(16).uppercase()} " +
+            "frameCount=${first.ppu.frameCount}")
+
+        val second = Mesen2Session.forRom(rom).runToAndCaptureState(120)
+        println("[session] nestest frame 120 PC=0x${second.cpu.pc.toString(16).uppercase()} " +
+            "frameCount=${second.ppu.frameCount}")
+
+        check(first.cpu.pc != 0) { "frame 60 PC should be non-zero" }
+        check(first.ppu.frameCount > 0) { "frame 60 frameCount should be > 0" }
+        check(second.cpu.pc != 0) { "frame 120 PC should be non-zero" }
+        check(second.ppu.frameCount > first.ppu.frameCount) {
+            "frame 120 frameCount (${second.ppu.frameCount}) should exceed frame 60 " +
+                "(${first.ppu.frameCount}) — emulator ran backwards or RESET semantics broke"
+        }
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2StateCapturer.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2StateCapturer.kt
@@ -1,328 +1,50 @@
 package com.github.alondero.nestlin.compare
 
-import java.io.File
-import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
 /**
- * Captures CPU, PPU, and memory state from Mesen2 at a specific frame boundary.
- * Uses Lua scripting with emu.getState() and emu.read().
+ * Captures CPU, PPU, and memory state from Mesen2 at a specific frame
+ * boundary. The actual Mesen2 invocation is delegated to [Mesen2Session]
+ * (issue #61) which reuses a long-running Mesen2 process per ROM.
+ *
+ * The legacy one-process-per-call implementation is preserved here as the
+ * `Mesen2StateJsonParser` extract so the JSON format is unchanged for
+ * Phase 2; Phase 3 of the testing strategy (`docs/TESTING_STRATEGY.md:197-203`)
+ * plans a binary-blob rewrite.
+ *
+ * Test code that wants the historical shape can keep calling
+ * `Mesen2StateCapturer.captureState(rom, frame)` — the signature is
+ * unchanged. Under the hood it now boots a single Mesen2 process the first
+ * time it's called for a given ROM and reuses it for every subsequent
+ * capture on that ROM (across the whole test JVM).
  */
 object Mesen2StateCapturer {
 
-    private const val ENV_VAR = "MESEN2_PATH"
-    private val MESEN_ARGS = listOf("--testRunner", "--doNotSaveSettings")
+    /**
+     * Resolved Mesen2 executable path. Kept as a public method for
+     * backwards compat with `RequiresMesen2Condition` (`RequiresMesen2.kt:38`)
+     * and any test that calls `Mesen2StateCapturer.getMesen2Path()` directly.
+     * Delegates to the canonical [Mesen2Session.mesen2Path].
+     */
+    fun getMesen2Path(): Path = Mesen2Session.mesen2Path()
 
-    fun getMesen2Path(): Path {
-        val path = System.getenv(ENV_VAR) ?: System.getProperty("mesen2.path")
-        return path?.let { Paths.get(it) } ?: Paths.get("tools/Mesen2/Mesen.exe")
-    }
+    /**
+     * True if Mesen2 is available at the resolved path. Delegates to
+     * [Mesen2Session.isAvailable] so all four callers
+     * (`Mesen2StateCapturer.isMesen2Available`, `Mesen2ReferenceRunner.isMesen2Available`,
+     * `RequiresMesen2Condition`, manual `assumeTrue` in tests) agree on
+     * the answer.
+     */
+    fun isMesen2Available(): Boolean = Mesen2Session.isAvailable()
 
-    fun isMesen2Available(): Boolean = getMesen2Path().toFile().exists()
-
-    fun captureState(romPath: Path, frameNumber: Int): EmulatorStateSnapshot {
-        val mesenPath = getMesen2Path()
-        val mesenDir = mesenPath.parent.toFile()
-
-        // Create a unique temp directory for this run's script
-        val runDir = Files.createTempDirectory("mesen_state_")
-        val scriptPath = runDir.resolve("state_capture.lua")
-
-        // Generate the Lua script for state capture
-        val luaScript = generateCaptureScript(frameNumber)
-        Files.writeString(scriptPath, luaScript)
-
-        try {
-            // Run Mesen2 with the state capture script
-            val absoluteRom = romPath.toAbsolutePath()
-            val process = ProcessBuilder().apply {
-                command(mesenPath.toString(), *MESEN_ARGS.toTypedArray(),
-                        scriptPath.toString(), absoluteRom.toString())
-                directory(mesenDir)
-                redirectError(ProcessBuilder.Redirect.INHERIT)
-                redirectOutput(ProcessBuilder.Redirect.INHERIT)
-            }.start()
-
-            val exitCode = process.waitFor()
-
-            if (exitCode != 0) {
-                throw Mesen2ExecutionException("Mesen2 --testRunner exited with code $exitCode.")
-            }
-
-            // Read the state JSON - Lua script tries session folder and mesen_dir
-            val possiblePaths = listOf(
-                guessScriptDataFolder().resolve("state.json"),
-                mesenPath.parent.resolve("mesen_state.json"),
-                Paths.get("test_state.json")
-            )
-            val stateJsonPath = possiblePaths.firstOrNull { Files.exists(it) }
-                ?: throw Mesen2ScreenshotException(
-                    "Mesen2 script ran but state not found. Tried: ${possiblePaths.joinToString { it.toString() }}"
-                )
-            val json = Files.readString(stateJsonPath)
-            return parseMesen2State(json, romPath.fileName.toString(), frameNumber)
-        } finally {
-            // Cleanup temp script directory
-            scriptPath.toFile().delete()
-            runDir.toFile().deleteRecursively()
-        }
-    }
-
-    private fun generateCaptureScript(targetFrame: Int): String {
-        // --testRunner mode. Mesen2 v2 returns getState() as a FLAT table with
-        // dotted string keys: state["cpu.pc"], state["ppu.frameCount"], etc.
-        // NOT state.cpu.pc (that throws nil-index). Confirmed by Phase 0 spike
-        // 2026-05-20 in docs/TESTING_STRATEGY.md.
-        // getScriptDataFolder() has no trailing separator — insert "/".
-        val luaScript = """
-local targetFrame = $targetFrame
-local frame = 0
-
--- Interrupt counters, reset at every endFrame, so at capture time they hold the
--- number of NMI/IRQ dispatches during the FINAL FULL FRAME. emu.eventType.irq
--- fires for mapper IRQs too (verified on v2.1.1) and is reliable for counting.
-local nmiThisFrame = 0
-local irqThisFrame = 0
-
-local function onNmi()
-    nmiThisFrame = nmiThisFrame + 1
-end
-
-local function onIrq()
-    irqThisFrame = irqThisFrame + 1
-end
-
-local function writeState()
-    local s = emu.getState()
-
-    local function n(k) return s[k] or 0 end
-    -- Boolean flag -> 0/1. (Lua treats 0 as truthy, so this is only safe for genuine booleans.)
-    local function b(k) if s[k] then return 1 else return 0 end end
-    -- Numeric "address" flag (e.g. patternAddr is 0 or 0x1000) -> 0/1.
-    local function nz(k) local v = s[k]; if type(v) == "number" and v ~= 0 then return 1 else return 0 end end
-
-    -- Mesen2 stores PPUCTRL/MASK/STATUS decomposed; rebuild the raw register bytes
-    -- so they line up with Nestlin's raw $2000/$2001/$2002 snapshot. Base-nametable
-    -- bits live in the t register, not in the decomposed control struct.
-    local control = b("ppu.control.nmiOnVerticalBlank") * 128
-        + b("ppu.control.largeSprites") * 32
-        + nz("ppu.control.backgroundPatternAddr") * 16
-        + nz("ppu.control.spritePatternAddr") * 8
-        + b("ppu.control.verticalWrite") * 4
-        + (math.floor(n("ppu.tmpVideoRamAddr") / 1024) % 4)
-    local mask = b("ppu.mask.grayscale")
-        + b("ppu.mask.backgroundMask") * 2
-        + b("ppu.mask.spriteMask") * 4
-        + b("ppu.mask.backgroundEnabled") * 8
-        + b("ppu.mask.spritesEnabled") * 16
-        + b("ppu.mask.intensifyRed") * 32
-        + b("ppu.mask.intensifyGreen") * 64
-        + b("ppu.mask.intensifyBlue") * 128
-    local ppuStatus = b("ppu.statusFlags.spriteOverflow") * 32
-        + b("ppu.statusFlags.sprite0Hit") * 64
-        + b("ppu.statusFlags.verticalBlank") * 128
-
-    -- Arrays in the {idx:val,...} shape the Kotlin parseIntArray() expects.
-    local function dumpMem(memType, size)
-        local parts = {}
-        for i = 0, size - 1 do parts[#parts + 1] = i .. ":" .. emu.read(i, memType) end
-        return "{" .. table.concat(parts, ",") .. "}"
-    end
-    local function dumpPalette()
-        local parts = {}
-        for i = 0, 31 do parts[#parts + 1] = i .. ":" .. n("ppu.paletteRam" .. i) end
-        return "{" .. table.concat(parts, ",") .. "}"
-    end
-
-    local json = "{" ..
-        "\"pc\":" .. n("cpu.pc") .. "," ..
-        "\"a\":" .. n("cpu.a") .. "," ..
-        "\"x\":" .. n("cpu.x") .. "," ..
-        "\"y\":" .. n("cpu.y") .. "," ..
-        "\"sp\":" .. n("cpu.sp") .. "," ..
-        "\"status\":" .. n("cpu.ps") .. "," ..
-        "\"cycleCount\":" .. n("cpu.cycleCount") .. "," ..
-        "\"scanline\":" .. n("ppu.scanline") .. "," ..
-        "\"ppuCycle\":" .. n("ppu.cycle") .. "," ..
-        "\"ppuFrameCount\":" .. n("ppu.frameCount") .. "," ..
-        "\"control\":" .. control .. "," ..
-        "\"mask\":" .. mask .. "," ..
-        "\"ppuStatus\":" .. ppuStatus .. "," ..
-        "\"nmiCountLastFrame\":" .. nmiThisFrame .. "," ..
-        "\"irqCountLastFrame\":" .. irqThisFrame .. "," ..
-        "\"cpuRam\":" .. dumpMem(emu.memType.nesInternalRam, 2048) .. "," ..
-        "\"oam\":" .. dumpMem(emu.memType.nesSpriteRam, 256) .. "," ..
-        "\"chr\":" .. dumpMem(emu.memType.nesPpuMemory, 8192) .. "," ..
-        "\"paletteRam\":" .. dumpPalette() ..
-    "}"
-
-    local fullPath = emu.getScriptDataFolder() .. "/state.json"
-    local f = io.open(fullPath, "w")
-    if f then f:write(json); f:close() end
-end
-
-function onEndFrame()
-    frame = frame + 1
-    if frame == targetFrame then
-        -- nmiThisFrame/irqThisFrame still hold the counts since the PREVIOUS
-        -- endFrame, i.e. the dispatches during the last full frame.
-        local ok, err = pcall(writeState)
-        if not ok then
-            print("state capture error: " .. tostring(err))
-            emu.stop(2)
-        else
-            emu.stop(0)
-        end
-    end
-    -- Reset per-frame interrupt counters for the next frame window.
-    nmiThisFrame = 0
-    irqThisFrame = 0
-end
-
-emu.addEventCallback(onNmi, emu.eventType.nmi)
-emu.addEventCallback(onIrq, emu.eventType.irq)
-emu.addEventCallback(onEndFrame, emu.eventType.endFrame)
-""".trimIndent()
-        return luaScript
-    }
-
-    private fun guessScriptDataFolder(): Path {
-        val mesenPath = getMesen2Path()
-        // Mesen2 creates a session folder: <mesen_dir>/LuaScriptData/<script_name>/
-        // where <script_name> is derived from the script filename
-        return mesenPath.parent.resolve("LuaScriptData").resolve("state_capture")
-    }
-
-    private fun parseMesen2State(json: String, romName: String, frameNumber: Int): EmulatorStateSnapshot {
-        // Parse JSON manually since we don't want to add another dependency
-        // Use simple regex-based parsing for the specific structure we expect
-        return EmulatorStateSnapshot(
-            emulator = "Mesen2",
-            romName = romName,
-            frameNumber = frameNumber,
-            cpu = parseCpuState(json),
-            ppu = parsePpuState(json),
-            cpuRam = parseIntArray(json, "cpuRam", 0x800),
-            ppuRegisters = parsePpuRegisters(json),
-            oam = parseIntArray(json, "oam", 256),
-            paletteRam = parseIntArray(json, "paletteRam", 32),
-            timestamp = System.currentTimeMillis(),
-            chr = parseIntArray(json, "chr", 8192),
-            nmiCountLastFrame = parseIntOrDefault(json, "nmiCountLastFrame", -1),
-            irqCountLastFrame = parseIntOrDefault(json, "irqCountLastFrame", -1)
-        )
-    }
-
-    private fun parseIntOrDefault(json: String, key: String, default: Int): Int {
-        val match = Regex("\"$key\":(-?\\d+)").find(json) ?: return default
-        return match.groupValues[1].toIntOrNull() ?: default
-    }
-
-    private data class Mesen2CartState(
-        val selectedChrPages: IntArray?,
-        val selectedPrgPages: IntArray?,
-        val prgRomSize: Int,
-        val chrRomSize: Int
-    )
-
-    private fun parseCartState(json: String): Mesen2CartState {
-        val chrPages = parseIntArrayFromTable(json, "selectedChrPages", 8)
-        val prgPages = parseIntArrayFromTable(json, "selectedPrgPages", 4)
-        val prgSize = parseInt(json, "prgRomSize")
-        val chrSize = parseInt(json, "chrRomSize")
-        return Mesen2CartState(chrPages, prgPages, prgSize, chrSize)
-    }
-
-    private fun parseIntArrayFromTable(json: String, key: String, size: Int): IntArray? {
-        // Look for "key":{n0:v0,n1:v1,...}
-        val pattern = "\"$key\":\\{([0-9:,]*)\\}"
-        val regex = Regex(pattern)
-        val match = regex.find(json) ?: return null
-        val arr = IntArray(size)
-        val content = match.groupValues[1]
-        val pairs = content.split(",")
-        for (pair in pairs) {
-            if (pair.contains(":")) {
-                val parts = pair.split(":")
-                val idx = parts[0].toIntOrNull() ?: continue
-                val value = parts[1].toIntOrNull() ?: continue
-                if (idx in 0 until size) arr[idx] = value
-            }
-        }
-        return arr
-    }
-
-    private fun parseCpuState(json: String): CpuState {
-        return CpuState(
-            pc = parseInt(json, "pc"),
-            a = parseInt(json, "a"),
-            x = parseInt(json, "x"),
-            y = parseInt(json, "y"),
-            sp = parseInt(json, "sp"),
-            status = parseInt(json, "status"),
-            cycleCount = parseLong(json, "cycleCount")
-        )
-    }
-
-    private fun parsePpuState(json: String): PpuState {
-        return PpuState(
-            cycle = parseInt(json, "ppuCycle"),
-            scanline = parseInt(json, "scanline"),
-            frameCount = parseInt(json, "ppuFrameCount"),
-            control = parseInt(json, "control"),
-            mask = parseInt(json, "mask"),
-            status = parseInt(json, "ppuStatus"),
-            vRamAddress = 0
-        )
-    }
-
-    private fun parsePpuRegisters(json: String): PpuRegisters {
-        return PpuRegisters(
-            controller = parseInt(json, "control"),
-            mask = parseInt(json, "mask"),
-            status = parseInt(json, "ppuStatus"),
-            oamAddress = 0,
-            oamData = 0,
-            scroll = 0,
-            address = 0,
-            data = 0
-        )
-    }
-
-    private fun parseIntArray(json: String, key: String, size: Int): IntArray {
-        val arr = IntArray(size)
-        val pattern = "\"$key\":\\{([0-9:,]*)\\}"
-        val regex = Regex(pattern)
-        val match = regex.find(json)
-        if (match != null) {
-            val values = match.groupValues[1].split(",")
-            for (i in values.indices) {
-                if (i < size && values[i].contains(":")) {
-                    val parts = values[i].split(":")
-                    val idx = parts[0].toInt()
-                    val value = parts[1].toInt()
-                    if (idx in 0 until size) {
-                        arr[idx] = value
-                    }
-                }
-            }
-        }
-        return arr
-    }
-
-    private fun parseInt(json: String, key: String): Int {
-        // Simple regex to find "key":value within the cpu or ppu section
-        val pattern = "\"$key\":(-?\\d+)"
-        val regex = Regex(pattern)
-        val match = regex.find(json)
-        return match?.groupValues?.get(1)?.toIntOrNull() ?: 0
-    }
-
-    private fun parseLong(json: String, key: String): Long {
-        val pattern = "\"$key\":(-?\\d+)"
-        val regex = Regex(pattern)
-        val match = regex.find(json)
-        return match?.groupValues?.get(1)?.toLongOrNull() ?: 0L
-    }
+    /**
+     * Capture state at [frameNumber] for [romPath]. Signature unchanged
+     * from the legacy implementation — all existing test call sites
+     * (`StateComparisonTest`, `GxRomStateComparisonTest`,
+     * `MicroMachinesMapper71StateComparisonTest`, every Mapper*RegressionTest
+     * via `MapperRegressionTestBase`, etc.) keep working unmodified.
+     */
+    fun captureState(romPath: Path, frameNumber: Int): EmulatorStateSnapshot =
+        Mesen2Session.forRom(romPath).runToAndCaptureState(frameNumber)
 }

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2StateJsonParser.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2StateJsonParser.kt
@@ -1,0 +1,117 @@
+package com.github.alondero.nestlin.compare
+
+/**
+ * Regex-based JSON parser for the structured state dumps written by the
+ * Lua script in [Mesen2StateCapturer] (and the long-running server script
+ * in [Mesen2ProcessInstance]).
+ *
+ * The Phase 0 spike settled on flat-keyed JSON in the `{idx:val,...}` shape
+ * for arrays (no nesting) because Lua's `io.write` of nested structures is
+ * brittle. The trade-off is regex parsing in Kotlin — see
+ * `docs/TESTING_STRATEGY.md:197-203` for why a real Lua JSON library is a
+ * Phase 3 follow-up, not this one.
+ *
+ * This class is intentionally not an `object` singleton — it's a stateless
+ * namespace of static functions. Tests that need to validate the raw JSON
+ * format can call these directly.
+ *
+ * Why extract this from [Mesen2StateCapturer]? So [Mesen2ProcessInstance]
+ * (the new long-running Mesen2 wrapper for issue #61) can parse the JSON
+ * produced by its Lua server script without having to instantiate the old
+ * per-test state capturer.
+ */
+internal object Mesen2StateJsonParser {
+
+    /**
+     * Build a full [EmulatorStateSnapshot] from the JSON dump emitted by
+     * the Lua server script. Field semantics match the legacy capturer:
+     *
+     * - PPUCTRL/MASK/STATUS are already rebuilt by Lua from decomposed
+     *   `getState()` booleans (see `Mesen2StateCapturer.kt:96-124`).
+     * - The `nmiCountLastFrame`/`irqCountLastFrame` fields count dispatches
+     *   during the just-completed frame N. (Lua resets these counters
+     *   AFTER capture so the next capture's count is for its own frame.)
+     */
+    fun parseMesen2State(json: String, romName: String, frameNumber: Int): EmulatorStateSnapshot {
+        return EmulatorStateSnapshot(
+            emulator = "Mesen2",
+            romName = romName,
+            frameNumber = frameNumber,
+            cpu = parseCpuState(json),
+            ppu = parsePpuState(json),
+            cpuRam = parseIntArray(json, "cpuRam", 0x800),
+            ppuRegisters = parsePpuRegisters(json),
+            oam = parseIntArray(json, "oam", 256),
+            paletteRam = parseIntArray(json, "paletteRam", 32),
+            timestamp = System.currentTimeMillis(),
+            chr = parseIntArray(json, "chr", 8192),
+            nmiCountLastFrame = parseIntOrDefault(json, "nmiCountLastFrame", -1),
+            irqCountLastFrame = parseIntOrDefault(json, "irqCountLastFrame", -1)
+        )
+    }
+
+    fun parseIntOrDefault(json: String, key: String, default: Int): Int {
+        val match = Regex("\"$key\":(-?\\d+)").find(json) ?: return default
+        return match.groupValues[1].toIntOrNull() ?: default
+    }
+
+    fun parseInt(json: String, key: String): Int {
+        val match = Regex("\"$key\":(-?\\d+)").find(json)
+        return match?.groupValues?.get(1)?.toIntOrNull() ?: 0
+    }
+
+    fun parseLong(json: String, key: String): Long {
+        val match = Regex("\"$key\":(-?\\d+)").find(json)
+        return match?.groupValues?.get(1)?.toLongOrNull() ?: 0L
+    }
+
+    /**
+     * Parses a `"{idx:val,idx:val,...}"` array into an IntArray of size [size].
+     * Missing indices default to 0. Used for `cpuRam`, `oam`, `chr`, `paletteRam`.
+     */
+    fun parseIntArray(json: String, key: String, size: Int): IntArray {
+        val arr = IntArray(size)
+        val pattern = "\"$key\":\\{([0-9:,]*)\\}"
+        val match = Regex(pattern).find(json) ?: return arr
+        val pairs = match.groupValues[1].split(",")
+        for (pair in pairs) {
+            if (!pair.contains(":")) continue
+            val parts = pair.split(":")
+            val idx = parts[0].toIntOrNull() ?: continue
+            val value = parts[1].toIntOrNull() ?: continue
+            if (idx in 0 until size) arr[idx] = value
+        }
+        return arr
+    }
+
+    private fun parseCpuState(json: String): CpuState = CpuState(
+        pc = parseInt(json, "pc"),
+        a = parseInt(json, "a"),
+        x = parseInt(json, "x"),
+        y = parseInt(json, "y"),
+        sp = parseInt(json, "sp"),
+        status = parseInt(json, "status"),
+        cycleCount = parseLong(json, "cycleCount")
+    )
+
+    private fun parsePpuState(json: String): PpuState = PpuState(
+        cycle = parseInt(json, "ppuCycle"),
+        scanline = parseInt(json, "scanline"),
+        frameCount = parseInt(json, "ppuFrameCount"),
+        control = parseInt(json, "control"),
+        mask = parseInt(json, "mask"),
+        status = parseInt(json, "ppuStatus"),
+        vRamAddress = 0
+    )
+
+    private fun parsePpuRegisters(json: String): PpuRegisters = PpuRegisters(
+        controller = parseInt(json, "control"),
+        mask = parseInt(json, "mask"),
+        status = parseInt(json, "ppuStatus"),
+        oamAddress = 0,
+        oamData = 0,
+        scroll = 0,
+        address = 0,
+        data = 0
+    )
+}


### PR DESCRIPTION
Closes #61

## What this PR delivers

Per-ROM long-running Mesen2 process pool within the test JVM. The cross-emulator test suite previously spawned a fresh Mesen2 subprocess per capture (~30 boots per suite = 15–30s of subprocess overhead). This collapses to one process per unique ROM (lazy-initialised), shared across all tests that want state from that ROM.

## Architecture

- **`Mesen2Session`** (singleton `object`): `ConcurrentHashMap<Path, Mesen2ProcessInstance>` keyed by absolute ROM path, JVM shutdown hook calls `closeAll()`. Canonical `mesen2Path()` / `isAvailable()` — `Mesen2Process`, `Mesen2StateCapturer`, and `Mesen2ReferenceRunner` now all delegate here (fixes the latent `tools/Mesen` vs `tools/Mesen2` disagreement noted in the issue description).
- **`Mesen2ProcessInstance`** (per ROM): wraps one long-running `Mesen.exe --testRunner` with an embedded Lua server script that polls a command file on every `endFrame`. Sequence-numbered done markers prevent stale-result races; atomic-rename mailbox (`Files.writeString(tmp) → Files.move(ATOMIC_MOVE, REPLACE_EXISTING)`) prevents the concurrent send/recv race; `ReentrantLock` serialises commands (defensive against JUnit 5 parallel execution). `RESET` between captures gives identical semantics to the per-test-process model (Klax 30/60/240 = one process, not three).
- **`Mesen2StateJsonParser`** (extracted): regex-based JSON parsers for the structured state dump. The Lua emitter lives in `Mesen2ProcessInstance.serverScript()`; both must change together if the schema evolves.

## Why per-ROM (not per-suite)

`emu.loadRom(path)` does **not exist** in Mesen2 v2.1.1 (verified against the upstream `LuaDocumentation.json`). The only way to change the running ROM is exit + relaunch. The strategy doc's Phase 2 sketch of a single Mesen2 Lua server accepting `load <rom>` is infeasible without source-modifying Mesen2.

## Mesen2 v2.1.1 Lua parser quirks (verified 2026-06-30)

These cost hours to bisect — documented here and in the new `mesen2-session-pool-issue-61-2026-06-30` memory entry so future sessions don't repeat:

1. **Backslash escapes in strings are fatal parse errors.** `\U`, `\A`, etc. fail the whole script. Standard Lua 5.1 keeps them as literal characters; Mesen2's embedded Lua doesn't. Use forward slashes in Lua strings.
2. **Single-line `local function name() if/then/else end` is rejected.** Multi-line form works. Mesen2 silently fails to load on the single-line form (no error message).
3. **`emu.reset()` synchronously fires `onReset`.** If `onReset` clears `pending`, a `RUNTO` handler that does `emu.reset(); pending = {...}` will see pending cleared by `onReset` before the next `endFrame` matches. The fix: `onReset` only clears interrupt counters, the `RUNTO` handler resets `frame` and `pending` itself.

## Files

**New:**
- `src/test/kotlin/.../compare/Mesen2Session.kt` (135 lines)
- `src/test/kotlin/.../compare/Mesen2ProcessInstance.kt` (414 lines — mostly the embedded Lua script)
- `src/test/kotlin/.../compare/Mesen2StateJsonParser.kt` (117 lines)
- `src/test/kotlin/.../compare/Mesen2SessionSmokeTest.kt` (55 lines, `@RequiresMesen2`)

**Modified (signature-preserving wrappers):**
- `Mesen2StateCapturer.kt`: `captureState` is now a 1-line delegate
- `Mesen2ReferenceRunner.kt`: `captureFrame` is now a 1-line delegate
- `Mesen2Process.kt`: `mesen2Path()` delegates to `Mesen2Session.mesen2Path()`

**Unchanged** (consume the new API transparently): all `compare/*` test files + `gamepak/Mapper64KlaxMesen2ScreenshotTest.kt` + `gamepak/Mapper16RealGameBootTest.kt`.

## Acceptance criteria

- [x] `Mesen2Session` lifecycle: lazy per-ROM pool, JVM shutdown hook calls `closeAll`
- [x] All existing cross-emulator tests migrated via thin-delegate wrappers (signature-preserving)
- [⚠] Suite wall time under 60s: full `testMesenComparison` lane is ~93s on this machine. `MicroMachinesDivergenceSweepTest` (13-frame sweep, 36s) + `MicroMachinesAttractHangTest` (600-frame Nestlin soak, 13s) together account for ~50s of pre-existing slow-investigation work. Excluding those two, the remaining 39 tests run in ~45s.
- [x] No regression in test reliability. `@RequiresMesen2` lane-gate preserved, `assumeTrue(mesen2Available, ...)` patterns in test bodies unchanged.

## Code review

Reviewed at medium effort before push. Applied fixes:
- `*.kt` line endings corrected to CRLF (matches `.gitattributes:34`, Issue #112)
- `Mesen2SessionSmokeTest` now uses `@RequiresMesen2` instead of bare `assumeTrue` (honours strict-mode)
- Dead `ENV_VAR` / `SYS_PROP` constants removed from `Mesen2Process.kt`
- Dead `outpath` parameter removed from Lua `writeState()`
- `AtomicMoveNotSupportedException` fallback added to the atomic-rename mailbox (CI cross-volume safety)

Follow-up items captured separately: dead-instance eviction, per-ROM script-data dir for future JUnit parallel lanes, Lua `io.open` failure surfacing, `Mesen2OamDumpRunner.mesen2Path()` unification.