### PR TITLE
GH #195: Remove orphaned Memory.apuAddressedMemory store

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/Memory.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Memory.kt
@@ -3,7 +3,6 @@ package com.github.alondero.nestlin
 import com.github.alondero.nestlin.gamepak.GamePak
 import com.github.alondero.nestlin.gamepak.Mapper
 import com.github.alondero.nestlin.ppu.PpuAddressedMemory
-import com.github.alondero.nestlin.apu.ApuAddressedMemory
 import com.github.alondero.nestlin.apu.DmaPort
 import java.io.DataInput
 import java.io.DataOutput
@@ -11,7 +10,6 @@ import java.io.DataOutput
 class Memory : DmaPort {
     private val internalRam = ByteArray(0x800)
     val ppuAddressedMemory = PpuAddressedMemory()
-    val apuAddressedMemory = ApuAddressedMemory()
 
     val controller1 = Controller()
     val controller2 = Controller()
@@ -158,10 +156,7 @@ class Memory : DmaPort {
                 // downstream symptom.
                 cpu?.workCyclesLeft = 513
             }
-            in 0x4000..0x401F -> {
-                apuAddressedMemory[address - 0x4000] = value
-                apu.handleRegisterWrite(address - 0x4000, value)
-            }
+            in 0x4000..0x401F -> apu.handleRegisterWrite(address - 0x4000, value)
             in 0x4020..0xFFFF -> {
                 mapper?.cpuWrite(address, value)
                 mapper?.let { applyMirroringFromMapper(it) }  // sync mirroring after each write
@@ -271,9 +266,17 @@ class Memory : DmaPort {
         return (addr2 + addr1).toSignedShort()
     }
 
+    /**
+     * Wipe CPU RAM and PPU addressable memory to a post-RESET state. The APU's
+     * `$4000-$401F` register file is **not** touched here — [Apu] owns its own
+     * private register store ([Apu.apuMemory]) and resets it via its own
+     * lifecycle (load-state + per-frame work). A previous version of this
+     * method also reset a now-removed Memory-side mirror of the APU registers
+     * (issue #195); that mirror was an orphan from the pre-#22 nullable-`apu`
+     * design and had no readers, so it was deleted.
+     */
     fun clear() {
         internalRam.fill(0xFF.toSignedByte())
-        apuAddressedMemory.reset()
         ppuAddressedMemory.reset()
     }
 

--- a/src/test/kotlin/com/github/alondero/nestlin/apu/AudioPipelineTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/apu/AudioPipelineTest.kt
@@ -107,16 +107,18 @@ class AudioPipelineTest {
 
     @Test
     fun `write to 4000 through Memory actually configures the APU pulse channel`() {
-        // Regression for issue #22: pre-factory, `Memory` had a nullable Apu and
-        // `apu?.handleRegisterWrite(...)` was a silent no-op when unwired, so a
-        // test that built `Memory()` + `Apu(memory)` WITHOUT setting `memory.apu = apu`
-        // (or the AudioPipelineTest pre-#22) wrote to `$4000` and saw the byte land
-        // in `Memory.apuAddressedMemory`, but the pulse channel driver never ran
-        // and `getAudioSamples()` returned all-zero buffers. Now the factory always
-        // wires the pair, so writing `$4000` through Memory MUST configure pulse1
-        // and the channel output MUST go non-zero. If anyone re-introduces a
-        // nullable Apu field (or accidentally restores `apu?.`), this test fails
-        // fast with a zero-output assertion.
+        // Regression for issue #22: pre-factory, `Memory` had a nullable Apu
+        // and `apu?.handleRegisterWrite(...)` was a silent no-op when unwired.
+        // A test that built `Memory()` + `Apu(memory)` WITHOUT setting
+        // `memory.apu = apu` wrote to `$4000`, saw the byte land in a
+        // Memory-side mirror of the APU register file, but the pulse channel
+        // driver never ran and `getAudioSamples()` returned all-zero buffers.
+        // The factory now always wires the pair, so writing `$4000` through
+        // Memory MUST configure pulse1 and the channel output MUST go non-zero.
+        // If anyone re-introduces a nullable Apu field (or accidentally
+        // restores `apu?.`), this test fails fast with a zero-output
+        // assertion. (Issue #195 later removed that redundant Memory-side
+        // mirror; the regression story stands regardless.)
         val (memory, apu) = Memory.createWithApu()
 
         // Enable pulse1 BEFORE the $4003 write so the length counter actually loads.


### PR DESCRIPTION
## Summary

Removes the dead `Memory.apuAddressedMemory` store left over from the pre-#22 nullable-`apu` design. After #22 the store had no readers — every `$4000-$401F` read goes through `Apu.handleRegisterRead` / `Apu.peekRegisterRead`, which read from `Apu.apuMemory` (the canonical store).

### Changes

- **Memory.kt**
  - Delete the unused `apuAddressedMemory` field and its `import` (lines 6, 14).
  - Drop the redundant write in the `$4000-$401F` `set` arm (line 162) — the next line `apu.handleRegisterWrite(...)` already covers it.
  - Drop the redundant `apuAddressedMemory.reset()` from `clear()` and add a KDoc explaining the new semantics: `clear()` only wipes CPU RAM + PPU addressable memory; the APU's `$4000-$401F` register file is owned by `Apu` and reset via its own lifecycle.
- **AudioPipelineTest.kt**
  - Update the historical comment on the "write to 4000 through Memory actually configures the APU pulse channel" test so it no longer names the removed field. The regression story (pre-#22 failure mode → post-#22 guarantee) is preserved; a one-line breadcrumb notes that #195 cleaned up the redundant mirror.

### Verification

- `./gradlew test` — all suites pass, 0 failures, 0 errors. `AudioPipelineTest` 6/6 (the test whose comment changed still passes).
- `./gradlew bootcheck -Prom=X:/src/nestlin/testroms/kirby.nes -Pframes=120` — **BOOTCHECK VERDICT: PASS** (8 distinct PRG states, 118 NMIs over 120 frames, IRQ count 0). Behaviour is observably a no-op because `Apu.apuMemory` is the canonical store; the deleted `Memory` mirror was just dead writes.

### Risk

Low. The only callers of `Memory.clear()` do not depend on it wiping the APU register file (grep confirms no such caller). Game-behaviour parity verified via `bootcheck`.

Closes #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
