### PR TITLE
GH #209: Wire a working Zapper light gun

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/Memory.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Memory.kt
@@ -31,16 +31,49 @@ class Memory : DmaPort {
      * wrapping [controller1]. Mutable so the Controller Configuration screen
      * can swap the device type at runtime without disturbing the underlying
      * controller's button bitmap or shift-register state.
+     *
+     * `@Volatile`: [setPortType] may run on the JavaFX thread (config-screen save)
+     * while the emulation thread reads this on every `$4016` access, so the swapped
+     * reference must be published safely. The device objects are immutable in their
+     * wiring, so a volatile reference swap is sufficient.
      */
+    @Volatile
     var port1: InputDevice = StandardGamepad(controller1)
         private set
 
     /**
      * The [InputDevice] currently plugged into port 2 (player 2). Defaults to a
-     * [StandardGamepad] wrapping [controller2]. See [port1] for the rationale.
+     * [StandardGamepad] wrapping [controller2]. See [port1] for the rationale
+     * (including why this is `@Volatile`).
      */
+    @Volatile
     var port2: InputDevice = StandardGamepad(controller2)
         private set
+
+    /**
+     * Live input providers for a plugged [com.github.alondero.nestlin.input.Zapper].
+     * [zapperTrigger] returns true while the trigger is held; [zapperLight] returns
+     * true when the aimed-at pixel is bright. Default to "no trigger / dark" so a
+     * headless or test [Memory] constructs a functional (idle) Zapper with no UI
+     * wiring. The UI installs real providers via [setZapperProviders]; because a
+     * plugged Zapper reads these fields through indirection on every poll, a later
+     * install is picked up without re-plugging the port. `@Volatile` so that later
+     * install is visible to the emulation thread.
+     */
+    @Volatile
+    private var zapperTrigger: () -> Boolean = { false }
+    @Volatile
+    private var zapperLight: () -> Boolean = { false }
+
+    /**
+     * Install the [com.github.alondero.nestlin.input.Zapper] input providers. Called
+     * once by the UI at startup; [trigger] maps to mouse-left-held over the focused
+     * window and [light] to a brightness sample of the frame buffer at the cursor.
+     */
+    fun setZapperProviders(trigger: () -> Boolean, light: () -> Boolean) {
+        zapperTrigger = trigger
+        zapperLight = light
+    }
 
     /**
      * What kind of device is in port [index] (0 or 1). Defaults to
@@ -73,7 +106,16 @@ class Memory : DmaPort {
                 1 -> StandardGamepad(controller2)
                 else -> throw IllegalArgumentException("Port index must be 0 or 1, got $index")
             }
-            InputDevice.DeviceType.ZAPPER -> com.github.alondero.nestlin.input.Zapper()
+            // The Zapper forwards to the current [zapperTrigger] / [zapperLight] fields
+            // on every read (not a snapshot at construction), so re-installing providers
+            // via [setZapperProviders] after a Zapper is already plugged is reflected
+            // immediately without re-plugging. isPort2 = true for $4017 (index 1); a
+            // port-1 Zapper reads 0 (see [Zapper]).
+            InputDevice.DeviceType.ZAPPER -> com.github.alondero.nestlin.input.Zapper(
+                triggerProvider = { zapperTrigger() },
+                lightSensor = { zapperLight() },
+                isPort2 = index == 1,
+            )
             InputDevice.DeviceType.NONE -> NoDevice()
         }
         when (index) {

--- a/src/main/kotlin/com/github/alondero/nestlin/input/InputConfig.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/input/InputConfig.kt
@@ -35,13 +35,13 @@ data class InputConfig(
 
         /**
          * Device types the user can actually choose from in the controller configuration
-         * screen. Zapper is reserved in the enum for forward compatibility but not yet
-         * listed here — its semantics are stubbed in [InputDevice] and the working
-         * implementation lands in a future PR.
+         * screen. Zapper is wired end-to-end — trigger on mouse-left, light
+         * sense sampled from the frame buffer at the cursor — so it is offered here.
          */
         val SUPPORTED_DEVICE_TYPES: List<com.github.alondero.nestlin.input.InputDevice.DeviceType> =
             listOf(
                 com.github.alondero.nestlin.input.InputDevice.DeviceType.STANDARD_GAMEPAD,
+                com.github.alondero.nestlin.input.InputDevice.DeviceType.ZAPPER,
                 com.github.alondero.nestlin.input.InputDevice.DeviceType.NONE,
             )
         // The production config location. Tests pass their own @TempDir so the round-trip

--- a/src/main/kotlin/com/github/alondero/nestlin/input/InputDevice.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/input/InputDevice.kt
@@ -139,13 +139,61 @@ abstract class OpenBusOnlyDevice : InputDevice {
 }
 
 /**
- * Zapper light gun — stub. The actual trigger-bit / light-sense semantics
- * (trigger = `$4017` D4; light sense = `$4017` D3; `$4016` reads always return
- * 0 for the zapper bits) are a future PR. For now, reads return the open-bus
- * mask (`0x40`) so a Zapper-plugged port behaves like an empty port from the
- * game's perspective.
+ * NES Zapper light gun. The Zapper does not speak the standard
+ * pad's shift-register protocol; instead each `$4017` read reports two live
+ * signals in the low bits, with the high bits floating to the open-bus mask:
+ *
+ * ```
+ *  $4017 read:  OB OB OB  T   L  0  0  0
+ *               D7 D6 D5  D4  D3 D2 D1 D0
+ * ```
+ *
+ *  - **D4 (trigger, `0x10`):** 1 while the trigger is held, 0 otherwise.
+ *  - **D3 (light sense, `0x08`):** **0 when a bright pixel is detected**, **1 when
+ *    dark**. Note the polarity — a lit target reads the bit as *clear*. This
+ *    matches real hardware (nesdev "Light sensed: 0 detected, 1 not detected")
+ *    and the Mesen2 oracle (`Zapper.h`: `(IsLightFound() ? 0 : 0x08)`). The
+ *    issue #209 prose had this inverted; the hardware-correct polarity is what
+ *    makes Duck Hunt's hit detection work, so we follow the oracle. See
+ *    [ZapperTest] for the four trigger/light truth-table cases.
+ *  - **D2-D0:** always 0 (no serial data on a plain NES Zapper).
+ *
+ * The Zapper is conventionally wired to **port 2** (`$4017`) only. A Zapper
+ * placed on port 1 ([isPort2] = false) reads back 0 — games never expect a
+ * light gun there, and this keeps a mis-configured UI selection inert rather
+ * than feeding a game phantom port-1 light data.
+ *
+ * There is no strobe/latch: [writeStrobe] is a no-op (inherited from
+ * [OpenBusOnlyDevice]) and reads are un-latched samples of the live providers,
+ * so [read] and [peek] are identical — [peek] is safe for the Memory Editor.
+ *
+ * @param triggerProvider returns true while the trigger is held (mouse-left held
+ *   over the focused game window). Defaults to always-released so a
+ *   directly-constructed Zapper (tests, headless) needs no wiring.
+ * @param lightSensor returns true when the pixel currently aimed at is **bright**
+ *   (a lit target). Defaults to always-dark, which is the hardware-correct
+ *   idle reading when the gun points away from any lit sprite.
+ * @param isPort2 whether this Zapper is plugged into port 2 (`$4017`). Defaults
+ *   to true; [Memory.setPortType] passes `index == 1`.
  */
-class Zapper : OpenBusOnlyDevice()
+class Zapper(
+    private val triggerProvider: () -> Boolean = { false },
+    private val lightSensor: () -> Boolean = { false },
+    private val isPort2: Boolean = true,
+) : OpenBusOnlyDevice() {
+
+    override fun read(): Byte = if (isPort2) {
+        val trigger = if (triggerProvider()) 0x10 else 0x00        // D4: high while trigger held
+        val light = if (lightSensor()) 0x00 else 0x08              // D3: clear when bright, set when dark
+        (StrobeRegister.OPEN_BUS_MASK or trigger or light).toByte()
+    } else {
+        // Zapper is conventionally on port 2 only; a port-1 Zapper reads 0.
+        0
+    }
+
+    // No latched state: peek is an alias for read.
+    override fun peek(): Byte = read()
+}
 
 /**
  * Nothing is plugged into this port. Reads return the open-bus mask so the

--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/Frame.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/Frame.kt
@@ -4,4 +4,6 @@ class Frame {
     val scanlines = Array(size = RESOLUTION_HEIGHT, init = {Array(size = RESOLUTION_WIDTH, init = {0x000000})})
 
     operator fun set(x: Int, y: Int, value: Int) {scanlines[y][x] = value}
+
+    operator fun get(x: Int, y: Int): Int = scanlines[y][x]
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/Ppu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/Ppu.kt
@@ -10,6 +10,17 @@ const val RESOLUTION_HEIGHT = 240
 
 const val POST_RENDER_SCANLINE = 240
 
+/**
+ * Whether the raster beam has finished drawing row [targetY] this frame, given it
+ * is currently on [beamScanline]. The [Frame] buffer is reused across
+ * frames, so a row the beam has not yet redrawn still holds the *previous* frame's
+ * colour — the Zapper light sensor must treat such a pixel as "not yet lit" or it
+ * reads phantom light (e.g. last frame's bright sky) during a game's blank-then-flash
+ * hit-detection sequence. A row counts as drawn once the beam has moved strictly past
+ * it (including the whole vblank period, where beamScanline >= 241 > any visible row).
+ */
+internal fun beamHasDrawnRow(targetY: Int, beamScanline: Int): Boolean = beamScanline > targetY
+
 class Ppu(var memory: Memory) {
 
     private var cycle = 0
@@ -20,6 +31,29 @@ class Ppu(var memory: Memory) {
     // Mesen2's emu.getState() exposes ppu.scanline/ppu.cycle. Not used by emulation.
     val currentScanline: Int get() = scanline
     val currentCycle: Int get() = cycle
+
+    /**
+     * Sum of the R+G+B channels (0..765) of the pixel the light gun is aimed at,
+     * read from the LIVE frame the PPU is *currently* drawing. This is
+     * what the Zapper light sensor samples on a `$4017` read: reading the in-progress
+     * frame (not the last published one) removes a full frame of lag, which is what
+     * decouples a game's hit from where the player is actually aiming during its fast
+     * blank-then-flash detection sequence.
+     *
+     * Returns 0 ("dark") for a row the beam has not yet drawn this frame (see
+     * [beamHasDrawnRow] — the reused [Frame] would otherwise hand back the previous
+     * frame's colour). Off-screen coordinates return -1.
+     *
+     * Runs on the emulation thread (the `$4017` read path), the same thread that
+     * writes [frame], so no synchronisation is needed. (The Memory Editor's peek path
+     * may call it from the UI thread; a torn read there only mis-colours a debug view.)
+     */
+    fun aimBrightness(x: Int, y: Int): Int {
+        if (x < 0 || y < 0 || x >= RESOLUTION_WIDTH || y >= RESOLUTION_HEIGHT) return -1
+        if (!beamHasDrawnRow(y, scanline)) return 0
+        val rgb = frame[x, y]
+        return ((rgb shr 16) and 0xFF) + ((rgb shr 8) and 0xFF) + (rgb and 0xFF)
+    }
 
     // Active timing region. NTSC has 262 scanlines (pre-render at 261); PAL has
     // 312 (pre-render at 311). VBlank still begins at scanline 241 dot 1 for both;

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/Application.kt
@@ -8,6 +8,7 @@ import com.github.alondero.nestlin.apu.AudioResampler
 import com.github.alondero.nestlin.file.load
 import com.github.alondero.nestlin.input.GamepadInput
 import com.github.alondero.nestlin.input.InputConfig
+import com.github.alondero.nestlin.input.InputDevice
 import com.github.alondero.nestlin.movie.Fm2Format
 import com.github.alondero.nestlin.movie.Movie
 import com.github.alondero.nestlin.movie.MovieLivePlayer
@@ -133,6 +134,146 @@ class NestlinApplication : FrameListener, Application() {
     private val frameBufferLock = Any()
     // Native-resolution RGB buffer. Upscaling is handled by ImageView.fitWidth/Height, not by replication.
     private var nextFrame = ByteArray(RESOLUTION_HEIGHT * RESOLUTION_WIDTH * 3)
+
+    // --- Zapper light-gun input state ---
+    // Written on the JavaFX thread (mouse handlers / focus listener), read on the
+    // emulation thread when a plugged Zapper polls $4017 — hence @Volatile.
+    @Volatile private var zapperTriggerDown = false
+    @Volatile private var windowFocused = true
+    // Aim, already mapped to a PPU pixel (mapping needs the live canvas size, only
+    // valid to read on the FX thread). Packed as (x shl 8) or y into ONE volatile so
+    // the light sampler never reads a torn half-updated coordinate; -1 = off-canvas.
+    @Volatile private var zapperAim = -1
+    // Last canvas-local cursor position (FX thread only), kept so the reticle can be
+    // re-placed when the canvas moves under it (window resize fires no mouse event).
+    private var lastPointerCanvasX = -1.0
+    private var lastPointerCanvasY = -1.0
+
+    // Whether a Zapper is plugged into either port. Drives the aim reticle and the
+    // "hide the OS cursor over the game so the reticle is the only pointer" behaviour.
+    // UI-thread only.
+    private var zapperActive = false
+    // Aim reticle overlay: a crisp scene-graph node — like the other indicators —
+    // pinned to the canvas at the current aim pixel. Its local origin is the top-left
+    // of a [ZAPPER_CROSSHAIR_SIZE]-box whose centre is the aim point.
+    private val zapperCrosshair: javafx.scene.Group = buildZapperCrosshair()
+
+    /**
+     * True when the pixel the cursor is over is "bright" — a lit target sprite.
+     * Threshold is R+G+B > 384 (of 765), which cleanly separates a game's white
+     * detection boxes from the blanked/dark backdrop it flashes them against.
+     *
+     * Reads the PPU's LIVE frame (via [Ppu.aimBrightness]) rather than the published
+     * [nextFrame]: the light gun must see the frame currently being drawn, or hit
+     * detection lags a frame behind the aim during the fast blank-then-flash sequence.
+     * This runs on the emulation thread (the $4017 read path), same as the PPU, so it
+     * needs no frame-buffer lock.
+     */
+    private fun zapperLightSample(): Boolean {
+        val aim = zapperAim
+        if (aim < 0) return false
+        val px = (aim shr 8) and 0xFF
+        val py = aim and 0xFF
+        return nestlin.ppu.aimBrightness(px, py) > ZAPPER_BRIGHTNESS_THRESHOLD
+    }
+
+    /**
+     * Point the Zapper at a canvas-local mouse coordinate: map it to a PPU pixel for
+     * the light sampler AND move the reticle. Both are driven from the same coordinate
+     * so the visible aim and the sampled pixel can never disagree. Must run on the FX
+     * thread ([canvas] size is read live). Off-canvas coordinates clear the aim (-1)
+     * and hide the reticle.
+     */
+    private fun updateZapperPointer(canvasX: Double, canvasY: Double) {
+        val w = canvas.width
+        val h = canvas.height
+        val onCanvas = w > 0.0 && h > 0.0 &&
+            canvasX >= 0.0 && canvasY >= 0.0 && canvasX < w && canvasY < h
+        if (!onCanvas) {
+            zapperAim = -1
+            lastPointerCanvasX = -1.0
+            lastPointerCanvasY = -1.0
+            zapperCrosshair.isVisible = false
+            return
+        }
+        val px = ((canvasX / w) * RESOLUTION_WIDTH).toInt().coerceIn(0, RESOLUTION_WIDTH - 1)
+        val py = ((canvasY / h) * RESOLUTION_HEIGHT).toInt().coerceIn(0, RESOLUTION_HEIGHT - 1)
+        zapperAim = (px shl 8) or py
+        lastPointerCanvasX = canvasX
+        lastPointerCanvasY = canvasY
+        positionZapperCrosshair(canvasX, canvasY)
+    }
+
+    /**
+     * Build the aim reticle: a ring with four ticks forming a gapped `+`. Drawn in a
+     * local coordinate box [0, [ZAPPER_CROSSHAIR_SIZE]] with the centre at
+     * ([ZAPPER_CROSSHAIR_CENTER], [ZAPPER_CROSSHAIR_CENTER]) so positioning is just
+     * "translate to (aim − centre)". Mouse-transparent so it never steals the canvas
+     * mouse handlers; starts hidden.
+     */
+    private fun buildZapperCrosshair(): javafx.scene.Group {
+        val red = javafx.scene.paint.Color.web("#FF3030")
+        val c = ZAPPER_CROSSHAIR_CENTER
+        fun tick(sx: Double, sy: Double, ex: Double, ey: Double) =
+            javafx.scene.shape.Line(sx, sy, ex, ey).apply {
+                stroke = red
+                strokeWidth = 1.5
+            }
+        val ring = javafx.scene.shape.Circle(c, c, 7.0).apply {
+            fill = javafx.scene.paint.Color.TRANSPARENT
+            stroke = red
+            strokeWidth = 1.5
+        }
+        return javafx.scene.Group(
+            ring,
+            tick(c, c - 11.0, c, c - 5.0),
+            tick(c, c + 5.0, c, c + 11.0),
+            tick(c - 11.0, c, c - 5.0, c),
+            tick(c + 5.0, c, c + 11.0, c),
+        ).apply {
+            isMouseTransparent = true
+            isVisible = false
+        }
+    }
+
+    /**
+     * Place the reticle over the canvas at a canvas-local coordinate. Maps canvas-local
+     * → holder coordinates via the canvas group's bounds (which already account for
+     * letterboxing/centring at any scale), then offsets by the reticle centre so the
+     * ring lands on the aim point. Hidden when no Zapper is plugged.
+     */
+    private fun positionZapperCrosshair(canvasX: Double, canvasY: Double) {
+        if (!zapperActive) {
+            zapperCrosshair.isVisible = false
+            return
+        }
+        val b = canvasGroup.boundsInParent
+        zapperCrosshair.translateX = b.minX + canvasX - ZAPPER_CROSSHAIR_CENTER
+        zapperCrosshair.translateY = b.minY + canvasY - ZAPPER_CROSSHAIR_CENTER
+        zapperCrosshair.isVisible = true
+    }
+
+    /**
+     * Re-place the reticle after the canvas has moved beneath a stationary cursor
+     * (a window resize/scale change fires no mouse event). Uses the last canvas-local
+     * cursor position; a no-op when the cursor is off-canvas or no Zapper is plugged.
+     */
+    private fun refreshZapperCrosshair() {
+        if (!zapperActive || lastPointerCanvasX < 0.0) return
+        positionZapperCrosshair(lastPointerCanvasX, lastPointerCanvasY)
+    }
+
+    /**
+     * Recompute [zapperActive] from the current port selection and apply the
+     * "hide the OS cursor over the game" behaviour. Called at startup and whenever
+     * the controller configuration is applied.
+     */
+    private fun updateZapperActive() {
+        zapperActive = inputConfig.ports.port1 == InputDevice.DeviceType.ZAPPER ||
+            inputConfig.ports.port2 == InputDevice.DeviceType.ZAPPER
+        canvas.cursor = if (zapperActive) javafx.scene.Cursor.NONE else javafx.scene.Cursor.DEFAULT
+        if (!zapperActive) zapperCrosshair.isVisible = false
+    }
 
     private var displayConfig = DisplayConfig.load()
     private val scaleMenuItems = mutableMapOf<ScaleMode, javafx.scene.control.RadioMenuItem>()
@@ -485,6 +626,54 @@ class NestlinApplication : FrameListener, Application() {
                 // Reset hover state on transition so the menu isn't stuck visible.
                 if (!nowFs) mouseNearTopProperty.set(false)
             }
+
+            // --- Zapper light-gun wiring ---
+            // The trigger is mouse-left-held while the game window is focused; the light
+            // sense reads the frame buffer at the cursor. Mouse handlers live on the canvas
+            // so event.x/event.y are already canvas-local (pre-scale), which is what
+            // updateZapperPointer maps to a PPU pixel. These run whether or not a Zapper is
+            // actually plugged — the providers are only consulted when Memory holds one.
+            canvas.setOnMousePressed { e ->
+                // Update the aim before raising the trigger so a reader on the emulation
+                // thread never sees "trigger high" paired with the previous aim pixel.
+                updateZapperPointer(e.x, e.y)
+                if (e.button == javafx.scene.input.MouseButton.PRIMARY) zapperTriggerDown = true
+            }
+            canvas.setOnMouseReleased { e ->
+                if (e.button == javafx.scene.input.MouseButton.PRIMARY) zapperTriggerDown = false
+            }
+            canvas.setOnMouseMoved { e -> updateZapperPointer(e.x, e.y) }
+            canvas.setOnMouseDragged { e -> updateZapperPointer(e.x, e.y) }
+            canvas.setOnMouseExited {
+                zapperAim = -1
+                lastPointerCanvasX = -1.0
+                lastPointerCanvasY = -1.0
+                zapperCrosshair.isVisible = false
+            }
+            // Reticle overlay, pinned top-left so its translateX/Y are plain holder
+            // coordinates (positionZapperCrosshair does the canvas→holder mapping).
+            canvasHolder.children.add(zapperCrosshair)
+            StackPane.setAlignment(zapperCrosshair, javafx.geometry.Pos.TOP_LEFT)
+            // Re-place the reticle when the canvas moves under a stationary cursor
+            // (window resize / scale change fires no mouse event).
+            canvasGroup.boundsInParentProperty().addListener { _, _, _ -> refreshZapperCrosshair() }
+            stage.focusedProperty().addListener { _, _, focused ->
+                windowFocused = focused
+                // Dropping focus releases the trigger so a click that moved focus away
+                // (e.g. to the config window) doesn't leave the trigger stuck high.
+                if (!focused) zapperTriggerDown = false
+            }
+            // Install the providers once; the plugged Zapper (if any) reads them live.
+            nestlin.memory.setZapperProviders(
+                trigger = { zapperTriggerDown && windowFocused },
+                light = { zapperLightSample() },
+            )
+            // Apply the saved per-port device selection at boot. The config-window save
+            // is the only other path that calls setPortType, so without this a saved
+            // Zapper selection wouldn't take effect until the user re-opened the config.
+            nestlin.memory.setPortType(0, inputConfig.ports.port1)
+            nestlin.memory.setPortType(1, inputConfig.ports.port2)
+            updateZapperActive()
 
             scene.setOnKeyPressed { event ->
                 when {
@@ -886,6 +1075,8 @@ class NestlinApplication : FrameListener, Application() {
         // reads return open-bus vs standard pad bytes (issue: 2-player support).
         nestlin.memory.setPortType(0, cfg.ports.port1)
         nestlin.memory.setPortType(1, cfg.ports.port2)
+        // Refresh the aim reticle / cursor-hide state for the new port selection.
+        updateZapperActive()
         println("[APP] Applied new controller configuration")
     }
 
@@ -1790,6 +1981,15 @@ class NestlinApplication : FrameListener, Application() {
     }
 
     companion object {
+        // Zapper light-sense brightness cutoff: a pixel counts as "bright"
+        // (lit target) when R+G+B exceeds this, out of a 765 max. 384 (~half) cleanly
+        // separates a white target from the dark backdrop games flash it against.
+        private const val ZAPPER_BRIGHTNESS_THRESHOLD = 384
+
+        // Aim reticle geometry: a SIZE-box whose centre is the aim point.
+        private const val ZAPPER_CROSSHAIR_SIZE = 24.0
+        private const val ZAPPER_CROSSHAIR_CENTER = ZAPPER_CROSSHAIR_SIZE / 2.0
+
         // The 9 F-keys that map to save state slots. Order matters: index 0
         // corresponds to slot 1 (F1), index 8 to slot 9 (F9). Used by
         // isSlotKey() / slotNumberFromKey() to keep the F1..F9 → 1..9 mapping

--- a/src/main/kotlin/com/github/alondero/nestlin/ui/ControllerConfigWindow.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ui/ControllerConfigWindow.kt
@@ -194,8 +194,7 @@ class ControllerConfigWindow(
         private val legendLabels = HashMap<Button, Label>()
 
         init {
-            // Device-type dropdown: NONE / STANDARD_GAMEPAD (ZAPPER reserved in the
-            // enum but not yet listed — its working semantics land in a future PR).
+            // Device-type dropdown: NONE / STANDARD_GAMEPAD / ZAPPER.
             val supportedTypes = InputConfig.SUPPORTED_DEVICE_TYPES
             deviceTypeChoice = ChoiceBox<InputDevice.DeviceType>().apply {
                 items = javafx.collections.FXCollections.observableArrayList(supportedTypes)

--- a/src/test/kotlin/com/github/alondero/nestlin/SaveStateMigrationTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/SaveStateMigrationTest.kt
@@ -112,8 +112,10 @@ class SaveStateMigrationTest {
             powerReset()
             SaveState.load(this, Files.newInputStream(savePath))
 
-            // Port 0 is a Zapper stub — $4016 reads return 0x40 (open-bus only).
-            assertThat(memory[0x4016], equalTo(0x40.toByte()))
+            // Port 0 holds a Zapper. The Zapper is conventionally a port-2 ($4017)
+            // device, so a port-0 (index 0, isPort2 = false) Zapper reads back 0 —
+            // games never expect a light gun on port 1 (issue #209).
+            assertThat(memory[0x4016], equalTo(0.toByte()))
 
             // Port 1 (StandardGamepad) restored its A-pressed state — read A's
             // bit after a strobe to confirm.

--- a/src/test/kotlin/com/github/alondero/nestlin/input/InputDeviceTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/input/InputDeviceTest.kt
@@ -36,13 +36,15 @@ class InputDeviceTest {
     }
 
     @Test
-    fun `Zapper returns open-bus-only byte on read and peek`() {
+    fun `Zapper idle read reports open-bus plus dark-light bit`() {
         val zapper: InputDevice = Zapper()
 
-        // No buttons pressed — there's nothing to latch, but the open-bus mask
-        // is the canonical "device idle" return value.
-        assertThat(zapper.read(), equalTo(0x40.toByte()))
-        assertThat(zapper.peek(), equalTo(0x40.toByte()))
+        // A default Zapper sits on port 2 with no trigger and no light provider.
+        // "No light detected" sets D3 (0x08) — real hardware polarity (nesdev:
+        // "Light sensed: 0 detected, 1 not detected") and the Mesen2 oracle. OR'd
+        // with the open-bus mask that's 0x48. See ZapperTest for the full table.
+        assertThat(zapper.read(), equalTo(0x48.toByte()))
+        assertThat(zapper.peek(), equalTo(0x48.toByte()))
     }
 
     @Test
@@ -54,8 +56,8 @@ class InputDeviceTest {
         zapper.writeStrobe(true)
         zapper.writeStrobe(false)
 
-        // Reads still return open-bus-only.
-        assertThat(zapper.read(), equalTo(0x40.toByte()))
+        // Reads are un-latched samples of the live providers, unaffected by strobe.
+        assertThat(zapper.read(), equalTo(0x48.toByte()))
     }
 
     @Test
@@ -129,12 +131,13 @@ class InputDeviceTest {
     }
 
     @Test
-    fun `Memory 0x4017 read returns open-bus-only after port 2 is set to Zapper`() {
+    fun `Memory 0x4017 read reports Zapper idle byte after port 2 is set to Zapper`() {
         val memory = Memory()
         memory.setPortType(1, InputDevice.DeviceType.ZAPPER)
 
+        // Default providers (no trigger, no light detected) → open-bus + dark bit.
         repeat(8) {
-            assertThat(memory[0x4017], equalTo(0x40.toByte()))
+            assertThat(memory[0x4017], equalTo(0x48.toByte()))
         }
     }
 

--- a/src/test/kotlin/com/github/alondero/nestlin/input/ZapperTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/input/ZapperTest.kt
@@ -1,0 +1,129 @@
+package com.github.alondero.nestlin.input
+
+import com.github.alondero.nestlin.Memory
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Truth-table tests for the NES [Zapper] light gun (issue #209).
+ *
+ * The `$4017` read layout is `OB OB OB T L 0 0 0`: D4 (0x10) is the trigger,
+ * D3 (0x08) is the light sense, and D7-D5 float to the open-bus mask (0x40).
+ *
+ * **Light-sense polarity is hardware-correct, not the issue prose.** The issue
+ * described a lit target as setting D3; real hardware is the opposite — nesdev
+ * ("Light sensed: 0 detected, 1 not detected") and Mesen2's `Zapper.h`
+ * (`IsLightFound() ? 0 : 0x08`) both clear D3 on a bright pixel and set it in the
+ * dark. That is the polarity Duck Hunt's hit detection actually depends on, so
+ * the four rows below encode it:
+ *
+ * | trigger | pixel  | $4017 |
+ * |---------|--------|-------|
+ * | off     | dark   | 0x48  |
+ * | off     | bright | 0x40  |
+ * | on      | dark   | 0x58  |
+ * | on      | bright | 0x50  |
+ */
+class ZapperTest {
+
+    private fun zapper(trigger: Boolean, bright: Boolean, isPort2: Boolean = true) =
+        Zapper(triggerProvider = { trigger }, lightSensor = { bright }, isPort2 = isPort2)
+
+    @Test
+    fun `trigger off, dark - open-bus plus light-off bit (0x48)`() {
+        assertThat(zapper(trigger = false, bright = false).read(), equalTo(0x48.toByte()))
+    }
+
+    @Test
+    fun `trigger off, bright - open-bus only, light bit cleared (0x40)`() {
+        assertThat(zapper(trigger = false, bright = true).read(), equalTo(0x40.toByte()))
+    }
+
+    @Test
+    fun `trigger on, dark - open-bus plus trigger plus light-off (0x58)`() {
+        assertThat(zapper(trigger = true, bright = false).read(), equalTo(0x58.toByte()))
+    }
+
+    @Test
+    fun `trigger on, bright - open-bus plus trigger, light bit cleared (0x50)`() {
+        assertThat(zapper(trigger = true, bright = true).read(), equalTo(0x50.toByte()))
+    }
+
+    @Test
+    fun `peek matches read for every trigger and light combination`() {
+        // The Zapper has no latched state, so the Memory Editor's side-effect-free
+        // peek must return exactly what read would.
+        for (trigger in listOf(false, true)) {
+            for (bright in listOf(false, true)) {
+                val z = zapper(trigger, bright)
+                assertThat(z.peek(), equalTo(z.read()))
+            }
+        }
+    }
+
+    @Test
+    fun `a port-1 Zapper reads 0 regardless of trigger and light`() {
+        // The Zapper is conventionally a port-2 ($4017) device. A port-1 Zapper
+        // (isPort2 = false) reads 0 so a mis-configured UI selection stays inert.
+        assertThat(zapper(trigger = true, bright = true, isPort2 = false).read(), equalTo(0.toByte()))
+        assertThat(zapper(trigger = false, bright = false, isPort2 = false).read(), equalTo(0.toByte()))
+        assertThat(zapper(trigger = true, bright = true, isPort2 = false).peek(), equalTo(0.toByte()))
+    }
+
+    @Test
+    fun `writeStrobe does not affect the next read - no shift register`() {
+        // Toggling the shared $4016 strobe must not latch or shift anything: the
+        // Zapper is polled, not clocked. Reads stay live samples of the providers.
+        val z = zapper(trigger = true, bright = true)
+        z.writeStrobe(true)
+        z.writeStrobe(false)
+        assertThat(z.read(), equalTo(0x50.toByte()))
+    }
+
+    @Test
+    fun `read reflects live provider changes between polls`() {
+        // A game polls the Zapper several times per shot; the reading must track
+        // the provider state at each poll, not a construction-time snapshot.
+        var trigger = false
+        var bright = false
+        val z = Zapper(triggerProvider = { trigger }, lightSensor = { bright })
+
+        assertThat(z.read(), equalTo(0x48.toByte()))   // idle: dark, no trigger
+        trigger = true
+        assertThat(z.read(), equalTo(0x58.toByte()))   // trigger pulled, still dark
+        bright = true
+        assertThat(z.read(), equalTo(0x50.toByte()))   // now aimed at a lit target
+    }
+
+    @Test
+    fun `Memory forwards providers to a Zapper plugged into port 2`() {
+        // The end-to-end path: Application installs providers on Memory, then the
+        // config screen swaps port 2 to a Zapper. $4017 reads must reflect the
+        // providers Memory holds.
+        var trigger = false
+        var bright = false
+        val memory = Memory()
+        memory.setZapperProviders(trigger = { trigger }, light = { bright })
+        memory.setPortType(1, InputDevice.DeviceType.ZAPPER)
+
+        assertThat(memory[0x4017], equalTo(0x48.toByte()))
+        trigger = true
+        bright = true
+        assertThat(memory[0x4017], equalTo(0x50.toByte()))
+    }
+
+    @Test
+    fun `Memory picks up providers installed after the Zapper is plugged in`() {
+        // Providers forward through Memory's fields on every read, so installing
+        // them after the port swap still works — no re-plug required.
+        var bright = false
+        val memory = Memory()
+        memory.setPortType(1, InputDevice.DeviceType.ZAPPER)   // plug first
+        memory.setZapperProviders(trigger = { false }, light = { bright })  // install after
+
+        assertThat(memory[0x4017], equalTo(0x48.toByte()))     // dark
+        bright = true
+        assertThat(memory[0x4017], equalTo(0x40.toByte()))     // bright: light bit cleared
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuAimBrightnessTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuAimBrightnessTest.kt
@@ -1,0 +1,73 @@
+package com.github.alondero.nestlin.ppu
+
+import com.github.alondero.nestlin.Memory
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.greaterThan
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression for the Zapper light-gun aim/hit mismatch (issue #209 follow-up).
+ *
+ * The Zapper light sensor samples [Ppu.aimBrightness], which reads the frame the PPU
+ * is *currently* drawing (not the last published one). Two properties matter:
+ *  - it reflects the live frame's pixels, so a game's hit lines up with the aim in the
+ *    same frame the target is flashed (the earlier "read last completed frame" version
+ *    lagged a frame and decoupled hits from where the player pointed); and
+ *  - it returns "dark" for a row the beam hasn't reached yet, since the reused [Frame]
+ *    still holds the previous frame's colour there ([beamHasDrawnRow]).
+ */
+class PpuAimBrightnessTest {
+
+    /** Tick a fresh PPU up to the start of vblank, so every visible row (0..239) of the
+     *  current frame is drawn and the beam (scanline >= 240) is past all of them — the
+     *  raster state in which a game reads `$4017` for hit detection. */
+    private fun tickToVblank(ppu: Ppu) {
+        var guard = 400_000
+        while (ppu.currentScanline < POST_RENDER_SCANLINE && guard-- > 0) ppu.tick()
+        check(ppu.currentScanline >= POST_RENDER_SCANLINE) { "PPU never reached vblank" }
+    }
+
+    @Test
+    fun `beamHasDrawnRow is true only once the beam has moved strictly past the row`() {
+        assertThat(beamHasDrawnRow(targetY = 100, beamScanline = 50), equalTo(false))   // beam above
+        assertThat(beamHasDrawnRow(targetY = 100, beamScanline = 100), equalTo(false))  // beam on the row
+        assertThat(beamHasDrawnRow(targetY = 100, beamScanline = 101), equalTo(true))   // beam past
+        assertThat(beamHasDrawnRow(targetY = 239, beamScanline = 241), equalTo(true))   // vblank: all rows done
+    }
+
+    @Test
+    fun `aimBrightness reads the live frame's bright backdrop after it is drawn`() {
+        val memory = Memory()
+        val ppu = Ppu(memory)
+
+        // Force-blank the whole frame to a BRIGHT backdrop (white, index 0x30). With
+        // rendering disabled the PPU scans out the backdrop for every visible pixel.
+        memory.ppuAddressedMemory.ppuInternalMemory[0x3F00] = 0x30.toByte()
+        memory.ppuAddressedMemory.mask.register = 0
+
+        tickToVblank(ppu)   // beam past every visible row, frame drawn
+
+        // On-screen pixels report the bright backdrop (R+G+B well over the 384 cutoff).
+        assertThat(ppu.aimBrightness(128, 120), greaterThan(384))
+        assertThat(ppu.aimBrightness(0, 0), greaterThan(384))
+        assertThat(ppu.aimBrightness(255, 239), greaterThan(384))
+    }
+
+    @Test
+    fun `aimBrightness returns -1 for off-screen coordinates`() {
+        val ppu = Ppu(Memory())
+        assertThat(ppu.aimBrightness(-1, 0), equalTo(-1))
+        assertThat(ppu.aimBrightness(0, -1), equalTo(-1))
+        assertThat(ppu.aimBrightness(RESOLUTION_WIDTH, 0), equalTo(-1))
+        assertThat(ppu.aimBrightness(0, RESOLUTION_HEIGHT), equalTo(-1))
+    }
+
+    @Test
+    fun `aimBrightness reports dark for a row the beam has not reached yet`() {
+        // Fresh PPU: beam is at scanline 0, so a lower row has not been drawn this
+        // frame. The gate must return 0 rather than the frame's (stale) contents.
+        val ppu = Ppu(Memory())
+        assertThat(ppu.aimBrightness(128, 200), equalTo(0))
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the open-bus-only `Zapper` stub (from PR #208) with a working NES Zapper light gun so games like Duck Hunt respond to aim + click.

- **Real `$4017` semantics** — D4 = trigger (mouse-left held while the window is focused), D3 = light sense. **Light-sense polarity follows real hardware / the Mesen2 oracle** (`Zapper.h`: `IsLightFound() ? 0 : 0x08`), i.e. a *bright* target reads D3 **clear** — the issue prose had this inverted, and the hardware-correct polarity is what makes hit detection work. A port-1 Zapper reads `0` (conventionally a port-2 device).
- **Light reads the live PPU frame** via new `Ppu.aimBrightness(x, y)` with a beam gate, instead of the last *published* frame. This removes a full frame of lag that otherwise decoupled the hit from the aim during a game's fast blank‑then‑flash detection sequence.
- **On-screen aim reticle** (the OS cursor is hidden over the game), so it's clear where the gun points; the reticle and the sampled pixel are driven from the same coordinate.
- **Saved port selection applied at boot** (previously only applied when the config window was saved) and `ZAPPER` re‑enabled in the Controls dropdown.
- **Concurrency:** port/provider fields are `@Volatile`; the FX‑thread aim is packed into a single volatile int so the emulation‑thread light sampler can't read a torn coordinate.

## Test plan

- [x] `ZapperTest` — trigger/light truth table (all four combos), port-1 reads 0, strobe no-op, live-provider tracking, Memory forwarding
- [x] `PpuAimBrightnessTest` — live-frame read, beam gate (`beamHasDrawnRow`), off-screen bounds
- [x] Updated `InputDeviceTest` / `SaveStateMigrationTest` for the hardware-correct idle byte (`0x48`) and port-1 `0`
- [x] Full `./gradlew test` green (no regressions; `TwoControllerTest` still passes)
- [ ] **Manual GUI smoke (needs a display + Duck Hunt ROM):** select Zapper on port 2, confirm the reticle tracks the cursor and shots register on the target

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)