### PR TITLE
GH #214: Mesen2Session pool resilience, parallel safety, Lua error surfacing

### DIFF
--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2OamDumpRunner.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2OamDumpRunner.kt
@@ -2,23 +2,25 @@ package com.github.alondero.nestlin.compare
 
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
 
 /**
  * Drives Mesen2 in GUI mode to dump OAM at a list of frames so we can
  * compare against Nestlin OAM byte-for-byte.
  *
- * Defaults to MESEN2_PATH env var, falls back to tools/Mesen2/Mesen.exe.
- * (NOT tools/Mesen — that is Mesen v1 and has no Lua support.)
+ * Path resolution delegates to [Mesen2Session.mesen2Path] (see [mesen2Path]),
+ * so this runner uses the same canonical chain as the rest of the compare lane.
  */
 object Mesen2OamDumpRunner {
     private val MESEN_ARGS = listOf("--testRunner", "--doNotSaveSettings")
 
-    fun mesen2Path(): Path {
-        val env = System.getenv("MESEN2_PATH")
-        if (env != null) return Paths.get(env)
-        return Paths.get("tools/Mesen2/Mesen.exe")
-    }
+    /**
+     * Delegates to [Mesen2Session.mesen2Path] so this runner honours the same
+     * canonical resolution chain (`MESEN2_PATH` env → `mesen2.path` property →
+     * absolute parent path → relative fallback) as the rest of the lane. It
+     * previously had its own env-only lookup, which made [isAvailable]'s
+     * skip-not-fail semantics subtly inconsistent (issue #214 fix 4).
+     */
+    fun mesen2Path(): Path = Mesen2Session.mesen2Path()
 
     fun isAvailable(): Boolean = mesen2Path().toFile().exists()
 

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2ProcessInstance.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2ProcessInstance.kt
@@ -54,11 +54,20 @@ class Mesen2ProcessInstance internal constructor(
     private val cmdFile: Path = sessionDir.resolve("cmd.txt")
     private val cmdTmpFile: Path = sessionDir.resolve("cmd.txt.tmp")
     private val doneFile: Path = sessionDir.resolve("done.txt")
+    // Mesen2's stderr (Lua parse/runtime errors) is redirected here so a hung
+    // boot can surface the actual cause in the exception, not just a timeout
+    // message pointing nowhere (issue #214 fix 5).
+    private val stderrFile: Path = sessionDir.resolve("mesen_stderr.log")
 
-    // Mesen2 script data folder is <mesen_dir>/LuaScriptData/<script_basename>/
-    // The script is named `session_server.lua`, so basename is `session_server`.
+    // Mesen2 names its per-script data folder <mesen_dir>/LuaScriptData/<script_basename>/,
+    // where <script_basename> is the Lua file's name without extension. Both the
+    // script filename and this dir are parameterised by ROM basename so two
+    // concurrent instances for different ROMs never clobber each other's
+    // state.json (issue #214 fix 2).
+    private val scriptBaseName: String = scriptBaseName(rom)
+    private val scriptFileName: String = "$scriptBaseName.lua"
     private val scriptDataDir: Path = Mesen2Session.mesen2Path().parent
-        .resolve("LuaScriptData").resolve("session_server")
+        .resolve("LuaScriptData").resolve(scriptBaseName)
     private val stateJsonPath: Path = scriptDataDir.resolve("state.json")
 
     private val process: Process
@@ -68,18 +77,21 @@ class Mesen2ProcessInstance internal constructor(
 
     init {
         val mesen = Mesen2Session.mesen2Path()
-        Files.writeString(sessionDir.resolve("session_server.lua"), serverScript())
+        Files.writeString(sessionDir.resolve(scriptFileName), serverScript())
 
         val absoluteRom = rom.toAbsolutePath()
         process = ProcessBuilder(
             mesen.toString(),
             "--testRunner",
             "--doNotSaveSettings",
-            sessionDir.resolve("session_server.lua").toAbsolutePath().toString(),
+            sessionDir.resolve(scriptFileName).toAbsolutePath().toString(),
             absoluteRom.toString()
         ).apply {
             directory(mesen.parent.toFile())
-            redirectError(ProcessBuilder.Redirect.INHERIT)
+            // Capture stderr to a file (not INHERIT) so waitForMarker can quote
+            // the last few lines — a Lua parse error would otherwise vanish into
+            // the console and leave only a bare timeout message (issue #214 fix 5).
+            redirectError(ProcessBuilder.Redirect.to(stderrFile.toFile()))
             redirectOutput(ProcessBuilder.Redirect.INHERIT)
         }.start()
 
@@ -124,16 +136,34 @@ class Mesen2ProcessInstance internal constructor(
     }
 
     /**
-     * Send `QUIT` to Lua, wait up to 5s for the process to exit, then
-     * `destroyForcibly()` if it didn't. Idempotent.
+     * True while the underlying process is still running and [close] has not
+     * been called. [Mesen2Session.forRom] uses this to evict a dead instance
+     * from the pool and boot a fresh one, restoring the self-healing behaviour
+     * of the old per-capture-boot model (issue #214 fix 1).
      */
-    fun close() {
+    fun isAlive(): Boolean = !closed && process.isAlive
+
+    /**
+     * Shut the instance down. Idempotent.
+     *
+     * When [force] is true (the JVM-shutdown-hook path) the process is killed
+     * immediately with no graceful QUIT — a dozen sessions each waiting on a
+     * QUIT round-trip would blow the shutdown-hook budget and Gradle would
+     * force-terminate the hook anyway (issue #214 fix 6). Explicit `@AfterAll`
+     * callers leave [force] false to give Lua a chance to `emu.stop` cleanly;
+     * the graceful wait is capped at 2s and falls back to a forcible kill.
+     */
+    fun close(force: Boolean = false) {
         lock.withLock {
             if (closed) return
             closed = true
             runCatching {
+                if (force) {
+                    process.destroyForcibly()
+                    return@runCatching
+                }
                 sendCommand("QUIT -1")
-                if (!process.waitFor(5, TimeUnit.SECONDS)) {
+                if (!process.waitFor(2, TimeUnit.SECONDS)) {
                     process.destroyForcibly()
                 }
             }
@@ -146,7 +176,7 @@ class Mesen2ProcessInstance internal constructor(
         if (!process.isAlive) {
             throw Mesen2ExecutionException(
                 "Mesen2 process for $rom died (exit code ${process.exitValue()}). " +
-                "Check test output for the Lua error."
+                "Check test output for the Lua error.${stderrTailSuffix()}"
             )
         }
     }
@@ -179,7 +209,8 @@ class Mesen2ProcessInstance internal constructor(
             if (!process.isAlive) {
                 throw Mesen2ExecutionException(
                     "Mesen2 process for $rom died while waiting for $expectedPrefix " +
-                    "(exit ${process.exitValue()}). Last done.txt contents: $lastSeen"
+                    "(exit ${process.exitValue()}). Last done.txt contents: $lastSeen" +
+                    stderrTailSuffix()
                 )
             }
             if (Files.exists(doneFile)) {
@@ -196,8 +227,24 @@ class Mesen2ProcessInstance internal constructor(
         }
         throw Mesen2ExecutionException(
             "Mesen2 timed out waiting for $expectedPrefix on $rom after ${timeoutMs}ms. " +
-            "Last done.txt contents: ${if (lastSeen.isEmpty()) "<none>" else lastSeen}"
+            "Last done.txt contents: ${if (lastSeen.isEmpty()) "<none>" else lastSeen}" +
+            stderrTailSuffix()
         )
+    }
+
+    /**
+     * The last few lines of Mesen2's stderr, formatted for appending to an
+     * exception message. Empty string when stderr is empty or unreadable — a
+     * Lua *parse* error lands here (Mesen2 prints it and exits), which is
+     * exactly the case a bare "timed out waiting for READY" hid before
+     * (issue #214 fix 5).
+     */
+    private fun stderrTailSuffix(maxLines: Int = 8): String {
+        val lines = runCatching { Files.readAllLines(stderrFile) }.getOrDefault(emptyList())
+            .filter { it.isNotBlank() }
+        if (lines.isEmpty()) return ""
+        return "\nMesen2 stderr (last ${minOf(maxLines, lines.size)} lines):\n" +
+            lines.takeLast(maxLines).joinToString("\n")
     }
 
     private fun matchesMarker(seen: String, expectedSeq: Long, expectedPrefix: String): Boolean {
@@ -321,7 +368,9 @@ local function writeState()
 
     local fullPath = emu.getScriptDataFolder() .. "/state.json"
     local f = io.open(fullPath, "w")
-    if f then f:write(json); f:close() end
+    if not f then error("could not open " .. fullPath .. " for write") end
+    f:write(json)
+    f:close()
 end
 
 local function writeScreenshot(outpath)
@@ -419,5 +468,17 @@ writeMarker("READY")
 """.trimIndent()
             .replace("@@ABS_CMD@@", absCmd)
             .replace("@@ABS_DONE@@", absDone)
+    }
+
+    companion object {
+        /**
+         * Derive the Lua script basename (and thus Mesen2's per-script
+         * `LuaScriptData/<basename>/` folder) from the ROM path. Two concurrent
+         * instances for different ROMs must land in different folders or they
+         * clobber each other's `state.json` (issue #214 fix 2). Non-alphanumeric
+         * characters are collapsed to `_` so the basename is filesystem-safe.
+         */
+        internal fun scriptBaseName(rom: Path): String =
+            "session_server_" + rom.fileName.toString().replace(Regex("[^a-zA-Z0-9]"), "_")
     }
 }

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2Session.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2Session.kt
@@ -61,7 +61,7 @@ object Mesen2Session {
         // and Mesen2 processes get a chance to quit cleanly. `close()` itself
         // forces termination if the QUIT command doesn't return within 5s.
         Runtime.getRuntime().addShutdownHook(Thread {
-            closeAll()
+            closeAll(force = true)
         })
     }
 
@@ -117,19 +117,37 @@ object Mesen2Session {
             throw Mesen2NotFoundException(message)
         }
         val abs = rom.toAbsolutePath()
-        return sessions.computeIfAbsent(abs) { Mesen2ProcessInstance(it) }
+        // Loop so a dead cached instance is evicted and re-booted rather than
+        // handed back forever. Before the per-ROM pool every capture spawned a
+        // fresh process, so a mid-suite crash (native crash, OOM, Lua server
+        // error) was self-healing; restore that here (issue #214 fix 1).
+        // Bounded in practice: each iteration either returns a live instance or
+        // boots a fresh one (a failed boot throws out of computeIfAbsent, which
+        // never caches, so it does not spin).
+        while (true) {
+            val instance = sessions.computeIfAbsent(abs) { Mesen2ProcessInstance(it) }
+            if (instance.isAlive()) return instance
+            // remove(key, value) only evicts if this exact dead instance is
+            // still mapped — a concurrent boot's replacement is left intact.
+            if (sessions.remove(abs, instance)) {
+                runCatching { instance.close(force = true) }
+            }
+        }
     }
 
     /**
      * Tears down all live Mesen2 sessions. Idempotent. Called automatically
-     * on JVM exit via the shutdown hook; safe to invoke manually from
-     * `@AfterAll` lifecycle methods if a test wants eager cleanup.
+     * on JVM exit via the shutdown hook (with [force] = true, so a dozen
+     * sessions don't each burn the graceful-QUIT budget — see
+     * [Mesen2ProcessInstance.close]); safe to invoke manually from `@AfterAll`
+     * lifecycle methods (leaving [force] false) if a test wants eager,
+     * graceful cleanup.
      */
-    fun closeAll() {
+    fun closeAll(force: Boolean = false) {
         val snapshot = sessions.values.toList()
         sessions.clear()
         for (instance in snapshot) {
-            runCatching { instance.close() }
+            runCatching { instance.close(force) }
         }
     }
 }

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2SessionResilienceTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2SessionResilienceTest.kt
@@ -1,0 +1,69 @@
+package com.github.alondero.nestlin.compare
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.startsWith
+import org.junit.jupiter.api.Test
+import java.nio.file.Paths
+
+/**
+ * Pure-unit coverage for the issue #214 Mesen2Session hardening that does NOT
+ * need a Mesen2 binary — the process-level resilience (dead-instance eviction,
+ * Lua error surfacing) is exercised by the `@RequiresMesen2` smoke test; these
+ * cases pin the parts that are just string/path logic so they run in the plain
+ * `test` lane on any CI runner.
+ */
+class Mesen2SessionResilienceTest {
+
+    // --- Fix 2: per-ROM script-data folder ----------------------------------
+
+    @Test
+    fun `scriptBaseName is prefixed and derived from the rom filename`() {
+        val name = Mesen2ProcessInstance.scriptBaseName(Paths.get("testroms/nestest.nes"))
+        assertThat(name, equalTo("session_server_nestest_nes"))
+    }
+
+    @Test
+    fun `scriptBaseName collapses every non-alphanumeric character to underscore`() {
+        // NO-INTRO names are full of spaces, parens and punctuation; none of
+        // them may leak into a filesystem path or two ROMs could still collide.
+        val name = Mesen2ProcessInstance.scriptBaseName(
+            Paths.get("S:/Media/Nintendo NES/Games/Micro Machines (USA) (Unl).nes")
+        )
+        assertThat(name, startsWith("session_server_"))
+        val suffix = name.removePrefix("session_server_")
+        assertThat(suffix, equalTo("Micro_Machines__USA___Unl__nes"))
+        check(suffix.all { it == '_' || it.isLetterOrDigit() }) {
+            "sanitised basename still contains path-unsafe characters: $suffix"
+        }
+    }
+
+    @Test
+    fun `different roms get different script-data folders`() {
+        // The whole point of the fix: two concurrent instances must not share a
+        // state.json under LuaScriptData/.
+        val a = Mesen2ProcessInstance.scriptBaseName(Paths.get("roms/klax.nes"))
+        val b = Mesen2ProcessInstance.scriptBaseName(Paths.get("roms/kirby.nes"))
+        check(a != b) { "klax and kirby collapsed to the same folder: $a" }
+    }
+
+    // --- Fix 4: Oam runner path delegation ----------------------------------
+
+    @Test
+    fun `Mesen2OamDumpRunner delegates path resolution to Mesen2Session`() {
+        // Force the property branch of the canonical resolution chain. If the
+        // OAM runner still had its own env-only lookup it would ignore this and
+        // fall back to the relative default, diverging from the session.
+        val key = "mesen2.path"
+        val previous = System.getProperty(key)
+        try {
+            System.setProperty(key, "Z:/some/where/Mesen.exe")
+            assertThat(
+                Mesen2OamDumpRunner.mesen2Path(),
+                equalTo(Mesen2Session.mesen2Path())
+            )
+        } finally {
+            if (previous == null) System.clearProperty(key) else System.setProperty(key, previous)
+        }
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2SessionSmokeTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mesen2SessionSmokeTest.kt
@@ -57,4 +57,31 @@ class Mesen2SessionSmokeTest {
                 "(${first.ppu.frameCount}) — emulator ran backwards or RESET semantics broke"
         }
     }
+
+    /**
+     * Issue #214 fix 1: a dead cached instance must be evicted and re-booted,
+     * not handed back forever. Before the per-ROM pool, every capture spawned a
+     * fresh process so a mid-suite crash self-healed; this pins that the pool
+     * preserves that property.
+     *
+     * We simulate the crash by force-closing the instance (equivalent to a
+     * native crash: `process.isAlive` goes false), then assert the next
+     * `forRom` returns a *different*, live instance that still captures state.
+     */
+    @Test
+    fun forRomReplacesADeadInstance() {
+        val rom = Paths.get("testroms/nestest.nes")
+
+        val dead = Mesen2Session.forRom(rom)
+        dead.close(force = true)
+        check(!dead.isAlive()) { "instance should be dead after force close" }
+
+        val fresh = Mesen2Session.forRom(rom)
+        check(fresh !== dead) { "forRom handed back the dead instance instead of re-booting" }
+        check(fresh.isAlive()) { "re-booted instance should be alive" }
+
+        // The re-booted instance must actually work, not just exist.
+        val state = fresh.runToAndCaptureState(60)
+        check(state.cpu.pc != 0) { "re-booted instance produced an all-zero snapshot" }
+    }
 }


### PR DESCRIPTION
Follow-ups from the #213 (issue #61) code review. All changes are in the `compare/` test harness — **no production code touched**.

## Fixes (all from issue #214)

1. **Dead-instance eviction** — `Mesen2Session.forRom` evicts and re-boots a dead cached instance instead of re-throwing it forever. A mid-suite Mesen2 crash/OOM used to poison the pool; this restores the self-healing of the old per-capture-boot model. The eviction loop is bounded (a boot that dies before READY throws out of the constructor).
2. **Per-ROM `scriptDataDir`** — Lua script filename and `getScriptDataFolder()` folder are now `session_server_<sanitized-rom>` so two concurrent instances for different ROMs never clobber one shared `state.json`.
3. **Lua `writeState` raises on `io.open` failure** — falls into the existing ERR-marker path instead of returning an all-zero snapshot (which could false-green against Nestlin's zeroed state).
4. **`Mesen2OamDumpRunner.mesen2Path()` delegates** to `Mesen2Session.mesen2Path()` (was env-only) for consistent skip-not-fail semantics.
5. **Boot timeout/death surfaces stderr** — Mesen2 stderr is captured to a per-session file and the last ~8 lines are appended to the exception, so a Lua parse error is visible instead of a bare "timed out waiting for READY".
6. **Fast forcible shutdown** — `close(force)`/`closeAll(force)`; the JVM shutdown hook kills immediately (no per-instance QUIT round-trip), graceful wait reduced 5s → 2s.

## Tests

- New `Mesen2SessionResilienceTest` — pure-unit (no Mesen2 needed): `scriptBaseName` sanitization + `Mesen2OamDumpRunner` path delegation. Runs in the plain `test` lane.
- `forRomReplacesADeadInstance()` added to the `@RequiresMesen2` smoke test — force-closes an instance (simulating a crash) and asserts a fresh, live, working instance is returned.

## Verification

- `./gradlew test` — green (includes the new pure-unit test + the project's lint lane).
- New Mesen2-gated tests (`Mesen2SessionSmokeTest`) — both **PASS** against local Mesen2.
- `testMesenComparison` has 10 pre-existing/environmental failures (6 missing `testroms/{tetris,lolo1,kirby}.nes` not in git; 4 pre-existing mapper-oracle divergences). Verified by stash-and-baseline against `master` that **none are introduced by this change**.

Closes #214