### PR TITLE
Fix 7 high-severity APU/PPU/mapper accuracy bugs

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/Apu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Apu.kt
@@ -90,8 +90,11 @@ class Apu(private val dmaPort: DmaPort) {
     fun tick() {
         cpuCycleCounter++
 
-        // Check frame counter sequencing (~7,457 cycles per quarter frame)
-        val frameResult = frameCounter.tick(cpuCycleCounter)
+        // Check frame counter sequencing (~7,457 cycles per quarter frame).
+        // The frame counter owns its own cycle reference (reset on $4017 writes),
+        // so it is driven purely by the per-cycle tick, not the free-running
+        // cpuCycleCounter below (which survives for the APU-clock /2 divider).
+        val frameResult = frameCounter.tick()
 
         if (frameResult.quarterFrame) clockQuarterFrame()
 
@@ -249,10 +252,11 @@ class Apu(private val dmaPort: DmaPort) {
      * Side-effect-free read of an APU register (issue #168, Memory Editor).
      *
      * `$4015` is the only APU register with a read side effect: [handleStatusRead]
-     * clears the frame-counter IRQ and the DMC IRQ. [peekRegisterRead] computes the
-     * identical status byte but leaves both IRQ flags pending, so a debug viewer
-     * polling `$4015` can never swallow an interrupt the game is waiting on. Every
-     * other register is plain backing storage, read straight from [apuMemory].
+     * clears the frame-counter IRQ (the DMC IRQ is acknowledged by a *write*, not a
+     * read). [peekRegisterRead] computes the identical status byte but leaves the
+     * frame IRQ flag pending, so a debug viewer polling `$4015` can never swallow an
+     * interrupt the game is waiting on. Every other register is plain backing
+     * storage, read straight from [apuMemory].
      */
     fun peekRegisterRead(address: Int): Byte = when (address) {
         0x15 -> peekStatusRead()
@@ -275,6 +279,10 @@ class Apu(private val dmaPort: DmaPort) {
 
     private fun handleStatusWrite(value: Byte) {
         apuMemory.status = value
+
+        // Writing $4015 clears the DMC interrupt flag (nesdev APU $4015). This is
+        // the correct ack path for a DMC IRQ — reading $4015 must NOT clear it.
+        dmc.clearIrq()
 
         // Enable/disable channels based on register bits
         if (!value.isBitSet(0)) {
@@ -318,9 +326,10 @@ class Apu(private val dmaPort: DmaPort) {
         if (frameIrq) status = status.setBit(6)
         if (dmc.irqPending) status = status.setBit(7)
 
-        // Reading $4015 clears IRQ flags
+        // Reading $4015 clears ONLY the frame interrupt flag. The DMC interrupt
+        // flag is explicitly NOT cleared by a read — it is acknowledged by a
+        // write to $4015 (see handleStatusWrite). nesdev APU $4015.
         frameIrq = false
-        dmc.clearIrq()
 
         return status
     }

--- a/src/main/kotlin/com/github/alondero/nestlin/apu/FrameCounter.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/apu/FrameCounter.kt
@@ -24,15 +24,27 @@ class FrameCounter {
 
     data class Result(val quarterFrame: Boolean, val halfFrame: Boolean, val irq: Boolean)
 
-    fun tick(cpuCycles: Int): Result {
+    /**
+     * Advance the frame sequencer by one CPU cycle and return the clocks it emits.
+     *
+     * The comparison is made against [cyclesSinceReset] — the sequencer's *own*
+     * cycle reference — NOT an absolute CPU-cycle counter. This is what makes a
+     * `$4017` write restart the sequence cleanly (see [write4017]): the standard
+     * per-frame re-sync idiom resets [cyclesSinceReset] to 0, so the next quarter
+     * clock lands 7457 cycles *after the write* instead of dumping every
+     * already-passed step at once.
+     */
+    fun tick(): Result {
         var quarterFrameClock = false
         var halfFrameClock = false
         var irq = false
 
+        cyclesSinceReset++
+
         val sequence = if (mode == Mode.FOUR_STEP) fourStepSequence else fiveStepSequence
 
         // Check each step in the sequence and fire if we've reached that cycle
-        while (step < sequence.size && cpuCycles >= sequence[step]) {
+        while (step < sequence.size && cyclesSinceReset >= sequence[step]) {
             when (step) {
                 0 -> {
                     // Step 0: Quarter frame (envelope & linear counter)
@@ -48,11 +60,17 @@ class FrameCounter {
                     quarterFrameClock = true
                 }
                 3 -> {
-                    // Step 3: End of frame (quarter & half frame)
-                    quarterFrameClock = true
-                    halfFrameClock = true
-                    if (mode == Mode.FOUR_STEP && !irqInhibit) {
-                        irq = true
+                    // Step 3: In 4-step mode this is the end of frame (quarter +
+                    // half + frame IRQ). In 5-step mode this slot is EMPTY — the
+                    // quarter+half moves to step 4. Firing here in 5-step mode
+                    // over-clocks envelopes/length by 25-50% (nesdev APU Frame
+                    // Counter).
+                    if (mode == Mode.FOUR_STEP) {
+                        quarterFrameClock = true
+                        halfFrameClock = true
+                        if (!irqInhibit) {
+                            irq = true
+                        }
                     }
                 }
                 4 -> {
@@ -65,9 +83,9 @@ class FrameCounter {
         }
 
         // Reset at end of sequence
-        val maxCycles = maxCycles()
-        if (cpuCycles >= maxCycles) {
+        if (cyclesSinceReset >= maxCycles()) {
             step = 0
+            cyclesSinceReset = 0
         }
 
         return Result(quarterFrameClock, halfFrameClock, irq)

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper1.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper1.kt
@@ -43,37 +43,39 @@ class Mapper1(private val gamePak: GamePak) : Mapper {
             return prgRam[address - 0x6000]
         }
         if (address < 0x8000) return 0
-        
+
         val prgMode = controlReg.toUnsignedInt() shr 2 and 0x03
+        val lowWindow = address < 0xC000
+        val offset = if (lowWindow) address - 0x8000 else address - 0xC000
+
+        // SUROM/SXROM: 512KB boards address only 256KB with the 4-bit PRG register;
+        // the active 256KB half (PRG A18) is selected by bit 4 of the CHR bank-0
+        // register. The outer bank applies to the switchable AND the fixed windows,
+        // and the fixed "last bank" is the last 16KB of the *current* half. Guarded
+        // on PRG size so ordinary <=256KB games (whose CHR bit 4 legitimately selects
+        // a CHR bank) are unaffected. See nesdev "MMC1" — SUROM/SXROM.
+        val is512k = prgBankCount > 16
+        val outer = if (is512k) (chrBank0 and 0x10) else 0   // 16KB-bank units: 0 or 16
+        val prgLow = prgBank and 0x0F
+
         val bank = when (prgMode) {
             0, 1 -> {
-                // 32KB mode: both 16KB banks use the same bank number (lower's bit 0 ignored)
-                val bankBase = (prgBank and 0xFE)
-                val offset = address - 0x8000
-                if (offset < 0x4000) {
-                    programRom[(bankBase * 0x4000 + offset) % programRom.size]
-                } else {
-                    programRom[((bankBase + 1) * 0x4000 + (offset - 0x4000)) % programRom.size]
-                }
+                // 32KB mode: both 16KB windows switch together (low bit ignored).
+                val base = outer or (prgBank and 0x0E)
+                if (lowWindow) base else base + 1
             }
             2 -> {
-                // Mode 2: $8000-$BFFF fixed to bank 0, $C000-$FFFF switchable
-                if (address < 0xC000) {
-                    programRom[(address - 0x8000) % minOf(0x4000, programRom.size)]
-                } else {
-                    programRom[(prgBank * 0x4000 + (address - 0xC000)) % programRom.size]
-                }
+                // Mode 2: $8000-$BFFF fixed to the first bank of the half, $C000 switchable.
+                if (lowWindow) outer else (outer or prgLow)
             }
             else /* 3 */ -> {
-                // Mode 3 (default): $8000-$BFFF switchable, $C000-$FFFF fixed to last bank
-                if (address < 0xC000) {
-                    programRom[(prgBank * 0x4000 + (address - 0x8000)) % programRom.size]
-                } else {
-                    programRom[((prgBankCount - 1) * 0x4000 + (address - 0xC000)) % programRom.size]
-                }
+                // Mode 3 (default): $8000 switchable, $C000 fixed to the last bank
+                // of the current half (or the whole-ROM last bank on <=256KB boards).
+                if (lowWindow) (outer or prgLow)
+                else if (is512k) (outer or 0x0F) else (prgBankCount - 1)
             }
         }
-        return bank
+        return programRom[(bank * 0x4000 + offset) % programRom.size]
     }
 
     override fun cpuWrite(address: Int, value: Byte) {

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper153.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper153.kt
@@ -37,6 +37,20 @@ class Mapper153(private val gamePak: GamePak) : Mapper {
     private val prgBankCount = programRom.size / 0x4000  // 16KB units
     private val chrMask = if (chrRom.isEmpty()) 0 else chrRom.size - 1
 
+    // CHR bus: the canonical mapper-153 board (Famicom Jump II) is CHR-RAM. When
+    // the iNES header reports 0 KB CHR, expose 8 KB of writable CHR-RAM; otherwise
+    // the eight CHR bank registers drive banked CHR-ROM reads (the synthetic /
+    // CHR-ROM configuration exercised by the unit tests).
+    private val chrMemory: ChrMemory = ChrMemory.default(chrRom)
+
+    // 512KB PRG (Famicom Jump II) can't be addressed by the 4-bit $8 register
+    // alone. On mapper 153 the eight "CHR bank" registers ($0-$7) are repurposed:
+    // their bit 0 is latched as PRG A18, selecting the active 256KB half. The outer
+    // bank applies to the switchable AND the fixed windows. Only meaningful on a
+    // 512KB board (nesdev "INES Mapper 153").
+    private val is512kPrg = prgBankCount > 16
+    private var prgOuterBank = 0   // 0 or 1 (bit 0 latched from a $0-$7 write)
+
     // 14 FCG registers.
     private val regs = IntArray(14)
 
@@ -58,18 +72,25 @@ class Mapper153(private val gamePak: GamePak) : Mapper {
 
     override fun isIrqPending(): Boolean = irqPending
 
+    /** PRG A18 as a 16KB-bank offset: 0 or 16, only on a 512KB board. */
+    private fun prgOuter16(): Int = if (is512kPrg) (prgOuterBank shl 4) else 0
+
     override fun cpuRead(address: Int): Byte {
         if (address in 0x6000..0x7FFF) {
             // $D bit 7 selects the source.
             return if ((regs[0xD] and 0x80) == 0) {
                 prgRam[address - 0x6000]
             } else {
-                val bank = regs[0xD] and 0x0F
+                val bank = prgOuter16() or (regs[0xD] and 0x0F)
                 programRom[(bank * 0x4000 + (address - 0x6000)) % programRom.size]
             }
         }
         if (address < 0x8000) return 0
-        val bank = if (address < 0xC000) (regs[0x8] and 0x0F) else (prgBankCount - 1)
+        val bank = when {
+            address < 0xC000 -> prgOuter16() or (regs[0x8] and 0x0F)  // switchable
+            is512kPrg -> prgOuter16() or 0x0F                          // fixed: last 16KB of the half
+            else -> prgBankCount - 1                                   // fixed: whole-ROM last bank
+        }
         val offset = address and 0x3FFF
         return programRom[(bank * 0x4000 + offset) % programRom.size]
     }
@@ -93,7 +114,11 @@ class Mapper153(private val gamePak: GamePak) : Mapper {
 
     private fun writeRegister(reg: Int, v: Int) {
         when (reg) {
-            in 0..7 -> regs[reg] = v and 0xFF
+            in 0..7 -> {
+                regs[reg] = v and 0xFF
+                // Registers $0-$7 additionally latch PRG A18 (bit 0) on 512KB boards.
+                prgOuterBank = v and 0x01
+            }
             0x8 -> regs[0x8] = v and 0x0F
             0x9 -> regs[0x9] = v and 0x03
             0xA -> {
@@ -109,18 +134,17 @@ class Mapper153(private val gamePak: GamePak) : Mapper {
 
     override fun ppuRead(address: Int): Byte {
         val a = address and 0x1FFF
-        if (chrRom.isEmpty()) return 0
+        // CHR-RAM board (Famicom Jump II): reads come from the 8KB CHR-RAM. The
+        // $0-$7 registers are PRG A18 latches here, NOT CHR bank selects.
+        if (chrRom.isEmpty()) return chrMemory.read(a)
         val window = a ushr 10
         val bank = regs[window] and 0xFF
         return chrRom[(bank * 0x0400 + (a and 0x03FF)) and chrMask]
     }
 
     override fun ppuWrite(address: Int, value: Byte) {
-        // CHR-RAM fallback: if the iNES byte says CHR-RAM, allow writes.
-        if (chrRom.isEmpty()) {
-            // No CHR-RAM allocated by default for mapper 153, but accept the
-            // write anyway so games don't crash on stray CHR writes.
-        }
+        // CHR-RAM is writable; CHR-ROM writes are dropped.
+        if (chrRom.isEmpty()) chrMemory.write(address and 0x1FFF, value)
     }
 
     override fun currentMirroring(): Mapper.MirroringMode {
@@ -143,6 +167,9 @@ class Mapper153(private val gamePak: GamePak) : Mapper {
         out.writeInt(irqCounter)
         out.writeBoolean(irqEnable)
         out.writeBoolean(irqPending)
+        out.writeInt(prgOuterBank)
+        // CHR-RAM bytes (0 bytes when CHR-ROM-backed, so CHR-ROM saves are unchanged).
+        chrMemory.serialize(out)
     }
 
     override fun loadState(input: DataInput) {
@@ -152,6 +179,8 @@ class Mapper153(private val gamePak: GamePak) : Mapper {
         irqCounter = input.readInt()
         irqEnable = input.readBoolean()
         irqPending = input.readBoolean()
+        prgOuterBank = input.readInt()
+        chrMemory.deserialize(input)
     }
 
     override fun snapshot(): MapperStateSnapshot {

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper7.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper7.kt
@@ -33,13 +33,14 @@ class Mapper7(private val gamePak: GamePak) : Mapper {
     }
 
     override fun cpuWrite(address: Int, value: Byte) {
-        // Bank switch via $8000-$FFFF
-        // Bits 0-2: PRG bank select (32KB banks)
-        // Bit 3: Mirroring control (0 = lower screen, 1 = upper screen)
+        // Bank switch via $8000-$FFFF. Control byte layout is `xxxM xPPP`:
+        //   bits 0-2: PRG bank select (32KB banks)
+        //   bit 4:    single-screen nametable select (0 = lower, 1 = upper)
+        // The mirroring bit is bit 4 (0x10), NOT bit 3 — matching Mesen/FCEUX.
         if (address in 0x8000..0xFFFF) {
             val valueInt = value.toUnsignedInt()
             prgBank = valueInt and 0x07
-            mirroringBit = (valueInt shr 3) and 0x01
+            mirroringBit = (valueInt shr 4) and 0x01
         }
     }
 

--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/Ppu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/Ppu.kt
@@ -564,9 +564,13 @@ class Ppu(var memory: Memory) {
             var finalPalette = 0
             var usedBackground = false
 
-            // Extract background pixel
+            // Extract background pixel. Honor PPUMASK background-enable (bit 3):
+            // with the background layer disabled it outputs the backdrop for every
+            // pixel, independent of the sprite-enable bit. Also honor the left-8px
+            // background clip (bit 1).
+            val showBackground = memory.ppuAddressedMemory.mask.showBackground()
             val showBgLeft = memory.ppuAddressedMemory.mask.backgroundInLeftmost8px()
-            val pixelValueVisible = if (x < 8 && !showBgLeft) 0 else pixelValue
+            val pixelValueVisible = if (!showBackground || (x < 8 && !showBgLeft)) 0 else pixelValue
 
             val paletteAddr = if (pixelValueVisible == 0) {
                 0x3F00  // Universal background color
@@ -580,9 +584,13 @@ class Ppu(var memory: Memory) {
 
 
 
-            // Check sprites (in order, first non-transparent sprite wins)
+            // Check sprites (in order, first non-transparent sprite wins). Honor
+            // PPUMASK sprite-enable (bit 4): with sprites disabled, no sprite pixel
+            // composites AND — because sprite-0 hit detection lives inside this loop
+            // and requires an opaque background pixel (`usedBackground`) — the hit
+            // correctly needs BOTH layers enabled (nesdev PPU sprite-0 hit).
             val showSpritesLeft = memory.ppuAddressedMemory.mask.spritesInLeftmost8px()
-            for (sprite in activeSpriteBuffer) {
+            if (memory.ppuAddressedMemory.mask.showSprites()) for (sprite in activeSpriteBuffer) {
                 // Skip if clipping leftmost 8px
                 val pixelX = cycle - 1
                 if (pixelX < 8 && !showSpritesLeft) continue

--- a/src/test/kotlin/com/github/alondero/nestlin/apu/ApuStatusIrqTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/apu/ApuStatusIrqTest.kt
@@ -1,0 +1,61 @@
+package com.github.alondero.nestlin.apu
+
+import com.github.alondero.nestlin.Apu
+import com.github.alondero.nestlin.Memory
+import com.github.alondero.nestlin.isBitSet
+import com.github.alondero.nestlin.toSignedByte
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+
+/**
+ * `$4015` status-register IRQ acknowledge semantics (nesdev APU $4015).
+ *
+ * The two IRQ flags are acknowledged on DIFFERENT accesses:
+ *  - The **frame** interrupt flag is cleared by *reading* `$4015`.
+ *  - The **DMC** interrupt flag is cleared by *writing* `$4015` — reading
+ *    `$4015` must leave it untouched.
+ *
+ * The old code had these swapped for DMC: it cleared the DMC flag on read and
+ * never cleared it on write, so a game whose IRQ handler reads `$4015` to
+ * identify the source would silently ack (and lose) a DMC IRQ, while a write
+ * that is supposed to ack it did nothing.
+ */
+class ApuStatusIrqTest {
+
+    private fun newApu(): Apu = Memory.createWithApu().second
+
+    @Test
+    fun `reading $4015 does NOT clear the DMC interrupt flag`() {
+        val apu = newApu()
+        apu.dmc.irqEnabled = true
+        apu.dmc.irqPending = true
+
+        val status = apu.handleRegisterRead(0x15)
+        assertTrue(status.isBitSet(7), "DMC IRQ must be reported in status bit 7")
+        assertTrue(apu.dmc.irqPending, "reading \$4015 must NOT clear the DMC IRQ")
+    }
+
+    @Test
+    fun `writing $4015 clears the DMC interrupt flag even when enabling the channel`() {
+        val apu = newApu()
+        apu.dmc.irqEnabled = true
+        apu.dmc.irqPending = true
+
+        // bit 4 set = enable DMC. The clear must come from the write itself, not
+        // from the channel-disable path (which would mask the bug).
+        apu.handleRegisterWrite(0x15, 0x10.toSignedByte())
+        assertFalse(apu.dmc.irqPending, "writing \$4015 must clear the DMC IRQ")
+    }
+
+    @Test
+    fun `reading $4015 still clears the frame interrupt flag`() {
+        val apu = newApu()
+        // Drive the 4-step sequencer to its frame-IRQ boundary (cycle 29829).
+        repeat(29829) { apu.tick() }
+        assertTrue(apu.isIrqPending(), "frame IRQ should be pending at the sequence end")
+
+        val status = apu.handleRegisterRead(0x15)
+        assertTrue(status.isBitSet(6), "frame IRQ must be reported in status bit 6")
+        assertFalse(apu.isIrqPending(), "reading \$4015 must clear the frame IRQ")
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/apu/FrameCounterTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/apu/FrameCounterTest.kt
@@ -1,0 +1,97 @@
+package com.github.alondero.nestlin.apu
+
+import com.github.alondero.nestlin.Region
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+
+/**
+ * Frame-counter (frame sequencer) regressions.
+ *
+ * Two hardware-accuracy bugs are pinned here:
+ *
+ *  1. A `$4017` write restarts the sequencer's *own* cycle reference. Before the
+ *     fix, `tick()` compared against an absolute CPU-cycle counter that was never
+ *     reset on the write, so a mid-frame `$4017` write (the standard per-frame
+ *     re-sync idiom) made the next tick fire every already-passed step at once —
+ *     three quarter-frame and two half-frame clocks back-to-back.
+ *
+ *  2. In 5-step mode the 4th step (index 3, cycle 29829 on NTSC) is an *empty*
+ *     slot; only step 4 (37281) clocks quarter+half. The old code reused the
+ *     4-step branch and wrongly clocked quarter+half at step 3.
+ */
+class FrameCounterTest {
+
+    private fun advanceTo(fc: FrameCounter, cycles: Int): FrameCounter.Result {
+        var last = FrameCounter.Result(false, false, false)
+        repeat(cycles) { last = fc.tick() }
+        return last
+    }
+
+    // ---- Bug 1: $4017 write restarts the sequencer reference clock ----
+
+    @Test
+    fun `quarter frame fires 7457 cycles after reset, not at an absolute boundary`() {
+        val fc = FrameCounter().apply { region = Region.NTSC; mode = FrameCounter.Mode.FOUR_STEP }
+        // 7456 ticks: no quarter yet.
+        repeat(7456) { assertFalse(fc.tick().quarterFrame, "premature quarter clock") }
+        // 7457th tick: the step-0 quarter clock.
+        assertTrue(fc.tick().quarterFrame, "quarter clock at cycle 7457")
+    }
+
+    @Test
+    fun `a $4017 write mid-frame restarts the sequence and does NOT burst-fire`() {
+        val fc = FrameCounter().apply { region = Region.NTSC; mode = FrameCounter.Mode.FOUR_STEP }
+        // Run well past three step boundaries (past 22371).
+        advanceTo(fc, 25000)
+        // Re-sync the frame counter, exactly as a game's NMI handler does every frame.
+        fc.write4017(0x00.toByte())  // 4-step, IRQ enabled
+
+        // The very next tick must NOT dump all the already-passed steps at once.
+        val next = fc.tick()
+        assertFalse(next.quarterFrame, "spurious quarter clock immediately after \$4017 write")
+        assertFalse(next.halfFrame, "spurious half clock immediately after \$4017 write")
+
+        // The first real quarter clock is 7457 cycles *after the write* (we already
+        // spent 1 tick above, so 7456 more).
+        repeat(7455) { assertFalse(fc.tick().quarterFrame, "premature quarter after re-sync") }
+        assertTrue(fc.tick().quarterFrame, "quarter clock 7457 cycles after \$4017 write")
+    }
+
+    // ---- Bug 2: 5-step mode's empty 4th step ----
+
+    @Test
+    fun `four-step mode clocks quarter and half at the final step with IRQ`() {
+        val fc = FrameCounter().apply { region = Region.NTSC; mode = FrameCounter.Mode.FOUR_STEP }
+        val r = advanceTo(fc, 29829)  // step 3 boundary
+        assertTrue(r.quarterFrame, "4-step step-3 quarter")
+        assertTrue(r.halfFrame, "4-step step-3 half")
+        assertTrue(r.irq, "4-step step-3 frame IRQ")
+    }
+
+    @Test
+    fun `five-step mode does not clock anything at the empty fourth step`() {
+        val fc = FrameCounter().apply { region = Region.NTSC; mode = FrameCounter.Mode.FIVE_STEP }
+        val r = advanceTo(fc, 29829)  // the empty slot in 5-step mode
+        assertFalse(r.quarterFrame, "5-step step-3 must be silent")
+        assertFalse(r.halfFrame, "5-step step-3 must be silent")
+        assertFalse(r.irq, "5-step never raises the frame IRQ")
+    }
+
+    @Test
+    fun `five-step mode clocks quarter and half at the fifth step`() {
+        val fc = FrameCounter().apply { region = Region.NTSC; mode = FrameCounter.Mode.FIVE_STEP }
+        val r = advanceTo(fc, 37281)  // step 4 boundary
+        assertTrue(r.quarterFrame, "5-step step-4 quarter")
+        assertTrue(r.halfFrame, "5-step step-4 half")
+        assertFalse(r.irq, "5-step never raises the frame IRQ")
+    }
+
+    @Test
+    fun `five-step mode clocks the linear counter four times per sequence, not five`() {
+        val fc = FrameCounter().apply { region = Region.NTSC; mode = FrameCounter.Mode.FIVE_STEP }
+        var quarters = 0
+        // One full 5-step sequence (wraps at 37282).
+        repeat(37282) { if (fc.tick().quarterFrame) quarters++ }
+        assertEquals(4, quarters, "5-step mode must produce exactly 4 quarter clocks per sequence")
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/apu/PalApuTimingTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/apu/PalApuTimingTest.kt
@@ -29,9 +29,9 @@ class PalApuTimingTest {
         val fc = FrameCounter().apply { region = Region.PAL; mode = FrameCounter.Mode.FOUR_STEP }
 
         // Nothing should fire before the PAL step-0 boundary (8313)...
-        assertFalse(fc.tick(8312).quarterFrame)
-        // ...and the quarter-frame clock fires exactly at it.
-        assertTrue(fc.tick(8313).quarterFrame)
+        repeat(8312) { assertFalse(fc.tick().quarterFrame) }
+        // ...and the quarter-frame clock fires exactly at it (the 8313th cycle).
+        assertTrue(fc.tick().quarterFrame)
     }
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper153Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper153Test.kt
@@ -118,6 +118,39 @@ class Mapper153Test {
         assertThat(mapper.currentMirroring(), equalTo(Mapper.MirroringMode.ONE_SCREEN_UPPER))
     }
 
+    // ---- CHR-RAM board (Famicom Jump II) ----
+
+    @Test
+    fun `header with 0 CHR allocates writable 8KB CHR-RAM`() {
+        val mapper = Mapper153(createTestGamePak(prg16k = 4, chr8k = 0))
+        // Zero-initialised RAM; writes stick and read back.
+        assertThat(mapper.ppuRead(0x0123).toUnsignedInt(), equalTo(0))
+        mapper.ppuWrite(0x0123, 0x5A.toSignedByte())
+        assertThat(mapper.ppuRead(0x0123).toUnsignedInt(), equalTo(0x5A))
+        // A high address in the second half of CHR-RAM too.
+        mapper.ppuWrite(0x1FFF, 0xA5.toSignedByte())
+        assertThat(mapper.ppuRead(0x1FFF).toUnsignedInt(), equalTo(0xA5))
+    }
+
+    // ---- 512KB PRG: CHR-register bit 0 is PRG A18 ----
+
+    @Test
+    fun `512KB PRG uses CHR-register bit 0 as PRG A18 for the switchable window`() {
+        val mapper = Mapper153(createTestGamePak(prg16k = 32, chr8k = 0))  // 512KB, CHR-RAM
+        mapper.cpuWrite(0x6008, 0x02.toSignedByte())   // reg 8 -> low bank 2
+        assertThat("lower half", mapper.cpuRead(0x8000).toUnsignedInt(), equalTo(2))
+        mapper.cpuWrite(0x6000, 0x01.toSignedByte())   // reg 0 bit 0 latches PRG A18 = 1
+        assertThat("upper half", mapper.cpuRead(0x8000).toUnsignedInt(), equalTo(16 + 2))
+    }
+
+    @Test
+    fun `512KB PRG fixes C000 to the last 16KB of the current 256KB half`() {
+        val mapper = Mapper153(createTestGamePak(prg16k = 32, chr8k = 0))
+        assertThat("lower half fixed", mapper.cpuRead(0xC000).toUnsignedInt(), equalTo(15))
+        mapper.cpuWrite(0x6000, 0x01.toSignedByte())   // PRG A18 = 1
+        assertThat("upper half fixed", mapper.cpuRead(0xC000).toUnsignedInt(), equalTo(31))
+    }
+
     // ---- IRQ: 16-bit counter, decremented per CPU cycle ----
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper1SuromTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper1SuromTest.kt
@@ -1,0 +1,84 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.github.alondero.nestlin.testutil.testGamePak
+import com.github.alondero.nestlin.toSignedByte
+import com.github.alondero.nestlin.toUnsignedInt
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * MMC1 512KB SUROM PRG banking (Dragon Warrior III/IV).
+ *
+ * A 512KB MMC1 board can only address 256KB with the 4-bit PRG-bank register;
+ * the fifth PRG address line (A18) that selects the active 256KB half comes from
+ * **bit 4 of the CHR bank-0 register**. That outer bank applies to BOTH the
+ * switchable window and the fixed "last bank" window — the fixed bank is the last
+ * 16KB of the *current* 256KB half, not the last bank of the whole ROM.
+ *
+ * Before the fix, the PRG register was used as a flat 5-bit index and CHR bit 4
+ * was ignored, so the upper 256KB was unreachable and the fixed bank was always
+ * the whole-ROM last bank.
+ *
+ * This behaviour is guarded on PRG size (only 512KB boards), so ordinary MMC1
+ * games whose CHR bit 4 legitimately selects a CHR bank are unaffected.
+ */
+class Mapper1SuromTest {
+
+    /** 512KB PRG (32 × 16KB banks, each stamped with its index), CHR-RAM. */
+    private fun surom(): Mapper1 {
+        val pak = testGamePak {
+            mapper = 1
+            prgKb = 512
+            chrKb = 0
+            stampPrgBanks(windowKb = 16)
+        }
+        return pak.createMapper() as Mapper1
+    }
+
+    /** Drive MMC1's 5-write serial load (LSB first) into the register at [addr]. */
+    private fun write5(m: Mapper1, addr: Int, value: Int) {
+        for (i in 0 until 5) m.cpuWrite(addr, (((value shr i) and 1)).toSignedByte())
+    }
+
+    private fun setControl(m: Mapper1, value: Int) = write5(m, 0x8000, value)   // $8000-$9FFF
+    private fun setChrBank0(m: Mapper1, value: Int) = write5(m, 0xA000, value)  // $A000-$BFFF
+    private fun setPrgBank(m: Mapper1, value: Int) = write5(m, 0xE000, value)   // $E000-$FFFF
+
+    @Test
+    fun `CHR bit 4 selects the 256KB half for the switchable window`() {
+        val m = surom()
+        setControl(m, 0x0C)      // PRG mode 3, 8KB CHR mode
+        setPrgBank(m, 5)
+
+        setChrBank0(m, 0x00)     // outer half 0
+        assertThat("lower half switchable", m.cpuRead(0x8000).toUnsignedInt(), equalTo(5))
+
+        setChrBank0(m, 0x10)     // outer half 1 (PRG A18 = 1)
+        assertThat("upper half switchable", m.cpuRead(0x8000).toUnsignedInt(), equalTo(16 + 5))
+    }
+
+    @Test
+    fun `fixed C000 bank is the last 16KB of the current 256KB half`() {
+        val m = surom()
+        setControl(m, 0x0C)      // PRG mode 3
+        setPrgBank(m, 0)
+
+        setChrBank0(m, 0x00)     // lower half -> fixed = bank 15
+        assertThat("lower half fixed", m.cpuRead(0xC000).toUnsignedInt(), equalTo(15))
+
+        setChrBank0(m, 0x10)     // upper half -> fixed = bank 31
+        assertThat("upper half fixed", m.cpuRead(0xC000).toUnsignedInt(), equalTo(31))
+    }
+
+    @Test
+    fun `every 16KB bank across the full 512KB is reachable`() {
+        val m = surom()
+        setControl(m, 0x0C)      // PRG mode 3, switchable at $8000
+        for (bank in 0 until 32) {
+            setChrBank0(m, (bank shr 4) shl 4)   // outer half from bit 4
+            setPrgBank(m, bank and 0x0F)
+            assertThat("bank $bank", m.cpuRead(0x8000).toUnsignedInt(), equalTo(bank))
+        }
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper7Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper7Test.kt
@@ -1,0 +1,82 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.github.alondero.nestlin.testutil.testGamePak
+import com.github.alondero.nestlin.toSignedByte
+import com.github.alondero.nestlin.toUnsignedInt
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Mapper 7 (AxROM). Control byte layout `xxxM xPPP`:
+ *   - bits 0-2 (`PPP`) select the 32KB PRG bank
+ *   - bit 4 (`M`) selects the single-screen nametable (0 = lower, 1 = upper)
+ *
+ * The mirroring select is **bit 4 (0x10)**, not bit 3 — matching Mesen
+ * (`value & 0x10`) and FCEUX. Reading it from bit 3 flips the nametable on the
+ * wrong write and corrupts scrolling in Battletoads, Cobra Triangle, etc.
+ */
+class Mapper7Test {
+
+    private fun newMapper7(prgKb: Int = 256): Mapper7 {
+        val pak = testGamePak {
+            mapper = 7
+            this.prgKb = prgKb
+            chrKb = 0            // AxROM is CHR-RAM
+            stampPrgBanks(windowKb = 32)
+        }
+        return pak.createMapper() as Mapper7
+    }
+
+    @Test
+    fun `mapper 7 is selected for header mapper 7`() {
+        assertThat(newMapper7() is Mapper7, equalTo(true))
+    }
+
+    @Test
+    fun `PRG bank select uses bits 0-2`() {
+        val m = newMapper7()
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(0))
+        m.cpuWrite(0x8000, 0x03.toSignedByte())
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(3))
+        m.cpuWrite(0x8000, 0x07.toSignedByte())
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(7))
+    }
+
+    @Test
+    fun `default mirroring is single-screen lower`() {
+        assertThat(newMapper7().currentMirroring(), equalTo(Mapper.MirroringMode.ONE_SCREEN_LOWER))
+    }
+
+    @Test
+    fun `bit 4 set selects single-screen upper`() {
+        val m = newMapper7()
+        m.cpuWrite(0x8000, 0x10.toSignedByte())
+        assertThat(m.currentMirroring(), equalTo(Mapper.MirroringMode.ONE_SCREEN_UPPER))
+    }
+
+    @Test
+    fun `bit 4 clear selects single-screen lower`() {
+        val m = newMapper7()
+        m.cpuWrite(0x8000, 0x10.toSignedByte())   // -> upper
+        m.cpuWrite(0x8000, 0x00.toSignedByte())   // -> lower
+        assertThat(m.currentMirroring(), equalTo(Mapper.MirroringMode.ONE_SCREEN_LOWER))
+    }
+
+    /** The key regression: bit 3 must NOT influence mirroring (only bit 4 does). */
+    @Test
+    fun `bit 3 set with bit 4 clear stays single-screen lower`() {
+        val m = newMapper7()
+        m.cpuWrite(0x8000, 0x08.toSignedByte())   // bit 3 set, bit 4 clear
+        assertThat(m.currentMirroring(), equalTo(Mapper.MirroringMode.ONE_SCREEN_LOWER))
+    }
+
+    @Test
+    fun `bank and mirroring decode from independent bit fields`() {
+        val m = newMapper7()
+        // 0x1F = bank 7 (bits 0-2) + mirroring upper (bit 4); bit 3 is a don't-care.
+        m.cpuWrite(0x8000, 0x1F.toSignedByte())
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(7))
+        assertThat(m.currentMirroring(), equalTo(Mapper.MirroringMode.ONE_SCREEN_UPPER))
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuLayerEnableTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuLayerEnableTest.kt
@@ -1,0 +1,83 @@
+package com.github.alondero.nestlin.ppu
+
+import com.github.alondero.nestlin.Memory
+import com.github.alondero.nestlin.isBitSet
+import com.github.alondero.nestlin.toSignedByte
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+
+/**
+ * PPUMASK per-layer enable bits (bit 3 = background, bit 4 = sprites) must be
+ * honored independently by the pixel pipeline.
+ *
+ * The decisive, easily-observed consequence is sprite-0 hit: the hit requires
+ * BOTH background and sprite rendering to be enabled (nesdev PPU: Sprite 0 hits
+ * "will not be triggered ... if background or sprite rendering is disabled").
+ *
+ * Before the fix, the whole pipeline was gated on `showBackground || showSprites`,
+ * so with only one layer enabled the other still rendered and sprite 0 could hit
+ * spuriously.
+ */
+class PpuLayerEnableTest {
+
+    /**
+     * Builds a PPU whose background tile 1 is fully opaque (pixel value 1) across
+     * the whole nametable, with sprite 0 (also opaque tile 1) placed at (100,100)
+     * so it overlaps opaque background — the classic sprite-0-hit condition.
+     */
+    private fun setupOverlap(): Pair<Memory, Ppu> {
+        val memory = Memory()
+        val ppu = Ppu(memory)
+
+        // Pattern table 0, tile 1 = solid pixel-value-1 (low plane 0xFF, high 0x00).
+        val chr = ByteArray(0x2000)
+        for (row in 0 until 8) chr[0x10 + row] = 0xFF.toSignedByte()
+        memory.ppuAddressedMemory.ppuInternalMemory.loadChrRom(chr)
+
+        // Fill nametable 0 with tile index 1 so every background pixel is opaque.
+        for (i in 0 until 0x3C0) memory.ppuAddressedMemory.ppuInternalMemory[0x2000 + i] = 1.toSignedByte()
+
+        // Palette entries (colours are irrelevant to the hit, which keys off pixel value).
+        memory.ppuAddressedMemory.ppuInternalMemory[0x3F01] = 0x30.toSignedByte()
+        memory.ppuAddressedMemory.ppuInternalMemory[0x3F11] = 0x16.toSignedByte()
+
+        // Sprite 0: Y=99 renders on scanline 100, tile 1, attr 0, X=100.
+        with(memory.ppuAddressedMemory.objectAttributeMemory) {
+            this[0] = 99.toSignedByte()
+            this[1] = 1.toSignedByte()
+            this[2] = 0.toSignedByte()
+            this[3] = 100.toSignedByte()
+        }
+        return memory to ppu
+    }
+
+    /** Runs the PPU across the sprite's scanline and reports whether sprite-0 hit ever set. */
+    private fun sprite0Hits(maskRegister: Int): Boolean {
+        val (memory, ppu) = setupOverlap()
+        memory.ppuAddressedMemory.mask.register = maskRegister.toSignedByte()
+        var guard = 300_000
+        while (guard-- > 0 && ppu.currentScanline < 120) {
+            ppu.tick()
+            if (memory.ppuAddressedMemory.status.register.isBitSet(6)) return true
+        }
+        return false
+    }
+
+    private val BACKGROUND = 0b0000_1000
+    private val SPRITES = 0b0001_0000
+
+    @Test
+    fun `sprite-0 hit fires when both background and sprite rendering are enabled`() {
+        assertTrue(sprite0Hits(BACKGROUND or SPRITES), "control: hit must occur with both layers on")
+    }
+
+    @Test
+    fun `sprite-0 hit does NOT fire when sprite rendering is disabled`() {
+        assertFalse(sprite0Hits(BACKGROUND), "no sprite-0 hit with sprites disabled (bit 4 clear)")
+    }
+
+    @Test
+    fun `sprite-0 hit does NOT fire when background rendering is disabled`() {
+        assertFalse(sprite0Hits(SPRITES), "no sprite-0 hit with background disabled (bit 3 clear)")
+    }
+}


### PR DESCRIPTION
APU:
- Frame counter now advances on its own cycle reference (reset on $4017
  writes) instead of comparing against the free-running CPU cycle counter.
  Previously a mid-frame $4017 write (the standard per-frame re-sync idiom)
  made the next tick burst-fire every already-passed step at once.
- 5-step mode no longer clocks quarter+half at the empty 4th step (index 3);
  only step 4 does. Fixes envelopes/length running 25-50% fast in 5-step mode.
- DMC IRQ is now acknowledged by a $4015 write and NOT cleared by a $4015
  read (the two were swapped).

PPU:
- Honor PPUMASK per-layer enable bits independently in the pixel path
  (bit 3 = background, bit 4 = sprites). Sprite-0 hit now requires BOTH
  layers enabled, matching hardware.

Mappers:
- AxROM (7): single-screen nametable select reads control bit 4 (0x10),
  not bit 3. Fixes nametable flips in Battletoads, Cobra Triangle, etc.
- MMC1 (1): 512KB SUROM/SXROM PRG A18 taken from CHR bank-0 bit 4, applied
  to switchable and fixed windows (fixed = last 16KB of the current 256KB
  half). Guarded on PRG size so <=256KB games are unaffected. Reaches the
  upper 256KB of Dragon Warrior III/IV.
- Bandai FCG (153): CHR-register bit 0 latched as PRG A18 for 512KB boards,
  plus 8KB writable CHR-RAM. Fixes Famicom Jump II (was blank + upper PRG
  unreachable).

Each fix ships a failing-first regression test. Full unit suite: 1303 pass,
0 failures (23 Mesen2-oracle tests skip without the oracle).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LdxswBzyCH3nYuJ8yUwY18