### PR TITLE
GH #219: Make Zapper.peek a safe approximation; delete duplicate kdoc

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/input/InputDevice.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/input/InputDevice.kt
@@ -105,20 +105,9 @@ class StandardGamepad(val controller: Controller) : InputDevice {
  * protocol: every read/peek returns the open-bus mask (`0x40`); the strobe
  * signal is a no-op; save/load have no per-device state yet.
  *
- * Both [Zapper] (light gun stub) and [NoDevice] (nothing plugged in) extend
- * this — they currently behave identically from the CPU's perspective. When
- * the Zapper semantics land (trigger bit on `$4017` D4, light sense on `$4017`
- * D3), only [Zapper] will override `read`/`peek`; [NoDevice] stays as-is.
- */
-/**
- * Shared implementation for devices that don't speak the standard NES pad
- * protocol: every read/peek returns the open-bus mask (`0x40`); the strobe
- * signal is a no-op; save/load have no per-device state yet.
- *
- * Both [Zapper] (light gun stub) and [NoDevice] (nothing plugged in) extend
- * this — they currently behave identically from the CPU's perspective. When
- * the Zapper semantics land (trigger bit on `$4017` D4, light sense on `$4017`
- * D3), only [Zapper] will override `read`/`peek`; [NoDevice] stays as-is.
+ * Both [Zapper] (light gun) and [NoDevice] (nothing plugged in) extend this —
+ * from the CPU's perspective they share a base behaviour, but [Zapper] further
+ * overrides `read`/`peek` to report the live trigger and light-sense bits.
  *
  * Marked abstract so callers can't instantiate it directly — the only valid
  * concrete types are [Zapper] and [NoDevice].
@@ -164,8 +153,14 @@ abstract class OpenBusOnlyDevice : InputDevice {
  * than feeding a game phantom port-1 light data.
  *
  * There is no strobe/latch: [writeStrobe] is a no-op (inherited from
- * [OpenBusOnlyDevice]) and reads are un-latched samples of the live providers,
- * so [read] and [peek] are identical — [peek] is safe for the Memory Editor.
+ * [OpenBusOnlyDevice]) and [read] is an un-latched sample of the live
+ * providers. [peek] is a deliberately **safe approximation** for debug
+ * viewers (Memory Editor, issue #168) that polls `$4017` from the JavaFX
+ * thread — see [peek] for the exact contract. In short: peek reads only
+ * the trigger lambda (whose thread safety is the caller's responsibility,
+ * satisfied by [Memory.zapperTrigger]'s `@Volatile` field) and never
+ * reaches into the PPU's live `scanline`/`frame`, which would otherwise
+ * be a cross-thread race during the editor's 10 Hz refresh.
  *
  * @param triggerProvider returns true while the trigger is held (mouse-left held
  *   over the focused game window). Defaults to always-released so a
@@ -191,8 +186,29 @@ class Zapper(
         0
     }
 
-    // No latched state: peek is an alias for read.
-    override fun peek(): Byte = read()
+    /**
+     * Debug-viewer-safe approximation of [read]. Invokes [triggerProvider]
+     * but **not** [lightSensor]: the light bit is hard-coded to 'dark' (D3
+     * set) regardless of whether the player is currently aimed at a lit
+     * sprite. Skipping the live PPU frame sample — which a real [read]
+     * reaches via [com.github.alondero.nestlin.ppu.Ppu.aimBrightness] —
+     * prevents the Memory Editor's 10 Hz refresh from racing the emulation
+     * thread on `scanline` / `frame` (issue #219, manifested as a flickering
+     * `$4017` value in the debug view). In-game polling uses [read], so
+     * gameplay is unaffected.
+     *
+     * Thread safety: the trigger lambda's cross-thread visibility is the
+     * *caller's* responsibility. In production [Memory] wraps it around a
+     * `@Volatile` field (`Memory.zapperTrigger`), which makes the off-thread
+     * read in peek safe; the Zapper class itself makes no memory-visibility
+     * promise about the closure it receives.
+     */
+    override fun peek(): Byte = if (isPort2) {
+        val trigger = if (triggerProvider()) 0x10 else 0x00
+        (StrobeRegister.OPEN_BUS_MASK or trigger or 0x08).toByte()
+    } else {
+        0
+    }
 }
 
 /**

--- a/src/test/kotlin/com/github/alondero/nestlin/input/ZapperPeekEditorSafetyTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/input/ZapperPeekEditorSafetyTest.kt
@@ -1,0 +1,49 @@
+package com.github.alondero.nestlin.input
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression for issue #219 — `Zapper.peek` must be safe to call from the
+ * Memory Editor's 10 Hz refresh, which runs on the JavaFX thread while the
+ * emulation thread writes the PPU's `scanline` and `frame`.
+ *
+ * The fix is to make peek a deliberate **approximation** of [Zapper.read]:
+ * the light bit is hard-coded to 'dark' (D3 set), so [Zapper.lightSensor] is
+ * never invoked and the peek path does not reach
+ * [com.github.alondero.nestlin.ppu.Ppu.aimBrightness] (which reads the live
+ * PPU frame). The trigger bit still reads through the caller-provided
+ * lambda — the caller's responsibility for cross-thread visibility is
+ * satisfied in production by [com.github.alondero.nestlin.Memory.zapperTrigger]'s
+ * `@Volatile` field.
+ *
+ * The single test below pins the load-bearing guarantee: a `lightSensor`
+ * that throws if invoked is the canary for "peek must not sample the live
+ * PPU". A future refactor that re-introduced a live light sample from peek
+ * would fail this test even if all the byte-math in [ZapperTest] still
+ * happened to pass.
+ */
+class ZapperPeekEditorSafetyTest {
+
+    @Test
+    fun `peek must not invoke the light sensor`() {
+        // Throwing lambdas are the strongest possible "must not call" pin: any
+        // invocation during peek is a test failure with the lambda's message.
+        val zapper = Zapper(
+            triggerProvider = { false },
+            lightSensor = { error("peek must not invoke the light sensor") },
+        )
+
+        // Port-2 Zapper — the in-game shape — must skip lightSensor.
+        assertThat(zapper.peek(), equalTo(0x48.toByte()))
+
+        // Port-1 Zapper takes the else branch (reads 0); also must skip lightSensor.
+        val port1 = Zapper(
+            triggerProvider = { false },
+            lightSensor = { error("peek must not invoke the light sensor (port 1)") },
+            isPort2 = false,
+        )
+        assertThat(port1.peek(), equalTo(0.toByte()))
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/input/ZapperTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/input/ZapperTest.kt
@@ -51,15 +51,44 @@ class ZapperTest {
     }
 
     @Test
-    fun `peek matches read for every trigger and light combination`() {
-        // The Zapper has no latched state, so the Memory Editor's side-effect-free
-        // peek must return exactly what read would.
+    fun `peek always reports the light bit as dark regardless of the light sensor`() {
+        // Peek is the Memory Editor's side-effect-free read (issue #219): it must
+        // report the live trigger bit (a @Volatile Boolean, safe off-thread) but
+        // MUST NOT sample the live PPU frame — that's racy when read from the
+        // JavaFX thread. The light bit is therefore always 'dark' (D3 set),
+        // independent of what `lightSensor()` would have returned. Pin all four
+        // (trigger, bright) combos so the approximation can't drift back toward
+        // an alias for read().
         for (trigger in listOf(false, true)) {
             for (bright in listOf(false, true)) {
                 val z = zapper(trigger, bright)
-                assertThat(z.peek(), equalTo(z.read()))
+                val expected = if (trigger) 0x58.toByte() else 0x48.toByte()
+                assertThat(z.peek(), equalTo(expected))
             }
         }
+    }
+
+    @Test
+    fun `peek differs from read when aimed at a bright pixel`() {
+        // Pins the divergence: when the trigger is held AND a bright pixel is
+        // visible, read() clears the light bit (0x50) but peek() reports the
+        // safe 'dark' approximation (0x58). This is the concrete shape of the
+        // approximation — the bug we're fixing showed up here as a flickering
+        // debug-viewer value; the fix shows up here as a stable 0x58.
+        val z = zapper(trigger = true, bright = true)
+        assertThat(z.read(), equalTo(0x50.toByte()))
+        assertThat(z.peek(), equalTo(0x58.toByte()))
+    }
+
+    @Test
+    fun `peek tracks the live trigger bit across provider changes`() {
+        // The trigger sample is read from a @Volatile Boolean, so peek must
+        // reflect provider changes between polls — only the light bit is fixed.
+        var trigger = false
+        val z = Zapper(triggerProvider = { trigger }, lightSensor = { true /* bright */ })
+        assertThat(z.peek(), equalTo(0x48.toByte()))   // trigger off → 0x48
+        trigger = true
+        assertThat(z.peek(), equalTo(0x58.toByte()))   // trigger on  → 0x58 (light bit stays 'dark')
     }
 
     @Test


### PR DESCRIPTION
GH #219: Make Zapper.peek a safe approximation; delete duplicate kdoc

Tidy-up of two minor leftovers surfaced during the #209 (Zapper) code
review. Neither affects in-game behaviour; both improve the debug-viewer
contract and the file's doc hygiene.

Memory Editor safety:

Before this fix, Zapper.peek was an alias for Zapper.read. read() invokes
lightSensor() which reaches into Ppu.aimBrightness -> reads live scanline
+ frame pixels. The Memory Editor's 10 Hz refresh calls peek from the
JavaFX thread; the emulation thread writes those PPU fields concurrently.
Int reads don't crash, but the displayed $4017 value flickers in the
debug view.

peek now returns OPEN_BUS | (trigger? 0x10 : 0) | 0x08 -- trigger bit
tracks the live lambda (whose thread safety is the caller's, satisfied
in production by Memory.zapperTrigger's @Volatile field), light bit is
hard-coded 'dark'. lightSensor is not invoked from peek, so the PPU race
path is unreachable from the debug viewer. In-game polling still goes
through read(), so gameplay is unaffected.

Tests:
- Replaced `peek matches read for every trigger and light combination`
  (no longer true) with three new tests pinning the approximation
  contract: always-dark light bit, read/peek divergence at bright pixel,
  live trigger tracking across provider changes.
- New ZapperPeekEditorSafetyTest pins the load-bearing guarantee with a
  throwing-lambda canary: peek must not invoke lightSensor.

Doc hygiene:

Deleted the duplicate kdoc block above OpenBusOnlyDevice. The first
(pre-existing since PR #208) and second (added during #209) blocks were
near-identical; the second adds the "Marked abstract so callers can't
instantiate it directly" rationale, so the merge keeps the second.
Also tightened the Zapper class kdoc + peek method kdoc to clarify that
the @Volatile lives on Memory.zapperTrigger (the Zapper class itself
makes no memory-visibility promise about the closure it receives).

Closes #219