### PR TITLE
PPU accuracy/speed fixes: mask layer gating, sprite overflow, greyscale/emphasis, $2007 palette buffer, $2006 fine-Y, Frame IntArray

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/Frame.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/Frame.kt
@@ -1,7 +1,9 @@
 package com.github.alondero.nestlin.ppu
 
 class Frame {
-    val scanlines = Array(size = RESOLUTION_HEIGHT, init = {Array(size = RESOLUTION_WIDTH, init = {0x000000})})
+    // Primitive IntArray rows: an Array<Array<Int>> would box every pixel write
+    // (~61k Integer allocations per frame at 60 fps). Same [y][x] indexing shape.
+    val scanlines = Array(size = RESOLUTION_HEIGHT, init = { IntArray(RESOLUTION_WIDTH) })
 
     operator fun set(x: Int, y: Int, value: Int) {scanlines[y][x] = value}
 

--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/NesPalette.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/NesPalette.kt
@@ -19,8 +19,39 @@ object NesPalette {
     )
 
     /**
+     * Attenuation applied to the two NON-emphasized channels per set emphasis bit —
+     * the standard emulator approximation of the PPU's analog de-emphasis circuit
+     * (the emphasized channel itself is left at full level).
+     */
+    private const val EMPHASIS_ATTENUATION = 0.746
+
+    /**
+     * Precomputed [emphasis 0-7][palette index 0-63] → RGB. Emphasis bit 0 = red,
+     * bit 1 = green, bit 2 = blue (NTSC layout — the PAL red/green swap is the
+     * caller's job, see `Ppu.emphasisBits`). Table lookup keeps the per-pixel cost
+     * at one array index instead of per-pixel floating point.
+     */
+    private val emphasisTable = Array(8) { emphasis ->
+        IntArray(64) { index ->
+            val rgb = colors[index]
+            if (emphasis == 0) rgb else {
+                var r = ((rgb shr 16) and 0xFF).toDouble()
+                var g = ((rgb shr 8) and 0xFF).toDouble()
+                var b = (rgb and 0xFF).toDouble()
+                if (emphasis and 0x1 != 0) { g *= EMPHASIS_ATTENUATION; b *= EMPHASIS_ATTENUATION }
+                if (emphasis and 0x2 != 0) { r *= EMPHASIS_ATTENUATION; b *= EMPHASIS_ATTENUATION }
+                if (emphasis and 0x4 != 0) { r *= EMPHASIS_ATTENUATION; g *= EMPHASIS_ATTENUATION }
+                (r.toInt() shl 16) or (g.toInt() shl 8) or b.toInt()
+            }
+        }
+    }
+
+    /**
      * Get RGB color for a given NES palette index (0-63).
      * Index is masked to 6 bits to handle mirroring.
      */
     fun getRgb(index: Int): Int = colors[index and 0x3F]
+
+    /** RGB for [index] under the given 3-bit colour-emphasis field (PPUMASK bits 5-7). */
+    fun getRgb(index: Int, emphasis: Int): Int = emphasisTable[emphasis and 0x7][index and 0x3F]
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/Ppu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/Ppu.kt
@@ -181,8 +181,7 @@ class Ppu(var memory: Memory) {
             // drawn before, so a mid-frame forced-blank window (e.g. Micro Machines'
             // title-screen palette swap) leaves a frozen "band" of stale tiles.
             // Issue #88 follow-up.
-            val backdropIndex = memory.ppuAddressedMemory.ppuInternalMemory[backdropPaletteAddress()].toUnsignedInt()
-            frame[cycle - 1, scanline] = NesPalette.getRgb(backdropIndex)
+            frame[cycle - 1, scanline] = resolveColor(backdropPaletteAddress())
         }
 
         // VBlank is set at scanline 241, NES dot 1 == Nestlin cycle 0.
@@ -219,6 +218,30 @@ class Ppu(var memory: Memory) {
     }
 
     private fun rendering() = with (memory.ppuAddressedMemory.mask) { showBackground() || showSprites() }
+
+    /**
+     * Final colour for the palette entry at [paletteAddr], with PPUMASK bit 0
+     * (greyscale — masks the index to the grey column $x0) and bits 5-7 (colour
+     * emphasis) applied. Every pixel the PPU emits goes through here so the two
+     * display modifiers affect background, sprites and forced-blank backdrop alike.
+     */
+    private fun resolveColor(paletteAddr: Int): Int {
+        val mask = memory.ppuAddressedMemory.mask
+        var index = memory.ppuAddressedMemory.ppuInternalMemory[paletteAddr].toUnsignedInt()
+        if (mask.greyscale()) index = index and 0x30
+        return NesPalette.getRgb(index, emphasisBits(mask))
+    }
+
+    /**
+     * The 3-bit emphasis field from PPUMASK. On PAL machines the red and green
+     * emphasis bits are swapped relative to NTSC (2C07 wiring difference).
+     */
+    private fun emphasisBits(mask: Mask): Int {
+        val bits = (mask.register.toUnsignedInt() shr 5) and 0x07
+        return if (region == Region.PAL) {
+            (bits and 0x4) or ((bits and 0x1) shl 1) or ((bits and 0x2) shr 1)
+        } else bits
+    }
 
     /**
      * The palette address whose colour the PPU emits for a visible pixel while rendering
@@ -303,11 +326,19 @@ class Ppu(var memory: Memory) {
         val spriteHeight = if (spriteSize == Control.SpriteSize.X_8_16) 16 else 8
 
         for (i in 0 until 64) {
-            if (secondaryOam.size >= 8) break
             val s = oam.getSprite(i)
             val y = s.y
             // NES Y semantics: sprite at Y appears at scanlines Y+1 through Y+spriteHeight
             if (target > y && target <= y + spriteHeight) {
+                if (secondaryOam.size >= 8) {
+                    // A 9th in-range sprite sets PPUSTATUS bit 5 (sprite overflow),
+                    // cleared at pre-render dot 1 alongside the other status flags.
+                    // (The hardware's buggy diagonal-scan false positives/negatives
+                    // are not modelled — only the documented >8-real-sprites case.)
+                    memory.ppuAddressedMemory.status.register =
+                        memory.ppuAddressedMemory.status.register.setBit(5)
+                    break
+                }
                 val tileYOffset = target - y - 1
                 val tileY = if (s.verticalFlip) (spriteHeight - 1) - tileYOffset else tileYOffset
                 secondaryOam.add(SecondaryOamEntry(s, tileY))
@@ -564,9 +595,12 @@ class Ppu(var memory: Memory) {
             var finalPalette = 0
             var usedBackground = false
 
-            // Extract background pixel
+            // Extract background pixel. PPUMASK bit 3 gates the background layer
+            // on its own (independent of bit 4) — a disabled background renders
+            // as pixel value 0 (the backdrop) even while sprites are showing.
+            val showBg = memory.ppuAddressedMemory.mask.showBackground()
             val showBgLeft = memory.ppuAddressedMemory.mask.backgroundInLeftmost8px()
-            val pixelValueVisible = if (x < 8 && !showBgLeft) 0 else pixelValue
+            val pixelValueVisible = if (!showBg || (x < 8 && !showBgLeft)) 0 else pixelValue
 
             val paletteAddr = if (pixelValueVisible == 0) {
                 0x3F00  // Universal background color
@@ -575,14 +609,14 @@ class Ppu(var memory: Memory) {
                 0x3F00 + (paletteIndex shl 2) + pixelValueVisible
             }
 
-            val bgNesColorIndex = memory.ppuAddressedMemory.ppuInternalMemory[paletteAddr].toUnsignedInt()
-            var rgbColor = NesPalette.getRgb(bgNesColorIndex)
+            var rgbColor = resolveColor(paletteAddr)
 
-
-
-            // Check sprites (in order, first non-transparent sprite wins)
+            // Check sprites (in order, first non-transparent sprite wins).
+            // PPUMASK bit 4 gates the sprite layer on its own: with sprites
+            // disabled, no sprite pixels and no sprite-0 hit.
+            val showSprites = memory.ppuAddressedMemory.mask.showSprites()
             val showSpritesLeft = memory.ppuAddressedMemory.mask.spritesInLeftmost8px()
-            for (sprite in activeSpriteBuffer) {
+            if (showSprites) for (sprite in activeSpriteBuffer) {
                 // Skip if clipping leftmost 8px
                 val pixelX = cycle - 1
                 if (pixelX < 8 && !showSpritesLeft) continue
@@ -629,9 +663,7 @@ class Ppu(var memory: Memory) {
             // Look up final color
             if (finalPixel != 0) {
                 // Sprite pixel is visible
-                val spritePaletteAddr = 0x3F10 + (finalPalette shl 2) + finalPixel
-                val spriteNesColorIndex = memory.ppuAddressedMemory.ppuInternalMemory[spritePaletteAddr].toUnsignedInt()
-                rgbColor = NesPalette.getRgb(spriteNesColorIndex)
+                rgbColor = resolveColor(0x3F10 + (finalPalette shl 2) + finalPixel)
             }
 
             frame[x, scanline] = rgbColor

--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/PpuAddressedMemory.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/PpuAddressedMemory.kt
@@ -194,15 +194,19 @@ class PpuAddressedMemory : NmiSource {
             6 -> address
             else /*7*/ -> {
                 val vramAddr = vRamAddress.asAddress() and 0x3FFF
-                val result = data
-                data = ppuInternalMemory[vramAddr]
-                vRamAddress.increment(controller.vramAddressIncrement())
-
-                // Palette reads are not buffered, they return immediately.
-                // However, they still update the buffer with mirrored nametable data (handled above).
+                val result: Byte
                 if (vramAddr >= 0x3F00) {
-                    return data
+                    // Palette reads are not buffered — the entry returns immediately.
+                    // The read buffer is still refilled, but with the NAMETABLE byte
+                    // that sits "underneath" the palette (addr - $1000, the $2Fxx
+                    // mirror), exactly as the real PPU's VRAM fetch does.
+                    result = ppuInternalMemory[vramAddr]
+                    data = ppuInternalMemory[vramAddr - 0x1000]
+                } else {
+                    result = data
+                    data = ppuInternalMemory[vramAddr]
                 }
+                vRamAddress.increment(controller.vramAddressIncrement())
                 result
             }
         }

--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/VramAddress.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/VramAddress.kt
@@ -23,7 +23,10 @@ class VramAddress {
     var fineYScroll = 0 // 3 bits so maximum value is 7 - wraps to coarseY if overflows
 
     fun setUpper7Bits(bits: Byte) {
-        fineYScroll = (fineYScroll and 0x04) or ((bits.toUnsignedInt() shr 4) and 0x03)
+        // Hardware forces bit 14 of t (fine Y bit 2) to ZERO on the first $2006
+        // write — only fine Y bits 0-1 arrive in the written byte. Preserving a
+        // stale bit 2 from an earlier $2005 write offsets rendering by 4 rows.
+        fineYScroll = (bits.toUnsignedInt() shr 4) and 0x03
         horizontalNameTable = bits.isBitSet(2)
         verticalNameTable = bits.isBitSet(3)
         coarseYScroll = (coarseYScroll and 0x07) or ((bits.toUnsignedInt() and 0x03) shl 3)

--- a/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuAddressedMemoryTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuAddressedMemoryTest.kt
@@ -115,13 +115,15 @@ class PpuAddressedMemoryTest {
     }
 
     @Test
-    fun `setUpper7Bits preserves fine Y high bit`() {
+    fun `setUpper7Bits clears fine Y high bit`() {
         addressedMemory.tempVRamAddress.fineYScroll = 0b100
 
-        // High byte write should update fineY low bits but preserve bit 2.
+        // First $2006 write: t bit 14 (fine Y bit 2) is forced to ZERO on hardware
+        // (the "t: X...... ........ = 0" line in the NESdev register table above) —
+        // only fine Y bits 0-1 arrive in the written byte.
         addressedMemory[6] = 0b00110000.toSignedByte()
 
-        assertThat(addressedMemory.tempVRamAddress.fineYScroll, equalTo(0b111))
+        assertThat(addressedMemory.tempVRamAddress.fineYScroll, equalTo(0b011))
     }
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuDataReadBufferTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuDataReadBufferTest.kt
@@ -1,0 +1,39 @@
+package com.github.alondero.nestlin.ppu
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * `$2007` read-buffer semantics for palette addresses (NESdev "PPUDATA"):
+ * a read in $3F00-$3FFF returns the palette entry IMMEDIATELY, but the internal
+ * read buffer is filled with the NAMETABLE byte that would sit at that address
+ * with A13 dropped (addr - $1000, i.e. the $2F00-mirror "underneath" the palette).
+ * Nestlin filled the buffer with the palette value instead, so the first
+ * post-palette read of ordinary VRAM returned palette garbage.
+ */
+class PpuDataReadBufferTest {
+
+    private fun setVramAddress(ppu: PpuAddressedMemory, addr: Int) {
+        ppu[6] = ((addr shr 8) and 0x3F).toByte()
+        ppu[6] = (addr and 0xFF).toByte()
+    }
+
+    @Test
+    fun `palette read fills the buffer with the nametable byte underneath`() {
+        val ppu = PpuAddressedMemory()
+        // The nametable byte "under" $3F00 is at $2F00 (mirrored into the NT RAM).
+        ppu.ppuInternalMemory[0x2F00] = 0xAB.toByte()
+        ppu.ppuInternalMemory[0x3F00] = 0x21.toByte()
+
+        setVramAddress(ppu, 0x3F00)
+        val paletteValue = ppu[7]
+        assertThat("palette returned immediately", paletteValue, equalTo(0x21.toByte()))
+
+        // Point somewhere else and read: the FIRST read returns the buffer,
+        // which must hold the nametable byte from under the palette — not $21.
+        setVramAddress(ppu, 0x2000)
+        val buffered = ppu[7]
+        assertThat("buffer held nametable-under-palette", buffered, equalTo(0xAB.toByte()))
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuGreyscaleEmphasisTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuGreyscaleEmphasisTest.kt
@@ -1,0 +1,81 @@
+package com.github.alondero.nestlin.ppu
+
+import com.github.alondero.nestlin.Memory
+import com.github.alondero.nestlin.ui.FrameListener
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * PPUMASK bit 0 (greyscale) and bits 5-7 (colour emphasis) were decoded by [Mask]
+ * but never applied to output pixels. Greyscale masks the palette index to the
+ * grey column ($00/$10/$20/$30); each emphasis bit attenuates the OTHER two
+ * colour channels (the standard emulator approximation of the PPU's analog
+ * de-emphasis).
+ *
+ * Both tests drive the forced-blank backdrop path (rendering disabled) because it
+ * is the simplest pixel-producing path and shares the same colour-resolution code
+ * as the rendering path.
+ */
+class PpuGreyscaleEmphasisTest {
+
+    private val backdropIndex = 0x21 // a saturated blue — distinct from its grey column ($20)
+
+    private fun runOneFrame(ppu: Ppu): Frame {
+        var captured: Frame? = null
+        ppu.addFrameListener(object : FrameListener {
+            override fun frameUpdated(frame: Frame) { captured = frame }
+        })
+        var guard = 400_000
+        while (captured == null && guard-- > 0) ppu.tick()
+        return captured ?: error("PPU did not complete a frame")
+    }
+
+    @Test
+    fun `greyscale bit masks the palette index to the grey column`() {
+        val memory = Memory()
+        val ppu = Ppu(memory)
+        memory.ppuAddressedMemory.ppuInternalMemory[0x3F00] = backdropIndex.toByte()
+        memory.ppuAddressedMemory.mask.register = 0b0000_0001.toByte() // greyscale, rendering off
+
+        val frame = runOneFrame(ppu)
+
+        // $21 & $30 = $20 — the greyscale column entry for that row.
+        assertThat(frame.scanlines[120][128], equalTo(NesPalette.getRgb(0x20)))
+    }
+
+    @Test
+    fun `red emphasis attenuates green and blue channels`() {
+        val memory = Memory()
+        val ppu = Ppu(memory)
+        memory.ppuAddressedMemory.ppuInternalMemory[0x3F00] = backdropIndex.toByte()
+        memory.ppuAddressedMemory.mask.register = 0b0010_0000.toByte() // red emphasis, rendering off
+
+        val frame = runOneFrame(ppu)
+        val pixel = frame.scanlines[120][128]
+        val base = NesPalette.getRgb(backdropIndex)
+
+        val r = (pixel shr 16) and 0xFF
+        val g = (pixel shr 8) and 0xFF
+        val b = pixel and 0xFF
+        val baseR = (base shr 16) and 0xFF
+        val baseG = (base shr 8) and 0xFF
+        val baseB = base and 0xFF
+
+        assertThat("red channel unchanged", r, equalTo(baseR))
+        assertThat("green attenuated", g < baseG, equalTo(true))
+        assertThat("blue attenuated", b < baseB, equalTo(true))
+    }
+
+    @Test
+    fun `no greyscale or emphasis leaves the palette colour untouched`() {
+        val memory = Memory()
+        val ppu = Ppu(memory)
+        memory.ppuAddressedMemory.ppuInternalMemory[0x3F00] = backdropIndex.toByte()
+        memory.ppuAddressedMemory.mask.register = 0
+
+        val frame = runOneFrame(ppu)
+
+        assertThat(frame.scanlines[120][128], equalTo(NesPalette.getRgb(backdropIndex)))
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuMaskLayerGatingTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuMaskLayerGatingTest.kt
@@ -1,0 +1,90 @@
+package com.github.alondero.nestlin.ppu
+
+import com.github.alondero.nestlin.Memory
+import com.github.alondero.nestlin.ui.FrameListener
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * PPUMASK bits 3 (show background) and 4 (show sprites) gate their layers
+ * INDIVIDUALLY on hardware. Nestlin treated "either bit set" as "render both
+ * layers": a game running sprites-only (bit 4) still had its background tiles
+ * scanned out, and a game running background-only (bit 3) still had sprites
+ * composited on top.
+ */
+class PpuMaskLayerGatingTest {
+
+    private val backdropIndex = 0x21   // blue
+    private val bgColorIndex = 0x16    // red
+    private val spriteColorIndex = 0x2A // green
+
+    /** 8KB CHR: tile 0 solid pixel-value 3, tile 1 solid pixel-value 3. */
+    private fun solidChr(): ByteArray {
+        val chr = ByteArray(0x2000)
+        for (tile in 0..1) {
+            for (row in 0..7) {
+                chr[tile * 16 + row] = 0xFF.toByte()      // low plane
+                chr[tile * 16 + 8 + row] = 0xFF.toByte()  // high plane
+            }
+        }
+        return chr
+    }
+
+    private fun setUpPpu(): Pair<Memory, Ppu> {
+        val memory = Memory()
+        val ppu = Ppu(memory)
+        val mem = memory.ppuAddressedMemory.ppuInternalMemory
+        mem.loadChrRom(solidChr())
+        // Fill the first nametable with tile 0 (attributes stay 0 → bg palette 0).
+        for (i in 0 until 960) mem[0x2000 + i] = 0
+        mem[0x3F00] = backdropIndex.toByte()
+        mem[0x3F03] = bgColorIndex.toByte()      // bg palette 0, pixel value 3
+        mem[0x3F13] = spriteColorIndex.toByte()  // sprite palette 0, pixel value 3
+        // OAM is zeroed at construction: 64 sprites at y=0, tile 0, x=0 —
+        // they cover scanlines 1-8 at columns ~1-8.
+        return memory to ppu
+    }
+
+    private fun runOneFrame(ppu: Ppu): Frame {
+        var captured: Frame? = null
+        ppu.addFrameListener(object : FrameListener {
+            override fun frameUpdated(frame: Frame) { captured = frame }
+        })
+        var guard = 400_000
+        while (captured == null && guard-- > 0) ppu.tick()
+        return captured ?: error("PPU did not complete a frame")
+    }
+
+    @Test
+    fun `sprites-only mode does not render background tiles`() {
+        val (memory, ppu) = setUpPpu()
+        // Show sprites + sprites-in-leftmost-8px; background OFF.
+        memory.ppuAddressedMemory.mask.register = 0b0001_0100.toByte()
+
+        val frame = runOneFrame(ppu)
+
+        // Mid-screen, far from any sprite: must be the backdrop, not the bg tile colour.
+        assertThat("pixel (128,120)", frame.scanlines[120][128], equalTo(NesPalette.getRgb(backdropIndex)))
+    }
+
+    @Test
+    fun `background-only mode does not render sprites`() {
+        val (memory, ppu) = setUpPpu()
+        // Put sprite 0 mid-screen (outside the left-8px clip zone): y=49 → visible on
+        // scanlines 50-57, x=100, solid tile 0, priority in-front.
+        val oam = memory.ppuAddressedMemory.objectAttributeMemory
+        oam[0] = 49.toByte()  // y
+        oam[1] = 0            // tile
+        oam[2] = 0            // attributes: palette 0, in front
+        oam[3] = 100.toByte() // x
+        // Show background + bg-in-leftmost-8px; sprites OFF.
+        memory.ppuAddressedMemory.mask.register = 0b0000_1010.toByte()
+
+        val frame = runOneFrame(ppu)
+
+        // (103,53) is inside the sprite's 8x8 box. With sprites disabled the
+        // background tile colour must win.
+        assertThat("pixel (103,53)", frame.scanlines[53][103], equalTo(NesPalette.getRgb(bgColorIndex)))
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuSpriteOverflowTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuSpriteOverflowTest.kt
@@ -1,0 +1,69 @@
+package com.github.alondero.nestlin.ppu
+
+import com.github.alondero.nestlin.Memory
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * PPUSTATUS bit 5 (sprite overflow) must be set during sprite evaluation when a
+ * 9th sprite falls on a scanline, and cleared at the pre-render line. Nestlin
+ * never set it — games that use it for raster timing saw a permanently-clear flag.
+ *
+ * (The hardware's buggy diagonal-OAM-scan false positives/negatives are NOT
+ * modelled — only the documented "more than 8 real sprites" case.)
+ */
+class PpuSpriteOverflowTest {
+
+    private fun tickToScanline(ppu: Ppu, target: Int) {
+        var guard = 400_000
+        while (ppu.currentScanline < target && guard-- > 0) ppu.tick()
+    }
+
+    @Test
+    fun `ninth sprite on a scanline sets the overflow flag`() {
+        val memory = Memory()
+        val ppu = Ppu(memory)
+        // Zero-init OAM = 64 sprites at y=0 → scanlines 1-8 each have 64 candidates.
+        memory.ppuAddressedMemory.mask.register = 0b0000_1000.toByte() // rendering on (bg)
+
+        tickToScanline(ppu, 100)
+
+        assertThat(memory.ppuAddressedMemory.status.spriteOverflow(), equalTo(true))
+    }
+
+    @Test
+    fun `eight or fewer sprites never set the overflow flag`() {
+        val memory = Memory()
+        val ppu = Ppu(memory)
+        val oam = memory.ppuAddressedMemory.objectAttributeMemory
+        // Move sprites 8..63 off-screen (y=0xF0 → never matches a visible scanline),
+        // leaving exactly 8 sprites (0..7) on scanlines 1-8.
+        for (i in 8 until 64) oam[i * 4] = 0xF0.toByte()
+        memory.ppuAddressedMemory.mask.register = 0b0000_1000.toByte()
+
+        tickToScanline(ppu, 100)
+
+        assertThat(memory.ppuAddressedMemory.status.spriteOverflow(), equalTo(false))
+    }
+
+    @Test
+    fun `overflow flag is cleared at the pre-render line`() {
+        val memory = Memory()
+        val ppu = Ppu(memory)
+        memory.ppuAddressedMemory.mask.register = 0b0000_1000.toByte()
+
+        tickToScanline(ppu, 100)
+        assertThat(memory.ppuAddressedMemory.status.spriteOverflow(), equalTo(true))
+
+        // Run through the pre-render line to the START of the next frame's scanline 0.
+        // The flag must have been cleared at pre-render; stop before scanline 0's
+        // cycle-64 sprite eval (which prepares crowded scanline 1) re-sets it.
+        var guard = 400_000
+        do {
+            ppu.tick()
+            if (guard-- <= 0) error("never reached start of next frame")
+        } while (!(ppu.currentScanline == 0 && ppu.currentCycle in 1..40))
+        assertThat(memory.ppuAddressedMemory.status.spriteOverflow(), equalTo(false))
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/ppu/VramAddressTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ppu/VramAddressTest.kt
@@ -103,4 +103,17 @@ class VramAddressTest {
         assertThat(addr.coarseXScroll, equalTo(31))
         assertThat(addr.coarseYScroll, equalTo(31)) // all 5 bits set
     }
+
+    @Test
+    fun `first $2006 write clears fine Y bit 2`() {
+        val addr = VramAddress()
+        // A $2005 second write can set fineY up to 7 (bit 2 set)...
+        addr.fineYScroll = 7
+
+        // ...but the first $2006 write only carries fineY bits 0-1 and hardware
+        // forces bit 14 of t (fineY bit 2) to ZERO. Writing $00 must fully clear fineY.
+        addr.setUpper7Bits(0x00)
+
+        assertThat(addr.fineYScroll, equalTo(0))
+    }
 }


### PR DESCRIPTION
Six PPU fixes, each test-first:

**Speed**
- Frame.kt — boxed Integer framebuffer rows → primitive IntArray. Eliminates ~61k Integer allocations per frame.

**Visual rendering**
- PPUMASK bits 3 (showBackground) and 4 (showSprites) now gate their layers on their own. Previously the OR of both rendered both, so sprites-only games got background tiles and vice versa. Sprite-0 hit correctly suppressed when either layer is off.
- Greyscale (PPUMASK bit 0) and colour emphasis (bits 5-7) now applied to every output pixel via a precomputed 8×64 emphasis table — one array lookup per pixel, no per-pixel float math. PAL red/green emphasis-bit swap applied.

**PPUSTATUS accuracy**
- Sprite overflow (bit 5) now set in sprite evaluation when a 9th in-range sprite lands on a scanline. Cleared at pre-render dot 1 alongside the other status flags. The hardware's buggy diagonal-scan quirk is deliberately out of scope.

**VRAM/$2000 register**
- $2007 palette read refills the read buffer with the nametable byte "underneath" the palette ($2Fxx mirror), per hardware. Previously the buffer held the palette value, so the first post-palette VRAM read returned garbage.
- First $2006 write forces t bit 14 (fine Y bit 2) to zero. Previously a stale bit 2 from an earlier $2005 write persisted, offsetting split-screen rendering by up to 4 rows. The pre-existing test that pinned the buggy behaviour has been corrected (its kdoc already cited the NESdev register table that contradicted its assertion).

**Tests**
- PpuMaskLayerGatingTest, PpuSpriteOverflowTest, PpuGreyscaleEmphasisTest, PpuDataReadBufferTest (all new).
- PpuAddressedMemoryTest, VramAddressTest: existing tests updated to match hardware.
- All test files written failing first, fixed, then verified green.

**Verified**
- `./gradlew build` (full unit suite, lint gates): green.
- `./gradlew bootcheck -Prom=X:/src/nestlin/testroms/kirby.nes -Pframes=120`: PASS.
- `testMesenComparison` shows ~10 pre-existing failures (independent of these changes — A/B-verified against `master`; mostly missing testroms/ in worktrees plus the OAM-attribute-bit-4 mask divergence tracked in memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)