### PR TITLE
Tidy: validate 0-PRG header at GamePak entry point (Closes #212)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
@@ -109,6 +109,19 @@ class GamePak(data: ByteArray, displayName: String = "") {
         // value the user sees in the header. The numbers are bytes 4 and 5.
         val prgBanks = data[4].toUnsignedInt()
         val chrBanks = data[5].toUnsignedInt()
+        // GH #212: a malformed 0-PRG dump (iNES byte 4 = 0) leaves programRom
+        // empty, and every mapper's `x % programRom.size` would then divide by
+        // zero. Reject it here so the bad ROM never reaches the mapper layer —
+        // patching each of the ~15 affected mappers individually was the old
+        // approach and falls over every time a new mapper is added. The iNES
+        // spec requires at least one 16KB PRG bank — there must be SOMETHING
+        // mapped at the CPU's $8000-$FFFF for any code to run.
+        if (prgBanks == 0) {
+            throw BadHeaderException(
+                "Header declares 0 PRG banks (iNES byte 4 = 0); every NES cartridge must have " +
+                    "at least one 16KB PRG bank mapped at 0x8000-0xFFFF"
+            )
+        }
         val declaredPrgBytes = prgBanks.toLong() * PRG_BANK_BYTES
         val declaredChrBytes = chrBanks.toLong() * CHR_BANK_BYTES
         val availableForPrg = data.size - INES_HEADER_SIZE

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper228.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper228.kt
@@ -130,10 +130,9 @@ class Mapper228(private val gamePak: GamePak) : Mapper {
         if (address < 0x8000) return dataBus
         // Physically-absent chip 2 selected: open bus (no game does this).
         if (prgOpenBus) return dataBus
-        // Defensive: a malformed 0-PRG dump (iNES byte 4 = 0) leaves programRom
-        // empty and would make the `% programRom.size` below divide by zero.
-        // Mirrors ppuRead's `chrRom.isEmpty()` guard — open bus is the safe read.
-        if (programRom.isEmpty()) return dataBus
+        // programRom is guaranteed non-empty here: GH #212 pushed the 0-PRG
+        // rejection into GamePak.requireValidHeader, so the BadHeaderException
+        // fires before any mapper (us included) is ever constructed.
         return if (address and 0x4000 == 0) {
             // $8000-$BFFF
             programRom[(prgBank0 * 0x4000 + (address - 0x8000)) % programRom.size]

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/GamePakTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/GamePakTest.kt
@@ -181,6 +181,36 @@ class GamePakTest {
     }
 
     /**
+     * Regression for GH #212: a malformed 0-PRG dump (iNES byte 4 = 0) used
+     * to slip past header validation, leaving `programRom` empty. The very
+     * next thing the mapper layer did was `x % programRom.size`, which
+     * ArithmeticExceptions divides by zero — Mapper1, Mapper10, Mapper11,
+     * Mapper16, Mapper33, Mapper34, Mapper64, Mapper65, Mapper68, Mapper69,
+     * Mapper71, Mapper113, Mapper153, Mapper206, plus others, all had the
+     * same unguarded pattern. The fix validates PRG-bank count >= 1 here so
+     * the bad input never reaches the mapper layer in the first place.
+     *
+     * The 0-PRG case is rejected before the size-overflow check (which also
+     * reads byte 4) because the size check would silently pass: 0 declared
+     * bytes trivially fits inside any file, including the 16-byte header-
+     * only stub used here. The message must name iNES byte 4 so a user
+     * hand-editing a header knows exactly which byte to fix.
+     */
+    @Test
+    fun gamePakWithZeroPrgBanksThrowsBadHeaderException() {
+        // 16-byte iNES header only — no PRG, no CHR. Byte 4 = 0 is the
+        // malformed 0-PRG signature from the issue.
+        val data = ByteArray(16)
+        data[0] = 0x4E; data[1] = 0x45; data[2] = 0x53; data[3] = 0x1A.toByte()
+        data[4] = 0   // declares ZERO 16KB PRG banks — every NES cartridge must have >= 1
+        data[5] = 0   // no CHR (valid; CHR-RAM cart or test stub)
+        val ex = assertBadHeader { GamePak(data) }
+        // The message must name iNES byte 4 — hand-headers are a common case.
+        assertThat(ex.message ?: "", containsSubstring("byte 4"))
+        assertThat(ex.message ?: "", containsSubstring("PRG"))
+    }
+
+    /**
      * Regression: for a 4MB+ file with `programRomSize = 0xFF` (255 banks, the
      * spec-allowed max), the validator passes (it uses `toUnsignedInt()`), but
      * `header.programRomSize` is the signed `Byte` -1. If the second init


### PR DESCRIPTION
Closes #212

A malformed iNES dump with byte 4 (PRG bank count) = 0 used to
slip past requireValidHeader, leaving programRom empty and causing
ArithmeticException at the first mapper cpuRead that did x %
programRom.size. Affected 15+ mappers including Mapper1, 4, 5, 10,
11, 16, 33, 34, 64, 65, 68, 69, 71, 113, 153, 206, 228.

Move the rejection into GamePak.requireValidHeader (alongside the
existing size-overflow checks) so the empty-programRom state is
unconstructable at the entry point. Patching every mapper
individually would silently return dataBus/0 instead of telling
the user their ROM is corrupt, and would break every new mapper
that forgot the pattern.

Mapper228's local inline guard (added in ae4329d during the
implement-and-verify cycle) becomes unreachable and is removed
with an updated 'guaranteed non-empty' comment.

bootcheck PASS on Action 52 (USA) (Rev A) (Unl).nes — Mapper228
boots cleanly for 180 frames with 145 NMI / 0 IRQ after the
defensive guard goes away.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>