### PR TITLE
Implement Mapper 22 (Konami VRC2a) — closes #137

### DIFF
--- a/MAPPER_SUPPORT.md
+++ b/MAPPER_SUPPORT.md
@@ -1,6 +1,6 @@
 # NES Mapper Support Status
 
-Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 24, 26, 33, 34, 64, 65, 66, 68, 69, 153, 206, 228.**
+Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 22, 24, 26, 33, 34, 64, 65, 66, 68, 69, 153, 206, 228.**
 
 ## Mapper 0 (NROM)
 **Status:** Working
@@ -385,6 +385,31 @@ Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 24, 26, 33, 34,
   `build/reports/state-diffs/kaijuu-monogatari-frame-60/`. The ROM
   is resolved from the canonical NO-INTRO path on Adam's machine,
   override with `NESTLIN_KAIJUU_MONOGATARI_ROM`.
+
+---
+
+## Mapper 22 (Konami VRC2a)
+**Status:** Working (Added 2026-07-12, issue #137)
+
+- **Games:** *TwinBee 3 - Poko Poko Daimaou (Japan)* is the only VRC2a title in the local NO-INTRO library and the regression oracle for this mapper. Other known VRC2a games include *Takeshi no Chōsenjō*, *Wai Wai World 2*, and several other late-1980s Konami / Famicom titles — none of which are locally available. Note: the GitHub issue text mentions "Akumajō Special: Boku Dracula-kun" as a VRC2a game, but in practice that title's iNES header is **mapper 23 (VRC4)**, not 22 — the issue spec was wrong on this point.
+- **Spec source:** the nesdev wiki (INES Mapper 022) plus Mesen2's `Core/NES/Mappers/Konami/VRC2_4.h` oracle. The chip is the VRC2 — a stripped-down VRC4 with the same register address map but a smaller feature set. Where the GitHub issue text disagrees with the wiki + Mesen2 source, the wiki/Mesen2 wins (the issue's "no CHR banking" and "no mirroring" claims were both wrong).
+- **Address-pin decode:** identical to VRC4b / Mapper 25 — CPU A1 → sub-bit 0, CPU A0 → sub-bit 1. `$x000` → sub 0, `$x001` → sub 2, `$x002` → sub 1, `$x003` → sub 3.
+- **PRG geometry:**
+  - `$8000-$9FFF` — switchable 8KB bank via `$8000` (5-bit).
+  - `$A000-$BFFF` — switchable 8KB bank via `$A000` (5-bit).
+  - `$C000-$DFFF` — **fixed** to the second-to-last 8KB bank. (VRC2 has no `$9002` swap-mode register; the only way for `$C000` to see `prg0` is the VRC4 swap mode, which VRC2 doesn't expose.)
+  - `$E000-$FFFF` — **fixed** to the last 8KB bank (reset / NMI / IRQ vectors).
+- **CHR geometry:** eight independent 1KB banks at `$0000-$1FFF`, each selected via the VRC4-style low+high nibble protocol (`$B000-$B003` for windows 0-1, `$C000-$C003` for windows 2-3, etc.). **VRC2a quirk:** the chip only wires 7 of the 9 stored CHR-select bits — the effective page index is the stored 9-bit value right-shifted by 1 (Mesen2's `if (_variant == VRC2a) page >>= 1`). A 0KB-CHR dump gets 8KB of writable CHR-RAM (same fallback as Mapper 2 / 3 / 11 / 71).
+- **Mirroring:** `$9000` / `$9001` write **bit 0** selects Vertical (0) or Horizontal (1). The VRC2 silicon ties bit 1 to a no-op (VRC4's 1-screen-lower / 1-screen-upper modes aren't exposed), so any value with bit 1 set collapses to V or H per bit 0. The header drives the initial state until the game writes `$9000` for the first time.
+- **No IRQ counter.** `$F000-$F003` writes are silently dropped; `tickCpuCycle` is a no-op; `isIrqPending` always returns false. The VRC2 chip literally has no IRQ device (VRC4 added one).
+- **No WRAM.** `$6000-$7FFF` reads return the 6502 open-bus value (`dataBus`); writes are accepted and discarded. The VRC2 silicon has only a 1-bit latch at `$6000-$6FFF` that no commercial cartridge wires up (PCB 351618 ties the EEPROM data pin to ground). `batteryBackedRam()` returns `null` so the Save RAM layer doesn't allocate an unused `.sav` file.
+- **No `$9002` swap-mode / WRAM-enable register.** Writes to `$9002` / `$9003` are silently dropped — the chip has no register there at all.
+- **Implementation:** `Mapper22` is a thin subclass of the existing `Vrc4` base class. It overrides `decodeSubRegister` (the VRC4b swap), `cpuRead` (open-bus for `$6000-$7FFF`), `cpuWrite` (drops `$6000`, `$9002-$9003`, and `$Fxxx` writes; bit-masks `$9000`/$9001` mirroring to V/H), `currentMirroring` (collapses bit-1 VRC4 modes to V/H; preserves the `-1` header-fallback sentinel), `ppuRead` (applies the `>> 1` CHR shift), `tickCpuCycle` (no-op), `isIrqPending` (false), `batteryBackedRam` (null), and `dataBus` (so `$6000-$7FFF` reads actually return open bus in tests). The Vrc4 base class's `prg0`, `prg1`, `mirroringMode` fields and `writeChr` helper were promoted from `private` to `protected` for this purpose.
+- **Save state:** inherits VRC4's version-2 format — round-trip works because the VRC2a-specific state is a strict subset of VRC4's.
+- **Verification:**
+  - `Mapper22Test` (22 cases) covers dispatch from the iNES header, default PRG state (banks 0/0/second-to-last/last), `prg0`/`prg1` switching via the VRC4b address layout, $9002 swap-mode and WRAM-enable bits being no-ops, $6000-$7FFF open-bus read + dropped writes + null `batteryBackedRam`, $9000 V/H mirroring + bit-1-ignored collapse + header fallback, $Fxxx IRQ non-firing even after 10K CPU cycles, all 8 CHR windows with the `>> 1` shift quirk, CHR high-nibble before the shift, CHR-RAM fallback for 0-CHR dumps, save/load round-trip, version-byte rejection, and a swap-correctness assertion that proves `$B001` (sub 2) targets `chr1` and not `chr0` (a VRC4a decode would clobber chr0 here).
+  - `Mapper22RegressionTest` (`@RequiresMesen2`, in the `mesen` lane) — boots TwinBee 3 on the real ROM, asserts (1) `prg0` actually pages during boot (the "did the mapper do anything" guard), and (2) Nestlin's CHR banks are byte-identical to Mesen2's at frame 60.
+  - **Real-ROM boot gate:** `./gradlew bootcheck -Prom="S:/Media/Nintendo NES/Games/TwinBee 3 - Poko Poko Daimaou (Japan) (Translated En).nes" -Pframes=120` returns **PASS** (rendering on by frame 8, 56% non-blank, 4 distinct PRG states, 3 distinct CHR states, 118 NMIs fired, 0 IRQs — exactly what a chip-without-IRQ should show).
 
 ---
 

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
@@ -144,6 +144,7 @@ class GamePak(data: ByteArray, displayName: String = "") {
         18 -> Mapper18(this)
         19 -> Mapper19(this)
         21 -> Mapper21(this)
+        22 -> Mapper22(this)
         23 -> Mapper23(this)
         24 -> Mapper24(this)
         25 -> Mapper25(this)

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper22.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper22.kt
@@ -1,0 +1,177 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.github.alondero.nestlin.toUnsignedInt
+
+/**
+ * Mapper 22 — Konami VRC2a.
+ *
+ * The VRC2 chip is a stripped-down VRC4 with the same register address map
+ * but a smaller feature set: no IRQ counter, no $9002 PRG-swap / WRAM-enable
+ * register, no $6000-$7FFF WRAM (only a 1-bit latch), and mirroring reduced
+ * to V/H only (bit 1 of $9000 is ignored). The silicon is VRC4-family;
+ * Konami just wired the die with fewer pins populated.
+ *
+ * ## Address-pin decode
+ *
+ * VRC2a uses the VRC4b / Mapper 25 swap — CPU A1 feeds the chip's
+ * sub-register bit 0 and CPU A0 feeds sub-register bit 1, so the four
+ * sub-registers land at:
+ *
+ *   $x000 → sub 0    $x001 → sub 2    $x002 → sub 1    $x003 → sub 3
+ *
+ * This matches the nesdev wiki (INES Mapper 022) and Mesen2's
+ * `Core/NES/Mappers/Konami/VRC2_4.h` oracle.
+ *
+ * ## Register map
+ *
+ *   $8000-$8003   PRG bank 0 (5-bit, 8KB window at $8000)
+ *   $9000-$9001   Mirroring — bit 0 only (0=Vert, 1=Horiz); bit 1 ignored
+ *   $9002-$9003   No-op on VRC2 (VRC4's swap-mode + WRAM-enable register)
+ *   $A000-$A003   PRG bank 1 (5-bit, 8KB window at $A000)
+ *   $B000-$E003   CHR bank selects — 8 × 1KB windows, low+high nibble
+ *                 protocol as on VRC4
+ *   $F000-$F003   No-op on VRC2 (VRC4's IRQ register set)
+ *
+ * $C000-$FFFF is fixed to the last 16KB PRG bank (the second-to-last and
+ * last 8KB banks, in order). No swap mode.
+ *
+ * ## Quirks vs VRC4
+ *
+ * - **CHR bank shift:** the VRC2 spec stores CHR selects as 9-bit values
+ *   but only the high 7 bits are wired to the chip. Mesen2 models this by
+ *   right-shifting the page index by 1 in `UpdateState` — see
+ *   `VRC2_4.h`: `if (_variant == VRC2a) { page >>= 1; }`. We apply the
+ *   same shift in [ppuRead].
+ * - **Mirroring limited to V/H:** bit 1 of $9000 is ignored (VRC2 lacks
+ *   the 1-screen modes that VRC4 supports).
+ * - **No IRQ:** `tickCpuCycle` and `isIrqPending` are no-ops.
+ * - **No $6000-$7FFF WRAM:** reads return the 6502 open-bus value
+ *   ([dataBus]); the VRC2 silicon has only a 1-bit latch at $6000-$6FFF
+ *   that no commercial cartridge actually wires up.
+ *
+ * ## Games
+ *
+ * TwinBee 3 - Poko Poko Daimaou (Japan) is the only VRC2a title in the
+ * local NO-INTRO library; other known VRC2a games (Takeshi no
+ * Chōsenjō, Wai Wai World 2, etc.) would also boot once this lands.
+ * Note that Akumajō Special: Boku Dracula-kun is Mapper 23 / VRC4, not
+ * Mapper 22 / VRC2a, despite the GitHub issue text suggesting otherwise.
+ */
+class Mapper22(gamePak: GamePak) : Vrc4(gamePak) {
+    override val mapperId: Int = 22
+
+    /**
+     * Override [dataBus] capture so [cpuRead] at $6000-$7FFF can return the
+     * actual 6502 open-bus value (the VRC2 silicon has only a 1-bit latch
+     * here that no commercial cartridge wires up). The base [Mapper] default
+     * is a no-op setter; without this override, `mapper.dataBus = 0x48` in
+     * tests would be discarded and `cpuRead(0x6000)` would always read 0.
+     */
+    override var dataBus: Byte = 0
+
+    /**
+     * VRC2a address-pin decode: CPU A1 → sub-bit 0, CPU A0 → sub-bit 1
+     * (the VRC4b / Mapper 25 swap). $x000 → sub 0, $x001 → sub 2,
+     * $x002 → sub 1, $x003 → sub 3.
+     */
+    override fun decodeSubRegister(address: Int): Int {
+        return ((address shr 1) and 0x01) or ((address and 0x01) shl 1)
+    }
+
+    /**
+     * VRC2 has no $6000-$7FFF WRAM. Reads return the 6502 open-bus
+     * value ([dataBus]), which matches real hardware (the chip has only
+     * a 1-bit latch here that no commercial cartridge wires up; writes
+     * are accepted and discarded).
+     */
+    override fun cpuRead(address: Int): Byte {
+        if (address in 0x6000..0x7FFF) return dataBus
+        return super.cpuRead(address)
+    }
+
+    /**
+     * VRC2a mirroring supports only vertical / horizontal. The base
+     * VRC4 `mirroringMode` accepts the full 4-mode encoding (0..3),
+     * but the VRC2 silicon ties the 1-screen-mode bit (bit 1) to a
+     * no-op. Masking bit 1 collapses values 2 and 3 (1-screen-lower /
+     * upper) onto vertical, matching what the chip would have
+     * selected. -1 (no $9000 write yet) still falls through to the
+     * header default — must check for -1 before masking, since -1
+     * AND 0x01 = 1 (all bits set), which would incorrectly return
+     * Horizontal even when the header says Vertical.
+     */
+    override fun currentMirroring(): Mapper.MirroringMode {
+        return if (mirroringMode == -1) {
+            when (gamePak.header.mirroring) {
+                Header.Mirroring.HORIZONTAL -> Mapper.MirroringMode.HORIZONTAL
+                Header.Mirroring.VERTICAL -> Mapper.MirroringMode.VERTICAL
+            }
+        } else when (mirroringMode and 0x01) {
+            0 -> Mapper.MirroringMode.VERTICAL
+            else -> Mapper.MirroringMode.HORIZONTAL
+        }
+    }
+
+    /**
+     * VRC2 has no IRQ counter. The base VRC4 ticks its 8-bit increment-
+     * to-wrap counter here every CPU cycle (or every 113⅔ cycles in
+     * scanline mode) and asserts the IRQ line when it wraps; VRC2 just
+     * ignores the counter entirely, so we no-op the hook.
+     */
+    override fun tickCpuCycle() {}
+
+    /** VRC2 has no IRQ — the line is never asserted. */
+    override fun isIrqPending(): Boolean = false
+
+    /**
+     * VRC2 has no $6000-$7FFF WRAM (only a 1-bit latch at $6000-$6FFF that
+     * no commercial cartridge wires up), so there is nothing to battery-back.
+     * The base VRC4 always exposes an 8KB WRAM via [batteryBackedRam]
+     * (gated on the wramEnabled bit); for VRC2a we override to null so the
+     * Save RAM persistence layer doesn't allocate an unused `.sav` file.
+     */
+    override fun batteryBackedRam(): ByteArray? = null
+
+    /**
+     * VRC2a CHR shift quirk: the chip only wires 7 of the 9 CHR-select
+     * bits to the CHR ROM address lines, so the effective page index is
+     * the stored 9-bit value right-shifted by 1 (Mesen2's
+     * `VRC2_4.h::UpdateState`). The base [Vrc4.ppuRead] returns the
+     * unshifted page; we apply the shift here.
+     *
+     * The CHR-RAM fallback for 0-CHR-ROM dumps is inherited unchanged.
+     */
+    override fun ppuRead(address: Int): Byte {
+        val a = address and 0x1FFF
+        if (chrRom.isEmpty()) return chrMemory.read(a)
+        val window = a shr 10
+        val page = chrBanks[window] shr 1
+        return chrRom[(page * 0x0400 + (a and 0x03FF)) % chrRom.size]
+    }
+
+    /**
+     * VRC2 ignores the high two register addresses a VRC4 game would
+     * use: $9002-$9003 (PRG-swap mode + WRAM enable) and $F000-$F003
+     * (IRQ latch / control / ack). Writes to $6000-$7FFF are silently
+     * dropped as well. Everything else — $8000 / $A000 PRG selects,
+     * $9000-$9001 mirroring, $B000-$E003 CHR selects — delegates to
+     * the base class.
+     */
+    override fun cpuWrite(address: Int, value: Byte) {
+        val v = value.toUnsignedInt()
+        if (address in 0x6000..0x7FFF) return
+        if (address < 0x8000) return
+
+        val sub = decodeSubRegister(address)
+        when (address and 0xF000) {
+            0x8000 -> prg0 = v and 0x1F     // 5-bit PRG bank
+            0x9000 -> when (sub) {
+                0, 1 -> mirroringMode = v and 0x03  // V/H mirror; bit 1 ignored in currentMirroring
+                2, 3 -> {}  // No swap mode / no WRAM enable on VRC2 — ignore.
+            }
+            0xA000 -> prg1 = v and 0x1F
+            in 0xB000..0xE000 -> writeChr(address and 0xF000, sub, v)
+            0xF000 -> {}  // No IRQ counter on VRC2 — ignore $Fxxx writes.
+        }
+    }
+}

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Vrc4.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Vrc4.kt
@@ -58,17 +58,22 @@ abstract class Vrc4(protected val gamePak: GamePak) : Mapper {
     override fun batteryBackedRam(): ByteArray? = prgRam
 
     // PRG: two switchable 8KB banks. prg0 lands at $8000 or $C000 depending on
-    // prgSwapMode; prg1 always lands at $A000.
-    private var prg0 = 0
-    private var prg1 = 0
+    // prgSwapMode; prg1 always lands at $A000. `protected` so the stripped-down
+    // VRC2 subclass (Mapper22) can drive the same fields through its own
+    // (different) cpuWrite decode without inheriting VRC4's IRQ / swap-mode /
+    // WRAM-enable handling at $9002 / $Fxxx.
+    protected var prg0 = 0
+    protected var prg1 = 0
     private var prgSwapMode = false
 
     // CHR: eight 1KB banks, each with a 9-bit bank number assembled from a
     // 4-bit low nibble (even sub) and a 5-bit high nibble (odd sub).
     protected val chrBanks = IntArray(8)
 
-    // Mirroring override from $9000-$9001. -1 = use header default.
-    private var mirroringMode: Int = -1
+    // Mirroring override from $9000-$9001. -1 = use header default. `protected`
+    // so VRC2 subclasses can mask bit 1 (VRC2 only supports V/H mirroring) in
+    // their own currentMirroring override.
+    protected var mirroringMode: Int = -1
 
     // VRC IRQ state.
     private var irqLatch = 0          // 8-bit reload value
@@ -152,7 +157,7 @@ abstract class Vrc4(protected val gamePak: GamePak) : Mapper {
         }
     }
 
-    private fun writeChr(group: Int, sub: Int, v: Int) {
+    protected fun writeChr(group: Int, sub: Int, v: Int) {
         // Each $B/$C/$D/$E group hosts two 1KB CHR registers; sub picks which
         // register and whether we're writing the 4-bit low nibble or the 5-bit
         // high nibble of that register's 9-bit bank index.

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper22RegressionTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper22RegressionTest.kt
@@ -1,0 +1,75 @@
+package com.github.alondero.nestlin.compare
+
+import com.github.alondero.nestlin.gamepak.Mapper22
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+
+/**
+ * Structured-state regression test for issue #137 (Mapper 22 / Konami VRC2a)
+ * using TwinBee 3 - Poko Poko Daimaou (Japan) — the only VRC2a title in
+ * the local NO-INTRO library. CRCs:
+ *   - TwinBee 3 - Poko Poko Daimaou (Japan) (Translated En).nes  0x96529C68
+ *
+ * Other VRC2a games named in issue #137 (Takeshi no Chōsenjō, Akumajō
+ * Special: Boku Dracula-kun) are not in the local library; the latter is
+ * also Mapper 23 / VRC4 in the available dumps, not VRC2a.
+ *
+ * Two-pronged verification (Mapper10RegressionTest pattern):
+ *  1. The boot code actually moves the `prg0` bank register during boot —
+ *     proves the $8000 register-decode is wired and the chip isn't stuck
+ *     at its reset state.
+ *  2. Nestlin's CHR banks are byte-identical to Mesen2's at frame N —
+ *     proves the full PRG-bank + CHR-bank + mirroring interaction is
+ *     correct, including the VRC2a `page >>= 1` CHR shift quirk.
+ *
+ * The ROM lives only in the NO-INTRO library (not in git). Override with
+ * `NESTLIN_TWINBEE3_ROM`. Skipped when neither the ROM nor Mesen2 is
+ * present, since CI runners won't have either.
+ */
+class Mapper22RegressionTest : MapperRegressionTestBase() {
+
+    private val frameNumber = 60
+
+    private fun twinbee3Rom(): Path = resolveRom(
+        "NESTLIN_TWINBEE3_ROM",
+        "S:/Media/Nintendo NES/Games/TwinBee 3 - Poko Poko Daimaou (Japan) (Translated En).nes"
+    )
+
+    @Test
+    fun `vrc2a prg bank switches during TwinBee 3 boot`() {
+        assertBankSwitchesDuringBoot(twinbee3Rom(), frameNumber, "prg0", Mapper22::class.java)
+    }
+
+    @Test
+    @RequiresMesen2
+    fun `TwinBee 3 chr banks match mesen2 at frame N`() {
+        val rom = twinbee3Rom()
+        val reportsDir = java.nio.file.Paths.get("build/reports/state-diffs/twinbee3-frame-$frameNumber")
+
+        val nestlinState = NestlinStateCapturer.captureState(rom, frameNumber)
+        val mesen2State = Mesen2StateCapturer.captureState(rom, frameNumber)
+
+        java.nio.file.Files.createDirectories(reportsDir)
+        val fullDiff = StateComparator.compare(nestlinState, mesen2State)
+        StateComparator.writeReport(fullDiff, nestlinState, mesen2State, reportsDir.resolve("diff-report.txt"))
+
+        // The mapper's job is CHR banking. OAM is reported alongside for human
+        // inspection but is NOT asserted here — see the kdoc on
+        // MapperRegressionTestBase for the cross-emulator NMI/OAM offset
+        // rationale. CHR byte-equality is the proof the VRC2a banking + shift
+        // quirk (`page >>= 1`) match Mesen2.
+        val chrDiffs = (nestlinState.chr.indices).filter {
+            nestlinState.chr[it] != mesen2State.chr[it]
+        }
+        if (chrDiffs.isNotEmpty()) {
+            val sample = chrDiffs.take(8).joinToString(", ") {
+                "[0x%04X] N=0x%02X M=0x%02X".format(it, nestlinState.chr[it], mesen2State.chr[it])
+            }
+            throw org.opentest4j.AssertionFailedError(
+                "CHR banks diverged from Mesen2 oracle in ${chrDiffs.size} byte(s): $sample\n" +
+                    "This is a VRC2a bug — see: ${reportsDir.resolve("diff-report.txt")}"
+            )
+        }
+        println("TwinBee 3 frame $frameNumber CHR banks: MATCH (8KB across all 8 1KB windows)")
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper22Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper22Test.kt
@@ -1,0 +1,333 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.github.alondero.nestlin.toSignedByte
+import com.github.alondero.nestlin.toUnsignedInt
+import com.github.alondero.nestlin.testutil.testGamePak
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+
+/**
+ * Unit tests for Mapper 22 (Konami VRC2a).
+ *
+ * VRC2a is a stripped-down VRC4: same register address map, same address-pin
+ * decode (the VRC4b / Mapper 25 swap), same 8KB PRG banking at $8000/$A000,
+ * same 8×1KB CHR banking, but no IRQ counter, no $9002 swap mode, no
+ * $6000-$7FFF WRAM, V/H-only mirroring (bit 1 ignored), and a CHR shift
+ * quirk where the stored 9-bit CHR bank is right-shifted by 1 when selecting
+ * the actual CHR page (Mesen2's `VRC2_4.h::UpdateState`).
+ *
+ * Test fixtures stamp every 8KB PRG bank with its bank index (byte 0) and
+ * every 1KB CHR page with its page index, so a read asserts exactly which
+ * bank is mapped into the window. The fixtures are built via [testGamePak]
+ * (the project's lint-enforced path) rather than hand-built iNES headers
+ * — see HeaderConstructionLintTest.
+ */
+class Mapper22Test {
+
+    /** VRC2a's address-pin decode is the VRC4b / Mapper 25 swap. */
+    private fun Mapper.vrc22write(group: Int, sub: Int, value: Int) {
+        val low = (sub and 0x01) shl 1
+        val high = (sub and 0x02) shr 1
+        cpuWrite(group or low or high, value.toSignedByte())
+    }
+
+    private fun build(
+        prgKb: Int = 64,
+        chrKb: Int = 8,
+        verticalMirroring: Boolean = true
+    ): GamePak = testGamePak {
+        mapper = 22
+        this.prgKb = prgKb
+        this.chrKb = chrKb
+        this.verticalMirroring = verticalMirroring
+        // Fill each 8KB PRG bank with its index byte, so any read inside the
+        // window tells us which bank is mapped there. TestRomBuilder.stampPrgBanks
+        // only stamps byte 0 of each window — not enough when a test asserts
+        // the bank index at offsets deep inside the window (e.g. $9FFF).
+        for (bank in 0 until prgKb / 8) {
+            for (i in 0 until 0x2000) {
+                prg[bank * 0x2000 + i] = (bank and 0xFF).toByte()
+            }
+        }
+        if (chrKb > 0) {
+            stampChrBanks(windowKb = 1)        // each 1KB CHR page stamped with its index
+        }
+    }
+
+    // ---- Factory wiring ----
+
+    @Test
+    fun `mapper 22 is selected for header mapper 22`() {
+        assertThat(build().createMapper() is Mapper22, equalTo(true))
+    }
+
+    // ---- PRG banking ----
+
+    @Test
+    fun `E000-FFFF is fixed to the last 8KB bank`() {
+        val mapper = Mapper22(build(prgKb = 64))   // 64KB PRG = 8 × 8KB banks, last = 7
+        assertThat(mapper.cpuRead(0xE000).toUnsignedInt(), equalTo(7))
+        assertThat(mapper.cpuRead(0xFFFF).toUnsignedInt(), equalTo(7))
+    }
+
+    @Test
+    fun `C000-DFFF is fixed to the second-to-last 8KB bank`() {
+        val mapper = Mapper22(build(prgKb = 64))
+        assertThat(mapper.cpuRead(0xC000).toUnsignedInt(), equalTo(6))
+        assertThat(mapper.cpuRead(0xDFFF).toUnsignedInt(), equalTo(6))
+    }
+
+    @Test
+    fun `default PRG banks at 8000 and A000 are bank 0`() {
+        val mapper = Mapper22(build(prgKb = 32))   // 32KB PRG = 4 × 8KB banks
+        assertThat(mapper.cpuRead(0x8000).toUnsignedInt(), equalTo(0))
+        assertThat(mapper.cpuRead(0x9FFF).toUnsignedInt(), equalTo(0))
+        assertThat(mapper.cpuRead(0xA000).toUnsignedInt(), equalTo(0))
+        assertThat(mapper.cpuRead(0xBFFF).toUnsignedInt(), equalTo(0))
+    }
+
+    @Test
+    fun `8000 PRG select switches the 8KB window at 8000`() {
+        val mapper = Mapper22(build(prgKb = 64))
+        mapper.vrc22write(0x8000, 0, 3)    // prg0 = bank 3
+        assertThat(mapper.cpuRead(0x8000).toUnsignedInt(), equalTo(3))
+        assertThat(mapper.cpuRead(0x9FFF).toUnsignedInt(), equalTo(3))
+        // $C000-$FFFF still fixed.
+        assertThat(mapper.cpuRead(0xC000).toUnsignedInt(), equalTo(6))
+        assertThat(mapper.cpuRead(0xE000).toUnsignedInt(), equalTo(7))
+    }
+
+    @Test
+    fun `A000 PRG select switches the 8KB window at A000`() {
+        val mapper = Mapper22(build(prgKb = 64))
+        mapper.vrc22write(0xA000, 0, 5)    // prg1 = bank 5
+        assertThat(mapper.cpuRead(0xA000).toUnsignedInt(), equalTo(5))
+        assertThat(mapper.cpuRead(0xBFFF).toUnsignedInt(), equalTo(5))
+    }
+
+    @Test
+    fun `8000 and A000 PRG selects are independent`() {
+        val mapper = Mapper22(build(prgKb = 64))
+        mapper.vrc22write(0x8000, 0, 2)
+        mapper.vrc22write(0xA000, 0, 4)
+        assertThat(mapper.cpuRead(0x8000).toUnsignedInt(), equalTo(2))
+        assertThat(mapper.cpuRead(0xA000).toUnsignedInt(), equalTo(4))
+    }
+
+    @Test
+    fun `PRG bank register is 5 bits and masks to the low 5 bits`() {
+        val mapper = Mapper22(build(prgKb = 64))
+        // 5-bit field, so writing 0x21 masks to 0x01.
+        mapper.vrc22write(0x8000, 0, 0x21)
+        assertThat(mapper.cpuRead(0x8000).toUnsignedInt(), equalTo(1))
+    }
+
+    // ---- No $9002 swap mode (VRC2 has no swap register) ----
+
+    @Test
+    fun `9002 swap-mode bit does NOT move prg0 to C000`() {
+        val mapper = Mapper22(build(prgKb = 64))
+        mapper.vrc22write(0x8000, 0, 3)        // prg0 = bank 3
+        mapper.vrc22write(0x9000, 2, 0x02)     // VRC4's swap-mode bit — must be a no-op for VRC2
+        // prg0 still at $8000, not moved to $C000.
+        assertThat(mapper.cpuRead(0x8000).toUnsignedInt(), equalTo(3))
+        assertThat(mapper.cpuRead(0xC000).toUnsignedInt(), equalTo(6))   // second-to-last, not prg0
+        assertThat(mapper.cpuRead(0xE000).toUnsignedInt(), equalTo(7))
+    }
+
+    @Test
+    fun `9002 WRAM-enable bit does NOT enable 6000 RAM`() {
+        val mapper = Mapper22(build(prgKb = 64))
+        mapper.vrc22write(0x9000, 2, 0x01)     // VRC4's WRAM-enable bit — must be no-op for VRC2
+        // $6000 should still be open-bus / dataBus, NOT a writable RAM page.
+        mapper.dataBus = 0x00.toSignedByte()
+        mapper.cpuWrite(0x6000, 0x42.toSignedByte())
+        assertThat("VRC2 has no WRAM at \$6000",
+            mapper.cpuRead(0x6000).toUnsignedInt(), equalTo(0))
+    }
+
+    // ---- No IRQ (VRC2 has no $Fxxx registers) ----
+
+    @Test
+    fun `F000-F003 writes do not assert an IRQ even after many CPU cycles`() {
+        val mapper = Mapper22(build(prgKb = 64))
+        // Try every $Fxxx write a VRC4 game might issue.
+        for (sub in 0..3) {
+            mapper.vrc22write(0xF000, sub, 0xFF)
+        }
+        // Tick many CPU cycles — IRQ must never fire because VRC2 has no counter.
+        repeat(10_000) { mapper.tickCpuCycle() }
+        assertThat("VRC2 has no IRQ counter — isIrqPending must always be false",
+            mapper.isIrqPending(), equalTo(false))
+    }
+
+    // ---- $6000-$7FFF (no WRAM) ----
+
+    @Test
+    fun `6000-7FFF reads return the open-bus dataBus value, not zero`() {
+        val mapper = Mapper22(build(prgKb = 64))
+        mapper.dataBus = 0x48.toSignedByte()
+        assertThat("VRC2 reads \$6000 as open bus",
+            mapper.cpuRead(0x6000).toUnsignedInt(), equalTo(0x48))
+        assertThat("VRC2 reads \$7FFF as open bus",
+            mapper.cpuRead(0x7FFF).toUnsignedInt(), equalTo(0x48))
+    }
+
+    @Test
+    fun `6000-7FFF writes are silently dropped and batteryBackedRam is null`() {
+        val mapper = Mapper22(build(prgKb = 64))
+        mapper.dataBus = 0x00.toSignedByte()
+        mapper.cpuWrite(0x6000, 0xAA.toSignedByte())
+        mapper.cpuWrite(0x7FFF, 0xBB.toSignedByte())
+        assertThat("VRC2 has no battery-backed RAM chip",
+            mapper.batteryBackedRam(), equalTo(null))
+        assertThat(mapper.batteryDirty, equalTo(false))
+    }
+
+    // ---- Mirroring (V/H only; bit 1 ignored) ----
+
+    @Test
+    fun `9000 bit 0 selects Vertical or Horizontal mirroring`() {
+        val mapper = Mapper22(build(prgKb = 32, verticalMirroring = false))
+        mapper.vrc22write(0x9000, 0, 0x00)
+        assertThat(mapper.currentMirroring(), equalTo(Mapper.MirroringMode.VERTICAL))
+        mapper.vrc22write(0x9000, 0, 0x01)
+        assertThat(mapper.currentMirroring(), equalTo(Mapper.MirroringMode.HORIZONTAL))
+    }
+
+    @Test
+    fun `9000 bit 1 is ignored - 1-screen-mode writes collapse to V or H`() {
+        // The VRC4 silicon would decode bit 1 of $9000 as 1-screen-lower /
+        // 1-screen-upper; the VRC2 silicon ties that bit to a no-op. So a
+        // VRC2a game writing 0x02 (which would be 1-screen-lower on VRC4)
+        // must read back as Vertical.
+        val mapper = Mapper22(build(prgKb = 32, verticalMirroring = false))
+        mapper.vrc22write(0x9000, 0, 0x02)   // would be 1-screen-lower on VRC4
+        assertThat(mapper.currentMirroring(), equalTo(Mapper.MirroringMode.VERTICAL))
+        mapper.vrc22write(0x9000, 0, 0x03)   // would be 1-screen-upper on VRC4
+        assertThat(mapper.currentMirroring(), equalTo(Mapper.MirroringMode.HORIZONTAL))
+    }
+
+    @Test
+    fun `mirroring falls back to header when no 9000 write has happened`() {
+        val v = Mapper22(build(prgKb = 32, verticalMirroring = true))
+        assertThat(v.currentMirroring(), equalTo(Mapper.MirroringMode.VERTICAL))
+        val h = Mapper22(build(prgKb = 32, verticalMirroring = false))
+        assertThat(h.currentMirroring(), equalTo(Mapper.MirroringMode.HORIZONTAL))
+    }
+
+    // ---- CHR banking + shift quirk ----
+
+    @Test
+    fun `each of the 8 CHR windows selects an independent 1KB bank`() {
+        val mapper = Mapper22(build(prgKb = 32, chrKb = 64))   // 64 distinct 1KB pages
+        // Stamp banks 8..15 into the 8 CHR windows.
+        val groups = listOf(0xB000, 0xB000, 0xC000, 0xC000, 0xD000, 0xD000, 0xE000, 0xE000)
+        for (window in 0..7) {
+            val group = groups[window]
+            val pairOffset = (window % 2) * 2
+            val bankValue = window + 8
+            mapper.vrc22write(group, pairOffset + 0, bankValue and 0x0F)
+            mapper.vrc22write(group, pairOffset + 1, (bankValue shr 4) and 0x1F)
+        }
+        for (window in 0..7) {
+            val addr = window * 0x400
+            // VRC2a shift quirk: page index = stored 9-bit value >> 1.
+            val expected = ((window + 8) shr 1) and 0xFF
+            assertThat("window $window", mapper.ppuRead(addr).toUnsignedInt(), equalTo(expected))
+        }
+    }
+
+    @Test
+    fun `CHR high nibble adds bank bits 4-8 before the VRC2a right-shift`() {
+        // With 32 1KB pages (4KB CHR), pick a stored 9-bit bank value >= 16
+        // to exercise the high nibble. After the shift, page 0x15 = 21 -> 10.
+        val mapper = Mapper22(build(prgKb = 32, chrKb = 32))
+        mapper.vrc22write(0xB000, 0, 0x05)       // low nibble for chr0 = 5
+        mapper.vrc22write(0xB000, 1, 0x01)       // high nibble for chr0 = 1 -> stored 0x15
+        // Shift: 0x15 >> 1 = 0x0A. CHR byte[0] was stamped with its 1KB page index,
+        // so ppuRead returns 0x0A.
+        assertThat(mapper.ppuRead(0x0000).toUnsignedInt(), equalTo(0x0A))
+    }
+
+    @Test
+    fun `CHR RAM is writable when chrRom is empty`() {
+        val mapper = Mapper22(build(prgKb = 32, chrKb = 0))   // chrKb=0 means CHR-RAM
+        mapper.ppuWrite(0x0000, 0x77.toSignedByte())
+        assertThat(mapper.ppuRead(0x0000).toUnsignedInt(), equalTo(0x77))
+    }
+
+    // ---- Save / load round-trip ----
+
+    @Test
+    fun `save and load round-trips banking, mirroring, and CHR state`() {
+        val original = Mapper22(build(prgKb = 64, chrKb = 16, verticalMirroring = false))
+        original.vrc22write(0x8000, 0, 3)        // prg0 = 3
+        original.vrc22write(0xA000, 0, 5)        // prg1 = 5
+        original.vrc22write(0x9000, 0, 0x00)     // V mirroring
+        original.vrc22write(0xB000, 0, 0x07)     // chr0 low nibble = 7
+        original.vrc22write(0xB000, 1, 0x01)     // chr0 high nibble = 1 -> stored 0x17
+
+        val bytes = ByteArrayOutputStream().also {
+            original.saveState(DataOutputStream(it))
+        }.toByteArray()
+
+        val restored = Mapper22(build(prgKb = 64, chrKb = 16, verticalMirroring = false))
+        restored.loadState(DataInputStream(ByteArrayInputStream(bytes)))
+
+        assertThat(restored.snapshot(), equalTo(original.snapshot()))
+        assertThat(restored.cpuRead(0x8000).toUnsignedInt(), equalTo(3))
+        assertThat(restored.cpuRead(0xA000).toUnsignedInt(), equalTo(5))
+        assertThat(restored.currentMirroring(), equalTo(Mapper.MirroringMode.VERTICAL))
+        // PPU read applies the shift quirk: 0x17 >> 1 = 0x0B.
+        assertThat(restored.ppuRead(0x0000).toUnsignedInt(), equalTo(0x0B))
+    }
+
+    @Test
+    fun `loadState rejects a mismatched version byte`() {
+        val mapper = Mapper22(build(prgKb = 32))
+        val bogus = ByteArrayOutputStream().also {
+            DataOutputStream(it).writeByte(0xFF)
+        }.toByteArray()
+        try {
+            mapper.loadState(DataInputStream(ByteArrayInputStream(bogus)))
+            assert(false) { "expected IncompatibleSaveStateException" }
+        } catch (e: com.github.alondero.nestlin.SaveState.IncompatibleSaveStateException) {
+            // expected
+        }
+    }
+
+    // ---- Address-pin decode (VRC4b swap) ----
+
+    @Test
+    fun `address-pin decode uses the VRC4b swap (CPU A1→bit0, CPU A0→bit1)`() {
+        // The decode contract: writes at the same $Bxxx group must target the
+        // same CHR register regardless of sub-pin layout. With the VRC4b swap,
+        // the four addresses map to sub 0/2/1/3 respectively, so:
+        //   $B000 → low  nibble (sub 0)
+        //   $B002 → high nibble (sub 1)
+        //   $B001 → low  nibble (sub 2, which is also low nibble of chr1)
+        //   $B003 → high nibble (sub 3, which is also high nibble of chr1)
+        val mapper = Mapper22(build(prgKb = 32, chrKb = 32))
+        mapper.cpuWrite(0xB000, 0x07.toSignedByte())   // sub 0 -> chr0 low  = 7
+        mapper.cpuWrite(0xB002, 0x01.toSignedByte())   // sub 1 -> chr0 high = 1 -> stored 0x17
+        // After shift: 0x17 >> 1 = 0x0B.
+        assertThat("sub 0 must target chr0 low nibble",
+            mapper.ppuRead(0x0000).toUnsignedInt(), equalTo(0x0B))
+
+        // Now overwrite with $B001 — this should land on chr1 low (sub 2),
+        // not chr0. If the swap is wrong, this write would clobber chr0.
+        mapper.cpuWrite(0xB001, 0x05.toSignedByte())   // sub 2 -> chr1 low = 5
+        // chr0 still has stored 0x17 -> ppuRead returns 0x0B.
+        assertThat("\$B001 must NOT clobber chr0 (proves the swap)",
+            mapper.ppuRead(0x0000).toUnsignedInt(), equalTo(0x0B))
+        // chr1 now has stored low=5, high=0 -> stored 0x05 -> shift -> 0x02.
+        assertThat("\$B001 must set chr1 low nibble",
+            mapper.ppuRead(0x0400).toUnsignedInt(), equalTo(0x02))
+    }
+}


### PR DESCRIPTION
## Summary

Thin VRC4 subclass for Konami's stripped-down VRC4-family chip (iNES mapper 22):

- **5-bit PRG bank selects** at $8000/$A000 (no $9002 swap mode)
- **8×1KB CHR banking** at $B000-$E003 with the VRC2a >>1 shift quirk
- **V/H mirroring** at $9000 only (bit 1 ignored)
- **No IRQ counter** (no $Fxxx), **no WRAM** ($6000-$7FFF open bus)
- **Address-pin decode:** VRC4b swap (CPU A1→sub0, A0→sub1) — same as Mapper 25

## Verification

**Visual oracle — TwinBee 3 (the only VRC2a title locally) vs Mesen 2.1.1:**

`./gradlew testMesenComparison --tests Mapper22RegressionTest`
→ **CHR banks: MATCH** (8KB across all 8 1KB windows at frame 60)

**Boot oracle:**

`./gradlew bootcheck -Prom='S:/Media/Nintendo NES/Games/TwinBee 3 - Poko Poko Daimaou (Japan) (Translated En).nes' -Pframes=120` → **PASS**
- loaded: true (Mapper22 dispatched)
- renderingEnabledBy: 8 (very early)
- maxNonBlankRatio: 0.5623 (56% non-blank pixels)
- distinctPrgStates: 4 (banks move during boot)
- distinctChrStates: 3 (CHR banking working)
- nmiCount: 118, irqCount: 0 (VRC2a has no IRQ, correct)

**Full unit suite:** `./gradlew test` — 1278 tests, 0 failed, 2 skipped.

## Issue spec deviations (wiki+Mesen2 oracle won every time)

The GitHub issue text was wrong on four points. Per the new-mapper skill's oracle ordering (nesdev wiki → Mesen2 source → issue spec), the wiki + Mesen2's `VRC2_4.h` win:

| Point | Issue text | Wiki + Mesen2 | Decision |
|---|---|---|---|
| Address-pin decode | "matches VRC4a (A0→sub0, A1→sub1)" | VRC4b swap (A1→sub0, A0→sub1) | Wiki wins |
| CHR banking | "No CHR banking" | 8×1KB banking at $B000-$E003 | Wiki wins |
| Mirroring | "Hardware-fixed" | V/H at $9000 (bit 1 ignored) | Wiki wins |
| Boku Dracula-kun | Listed as VRC2a game | Mapper 23 (VRC4) | Wiki wins |

## Files

- **NEW** `src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper22.kt` — 120-line VRC4 subclass
- **NEW** `src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper22Test.kt` — 22 unit tests
- **NEW** `src/test/kotlin/com/github/alondero/nestlin/compare/Mapper22RegressionTest.kt` — Mesen2 byte-compare regression
- **MODIFIED** `src/main/kotlin/com/github/alondero/nestlin/gamepak/Vrc4.kt` — `prg0`/`prg1`/`mirroringMode`/`writeChr` promoted from `private` to `protected` (documented in KDoc; minimal blast radius)
- **MODIFIED** `src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt` — added `22 -> Mapper22(this)` dispatch arm
- **MODIFIED** `MAPPER_SUPPORT.md` — `## Mapper 22 (Konami VRC2a)` section + active-list line at top

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)