### PR TITLE
Apply FM2 commands field (soft/hard reset) during replay (GH #125)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Nestlin.kt
@@ -198,6 +198,26 @@ class Nestlin {
     }
 
     /**
+     * Soft reset: equivalent to pressing the NES RESET button. The CPU is redirected to
+     * its RESET vector and registers are zeroed, but **internal RAM ($0000-$07FF) and
+     * PPU registers are preserved** — the RESET line on real hardware does NOT
+     * power-cycle the work RAM or the PPU's latched state.
+     *
+     * Used by the FM2 movie replayer when a row's `commands` field has bit 0 set
+     * (issue #125). The companion [powerReset] is what gets called for bit 1 (the
+     * power-cycle case), and it goes through [Cpu.reset] which DOES clear RAM via
+     * [com.github.alondero.nestlin.Memory.clear].
+     *
+     * Implementation note: we deliberately do NOT touch the rewind buffer. A soft reset
+     * is a transition within the same session (the user can still rewind across it
+     * to inspect what was happening before the RESET button was pressed), unlike a
+     * power-cycle which [powerReset] treats as a brand-new boot timeline.
+     */
+    fun softReset() {
+        cpu.softReset()
+    }
+
+    /**
      * Engage or disengage rewind scrubbing (issue #52). Called from the UI thread on
      * hold/release of the Backspace key. While active and [EmulatorConfig.rewindEnabled], the
      * emulation loop walks backward through the rewind buffer at ~3× real-time, re-rendering each

--- a/src/main/kotlin/com/github/alondero/nestlin/cli/ReplayCommand.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cli/ReplayCommand.kt
@@ -162,6 +162,10 @@ object ReplayCommand {
     private fun replayInto(nestlin: Nestlin, movie: Movie, frameLimit: Int?) {
         val rows = if (frameLimit != null) movie.inputs.take(frameLimit) else movie.inputs
         for (input in rows) {
+            // Same per-row ordering as MoviePlayer.replayInto (issue #125): commands
+            // first via the shared MovieInput.applyCommands helper, then latch input,
+            // then step one frame.
+            input.applyCommands(nestlin)
             nestlin.getController1().setButtonBitmap(input.controller1)
             nestlin.getController2().setButtonBitmap(input.controller2)
             nestlin.runOneFrame()

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/Cpu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/Cpu.kt
@@ -106,6 +106,28 @@ class Cpu(
 
     fun reset() {
         memory.clear()
+        resetCpuState()
+    }
+
+    /**
+     * Soft reset — equivalent to pressing the NES RESET button (issue #125). The CPU
+     * is redirected to its RESET vector and registers are zeroed, but **internal RAM
+     * ($0000-$07FF) and PPU registers are preserved** — the RESET line on real hardware
+     * does NOT power-cycle the work RAM or the PPU's latched state.
+     *
+     * Contrast with [reset] (the power-cycle / "hard reset" path), which calls
+     * [com.github.alondero.nestlin.Memory.clear] to wipe RAM and reset the PPU.
+     */
+    fun softReset() {
+        resetCpuState()
+    }
+
+    /**
+     * Reset the CPU's own state (registers, processor status, cycle counters, PC from
+     * the RESET vector). Shared by [reset] (full power-cycle, which clears RAM first)
+     * and [softReset] (RESET button, which preserves RAM).
+     */
+    private fun resetCpuState() {
         _processorStatus.reset()
         _registers.reset()
         _workCyclesLeft = 0

--- a/src/main/kotlin/com/github/alondero/nestlin/movie/Movie.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/movie/Movie.kt
@@ -32,5 +32,25 @@ data class Movie(
         /** FM2 port device codes: 1 = standard gamepad, 0 = nothing connected. */
         const val PORT_GAMEPAD = 1
         const val PORT_NONE = 0
+
+        /**
+         * FM2 `commands` field bit positions (issue #125). The mask values ([SOFT_RESET],
+         * [HARD_RESET]) are what appear on disk and in test fixtures; the bit indices
+         * ([SOFT_RESET_BIT], [HARD_RESET_BIT]) are what `isBitSet` consumes internally.
+         *
+         *   - [SOFT_RESET] — pressing the NES RESET button. CPU jumps to the reset vector;
+         *     internal RAM is preserved. FCEUX convention: bit 0.
+         *   - [HARD_RESET] — power-cycle. Internal RAM is cleared (filled with 0xFF in
+         *     Nestlin, matching the NES cold-boot pattern); CPU jumps to the reset vector.
+         *     FCEUX convention: bit 1.
+         *
+         * Bits 2+ are FDS / VS-System / NMI control codes that don't apply to plain NES
+         * games — they're parsed and preserved on disk but no action is taken in the
+         * replayer (yet).
+         */
+        const val SOFT_RESET_BIT = 0
+        const val HARD_RESET_BIT = 1
+        const val SOFT_RESET = 1 shl SOFT_RESET_BIT
+        const val HARD_RESET = 1 shl HARD_RESET_BIT
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/movie/MovieInput.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/movie/MovieInput.kt
@@ -1,5 +1,8 @@
 package com.github.alondero.nestlin.movie
 
+import com.github.alondero.nestlin.Nestlin
+import com.github.alondero.nestlin.isBitSet
+
 /**
  * One frame's worth of input in a movie's input log.
  *
@@ -8,10 +11,35 @@ package com.github.alondero.nestlin.movie
  * on-disk order. [Fm2Format] translates to/from FM2's reversed `RLDUTSBA` column layout.
  *
  * [commands] is the FM2 command field: bit 0 = soft reset, bit 1 = hard reset (power cycle).
- * Defaults to 0 (no console command this frame).
+ * Defaults to 0 (no console command this frame). Use [applyCommands] to translate the bits
+ * into the matching [Nestlin] entry point — both [MoviePlayer.replayInto] and the
+ * [com.github.alondero.nestlin.cli.ReplayCommand] CLI use the same helper so the two
+ * replay paths can't drift apart on what a `commands=3` row means.
  */
 data class MovieInput(
     val controller1: Int,
     val controller2: Int = 0,
     val commands: Int = 0,
-)
+) {
+    /** True if this row carries a hard-reset / power-cycle bit (issue #125). */
+    private val hasHardReset: Boolean get() = commands.isBitSet(Movie.HARD_RESET_BIT)
+
+    /** True if this row carries a soft-reset bit (issue #125). */
+    private val hasSoftReset: Boolean get() = commands.isBitSet(Movie.SOFT_RESET_BIT)
+
+    /**
+     * Apply this row's [commands] to [nestlin]. When both reset bits are set, hard reset
+     * dominates (a power-cycle obliterates whatever the soft reset would have done).
+     *
+     * Used by [MoviePlayer.replayInto], [MovieLivePlayer]'s latch hook, and
+     * [com.github.alondero.nestlin.cli.ReplayCommand] — the FM2 commands field has one
+     * interpretation regardless of which replay path drives the machine.
+     */
+    fun applyCommands(nestlin: Nestlin) {
+        if (hasHardReset) {
+            nestlin.powerReset()
+        } else if (hasSoftReset) {
+            nestlin.softReset()
+        }
+    }
+}

--- a/src/main/kotlin/com/github/alondero/nestlin/movie/MovieLivePlayer.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/movie/MovieLivePlayer.kt
@@ -51,9 +51,12 @@ class MovieLivePlayer(
         framesDriven++
         if (nextRow < movie.length) {
             val row = movie.inputs[nextRow]
+            // Order matches MoviePlayer.replayInto: commands fire FIRST so the upcoming
+            // frame's first NMI sees post-reset state, then the latched input is the
+            // thing the game polls.
+            row.applyCommands(nestlin)
             nestlin.getController1().setButtonBitmap(row.controller1)
             nestlin.getController2().setButtonBitmap(row.controller2)
-            // TODO: honour row.commands (soft/hard reset) once a real movie needs mid-run resets.
             nextRow++
         }
     }
@@ -72,6 +75,8 @@ class MovieLivePlayer(
         // would do, but in the same thread as start()).
         val row0 = movie.inputs.firstOrNull()
         if (row0 != null) {
+            // Same order as the latch hook: commands first, then input latch.
+            row0.applyCommands(nestlin)
             nestlin.getController1().setButtonBitmap(row0.controller1)
             nestlin.getController2().setButtonBitmap(row0.controller2)
             nextRow = 1

--- a/src/main/kotlin/com/github/alondero/nestlin/movie/MoviePlayer.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/movie/MoviePlayer.kt
@@ -40,12 +40,21 @@ class MoviePlayer {
     /**
      * Replay [movie] into an already-booted [nestlin]. Each row's input is applied *before* its
      * frame is stepped, matching FM2's "input latched once per frame" model.
+     *
+     * Per-row ordering (issue #125):
+     *
+     *   1. Apply any `commands` bits the row carries via [MovieInput.applyCommands] —
+     *      soft reset (bit 0) → [Nestlin.softReset], hard reset (bit 1) → [Nestlin.powerReset].
+     *      Doing this BEFORE latching the input matches FCEUX's "reset fires, then the
+     *      game's first NMI polls the new pad" semantics.
+     *   2. Latch the row's input onto the two controller ports.
+     *   3. Step one frame.
      */
     fun replayInto(nestlin: Nestlin, movie: Movie) {
         for (input in movie.inputs) {
+            input.applyCommands(nestlin)
             nestlin.getController1().setButtonBitmap(input.controller1)
             nestlin.getController2().setButtonBitmap(input.controller2)
-            // TODO: honour input.commands (soft/hard reset) once a real movie needs mid-run resets.
             nestlin.runOneFrame()
         }
     }

--- a/src/test/kotlin/com/github/alondero/nestlin/movie/MovieCommandsTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/movie/MovieCommandsTest.kt
@@ -1,0 +1,282 @@
+package com.github.alondero.nestlin.movie
+
+import com.github.alondero.nestlin.Controller.Button
+import com.github.alondero.nestlin.Nestlin
+import com.github.alondero.nestlin.file.load
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.containsSubstring
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+import java.nio.file.Paths
+
+/**
+ * Regression tests for issue #125: the FM2 movie replayer must honour the per-frame
+ * `commands` field. Bits:
+ *
+ *   - bit 0 (value 1) = soft reset (RESET button — CPU jumps to RESET vector, RAM preserved)
+ *   - bit 1 (value 2) = hard reset / power cycle (RAM cleared, CPU jumps to RESET vector)
+ *
+ * Real TAS movies and bug reproductions rely on the reset button. Without command
+ * handling, replay desyncs the moment a movie invokes a reset.
+ *
+ * The round-trip and parsing tests live here too because the commands field is the
+ * FM2 spec item under test, and the contract "write then read returns the same bits"
+ * is the easiest thing to verify without booting a ROM.
+ */
+class MovieCommandsTest {
+
+    private val romPath = Paths.get("testroms/nestest.nes")
+
+    private fun freshNestlin(): Nestlin =
+        Nestlin().apply {
+            config.speedThrottlingEnabled = false
+            load(romPath)
+        }.also { it.powerReset() }
+
+    // ------------------------------------------------------------------------------------------- //
+    // FM2 parsing — the commands field must round-trip through write/read.
+    // ------------------------------------------------------------------------------------------- //
+
+    @Test
+    fun `FM2 commands field round-trips through write and read`() {
+        val movie = Movie(
+            romFilename = "test",
+            romChecksum = "base64:x",
+            inputs = listOf(
+                MovieInput(controller1 = 0, commands = 0),
+                MovieInput(controller1 = 0, commands = 1),  // soft reset
+                MovieInput(controller1 = 0, commands = 2),  // hard reset
+                MovieInput(controller1 = 0, commands = 3),  // both
+            )
+        )
+
+        val parsed = Fm2Format.read(Fm2Format.write(movie))
+
+        assertThat(
+            parsed.inputs.map { it.commands },
+            equalTo(listOf(0, 1, 2, 3)),
+        )
+    }
+
+    @Test
+    fun `FM2 commands field writes the decimal command value into the row prefix`() {
+        // The line format is `|<cmd>|<p0>|<p1>|<p2>|`. Verifies the column shape directly so a
+        // future refactor that drops the commands field can't pass with a silent default-to-0.
+        val movie = Movie(
+            romFilename = "test",
+            romChecksum = "base64:x",
+            inputs = listOf(
+                MovieInput(controller1 = 0, commands = 1),
+                MovieInput(controller1 = 0, commands = 2),
+            )
+        )
+
+        val text = Fm2Format.write(movie)
+        assertThat(text, containsSubstring("|1|"))
+        assertThat(text, containsSubstring("|2|"))
+    }
+
+    // ------------------------------------------------------------------------------------------- //
+    // Replay semantics — soft vs hard reset.
+    //
+    // The discriminator between soft and hard reset, on real NES hardware and in FCEUX, is
+    // whether the CPU's internal RAM ($0000-$07FF, mirrored) is cleared. A soft reset
+    // (RESET button) leaves RAM contents alone and just sets PC to the reset vector; a power
+    // cycle fills RAM with $00/$FF depending on the board and clears everything.
+    //
+    // In Nestlin, `Memory.clear()` fills internal RAM with 0xFF — that's the observable
+    // "hard reset" side effect. So the test strategy is: poke a sentinel byte, replay a row
+    // tagged with the reset command, then peek the byte. Soft reset must keep it; hard reset
+    // must overwrite it with 0xFF.
+    // ------------------------------------------------------------------------------------------- //
+
+    @Test
+    fun `soft reset command preserves internal RAM during replay`() {
+        val nes = freshNestlin()
+        // Let the boot ROM settle a few frames so the CPU is in steady state.
+        repeat(20) { nes.runOneFrame() }
+
+        // Place sentinels that the next reset must NOT clobber.
+        nes.pokeMemory(0x0042, 0x42.toByte())
+        nes.pokeMemory(0x0200, 0x99.toByte())
+        assertThat(nes.peekMemory(0x0042), equalTo(0x42.toByte()))
+
+        val movie = Movie(
+            romFilename = "nestest",
+            romChecksum = "base64:x",
+            inputs = listOf(MovieInput(controller1 = 0, commands = Movie.SOFT_RESET)),
+        )
+        MoviePlayer().replayInto(nes, movie)
+
+        // Soft reset (RESET button) must preserve internal RAM — the RESET line on real
+        // hardware does NOT power-cycle the work RAM.
+        assertThat(nes.peekMemory(0x0042), equalTo(0x42.toByte()))
+        assertThat(nes.peekMemory(0x0200), equalTo(0x99.toByte()))
+    }
+
+    @Test
+    fun `hard reset command clears internal RAM during replay`() {
+        val nes = freshNestlin()
+        repeat(20) { nes.runOneFrame() }
+
+        nes.pokeMemory(0x0042, 0x42.toByte())
+        nes.pokeMemory(0x0200, 0x99.toByte())
+
+        val movie = Movie(
+            romFilename = "nestest",
+            romChecksum = "base64:x",
+            inputs = listOf(MovieInput(controller1 = 0, commands = Movie.HARD_RESET)),
+        )
+        MoviePlayer().replayInto(nes, movie)
+
+        // Memory.clear() fills internal RAM with 0xFF — power-cycle semantics.
+        assertThat(nes.peekMemory(0x0042), equalTo(0xFF.toByte()))
+        assertThat(nes.peekMemory(0x0200), equalTo(0xFF.toByte()))
+    }
+
+    @Test
+    fun `reset and input on the same row are both applied`() {
+        val nes = freshNestlin()
+        repeat(20) { nes.runOneFrame() }
+        nes.pokeMemory(0x0042, 0x42.toByte())  // sentinel for soft-reset preservation
+
+        // Row carries BOTH a soft-reset command AND a button press. The reset must fire
+        // (preserving RAM) AND the button must be latched for the frame (otherwise the
+        // game polled $4016 sees 0 instead of A).
+        val movie = Movie(
+            romFilename = "nestest",
+            romChecksum = "base64:x",
+            inputs = listOf(
+                MovieInput(controller1 = Button.A.mask, commands = Movie.SOFT_RESET)
+            )
+        )
+        MoviePlayer().replayInto(nes, movie)
+
+        assertThat(nes.peekMemory(0x0042), equalTo(0x42.toByte()))
+        // Don't try to observe the button press in a deterministic way — that depends on
+        // what the test ROM's NMI handler does with $4016 reads, which can vary. The fact
+        // that we got here without a crash means both effects ran.
+    }
+
+    @Test
+    fun `commands field takes effect at the START of a frame, before input latch`() {
+        // FM2 convention: the command for row N fires at the START of frame N, then the
+        // row's input is latched, then the frame runs. The order matters for games that
+        // poll input in their very first NMI after a reset — they should see the row's
+        // input, not whatever was held before. We approximate that contract by ensuring
+        // the reset and the input set both happen on the same row and the controller ends
+        // up holding the row's value.
+        val nes = freshNestlin()
+        // Pre-pollute controller 1 with some prior value so we can prove it was overwritten.
+        nes.getController1().setButtonBitmap(Button.B.mask)
+
+        val movie = Movie(
+            romFilename = "nestest",
+            romChecksum = "base64:x",
+            inputs = listOf(
+                MovieInput(controller1 = Button.A.mask, commands = Movie.HARD_RESET)
+            )
+        )
+        MoviePlayer().replayInto(nes, movie)
+
+        assertThat(nes.getController1().buttons, equalTo(Button.A.mask))
+    }
+
+    @Test
+    fun `commands field with value 0 leaves state unchanged`() {
+        val nes = freshNestlin()
+        repeat(20) { nes.runOneFrame() }
+        nes.pokeMemory(0x0042, 0x42.toByte())
+
+        val movie = Movie(
+            romFilename = "nestest",
+            romChecksum = "base64:x",
+            inputs = listOf(MovieInput(controller1 = Button.A.mask, commands = 0)),
+        )
+        MoviePlayer().replayInto(nes, movie)
+
+        // With commands=0 the frame should run normally: no reset, just a button latch.
+        // RAM should be untouched (the test ROM doesn't write to \$0042 itself; if it
+        // does in the future this assertion should be revisited).
+        assertThat(nes.peekMemory(0x0042), equalTo(0x42.toByte()))
+        assertThat(nes.getController1().buttons, equalTo(Button.A.mask))
+    }
+
+    // ------------------------------------------------------------------------------------------- //
+    // Live playback — the same commands field must be honoured by the real-time player
+    // (MovieLivePlayer). The latch hook installs at end-of-frame, so the natural place to
+    // fire commands is at the same boundary: the row's input AND its commands take effect
+    // between frames, ready for the upcoming frame's NMI.
+    // ------------------------------------------------------------------------------------------- //
+
+    @Test
+    fun `MovieLivePlayer honours soft-reset commands on its primed row`() {
+        val nes = freshNestlin()
+        repeat(20) { nes.runOneFrame() }
+        nes.pokeMemory(0x0042, 0x42.toByte())
+
+        val movie = Movie(
+            romFilename = "nestest",
+            romChecksum = "base64:x",
+            inputs = listOf(MovieInput(controller1 = 0, commands = Movie.SOFT_RESET)),
+        )
+        val player = MovieLivePlayer(nes, movie)
+        player.start()
+
+        // start() primes row 0 immediately (mirrors the headless loop). The soft-reset
+        // for row 0 must take effect BEFORE the first frame runs, so RAM is preserved.
+        assertThat(nes.peekMemory(0x0042), equalTo(0x42.toByte()))
+        player.stop()
+    }
+
+    @Test
+    fun `MovieLivePlayer honours hard-reset commands fired from the latch hook`() {
+        val nes = freshNestlin()
+        repeat(20) { nes.runOneFrame() }
+        nes.pokeMemory(0x0042, 0x42.toByte())
+
+        // Single-row movie with hard reset. After start() the row's commands must fire
+        // (clearing RAM) BEFORE the first frame runs — same "commands-then-input-then-frame"
+        // order as MoviePlayer.replayInto.
+        val movie = Movie(
+            romFilename = "nestest",
+            romChecksum = "base64:x",
+            inputs = listOf(
+                MovieInput(controller1 = 0, commands = Movie.HARD_RESET),
+            ),
+        )
+        val player = MovieLivePlayer(nes, movie)
+        player.start()
+
+        assertThat(nes.peekMemory(0x0042), equalTo(0xFF.toByte()))
+        player.stop()
+    }
+
+    @Test
+    fun `MovieLivePlayer fires a mid-movie reset command at the latch boundary`() {
+        // The first row is a no-op (commands=0). The second row carries a hard reset.
+        // After running the first frame, the latch hook has fired row 1's commands, so
+        // RAM should be cleared.
+        val nes = freshNestlin()
+        repeat(20) { nes.runOneFrame() }
+        nes.pokeMemory(0x0042, 0x42.toByte())
+
+        val movie = Movie(
+            romFilename = "nestest",
+            romChecksum = "base64:x",
+            inputs = listOf(
+                MovieInput(controller1 = 0),                              // row 0: no command
+                MovieInput(controller1 = 0, commands = Movie.HARD_RESET), // row 1: hard reset
+            ),
+        )
+        val player = MovieLivePlayer(nes, movie)
+        player.start()
+
+        // Frame 0 runs with row 0's input + no command. At end of frame 0 the latch hook
+        // primes row 1: applies HARD_RESET (clearing RAM) and latches row 1's input.
+        nes.runOneFrame()
+
+        assertThat(nes.peekMemory(0x0042), equalTo(0xFF.toByte()))
+        player.stop()
+    }
+}


### PR DESCRIPTION
## Summary

The FM2 movie replayer parsed the per-row `commands` field but ignored it (TODO in `MoviePlayer.replayInto` + `MovieLivePlayer.latchHook`), causing any movie that invokes the RESET button to desync the moment the reset fires. This change wires the bits through to the Nestlin reset entry points so real TAS movies and bug reproductions replay byte-for-byte.

## Commands semantics (FCEUX convention)

- **bit 0 (value 1) = soft reset** — pressing the NES RESET button. CPU jumps to the reset vector; **internal RAM ($0000-$07FF) and PPU registers are preserved**. New `Cpu.softReset()` + `Nestlin.softReset()`.
- **bit 1 (value 2) = hard reset / power cycle**. Existing `Cpu.reset()` / `Nestlin.powerReset()` path. Wipes RAM with `0xFF` via `Memory.clear()` and re-applies the reset vector.
- **Both bits set → hard reset wins** (a power-cycle obliterates whatever the soft reset would have done). `applyCommands` documents this.
- Bits 2+ are FDS / VS-System / NMI codes; preserved on disk but no action is taken in the replayer yet.

## Per-row ordering (matches FCEUX)

```
1. applyCommands(nestlin)        — soft/hard reset fires FIRST
2. setButtonBitmap(controller1)  — row's input latched
3. setButtonBitmap(controller2)  — row's input latched
4. runOneFrame()                 — step one frame
```

Doing the reset before latching input means a game's first NMI after a reset sees the freshly-latched pad, not whatever was held before — the "reset button + start pressing A" boot pattern works as expected.

## Single shared helper

`MovieInput.applyCommands(nestlin)` is the only place that translates FM2 commands bits → Nestlin entry points. All three replay paths call it:

- `MoviePlayer.replayInto` (headless)
- `MovieLivePlayer.start()` AND its frame-end latch hook (real-time)
- `ReplayCommand.replayInto` (CLI `nestlin replay`)

This keeps the three paths from drifting apart on what `commands=3` means.

## Implementation notes

- `Cpu.reset()` previously did both `memory.clear()` AND the state reset; split into `reset()` (clear + state) and `softReset()` (state only) with the shared bits extracted to a private `resetCpuState()`. No caller of the existing `reset()` changed behaviour.
- `resetCpuState()` zeroes the NMI/IRQ diagnostic counters on both reset paths. Symmetric with registers/PC; no current caller relies on preserving these counters across a reset, but worth knowing if future diagnostic UI cares.
- `Nestlin.softReset()` deliberately does NOT clear the rewind buffer (a soft reset is a transition within the same session, not a fresh boot timeline like `powerReset`).

## Tests

`MovieCommandsTest` (10 cases) covers FM2 round-trip, FM2 line format, soft-reset preserves RAM, hard-reset clears RAM, combined input+reset on same row, command-then-input ordering (controller holds row's value after reset), `commands=0` no-op, plus both `MovieLivePlayer` code paths (primed row + mid-movie latch boundary). Uses the public `peekMemory` / `pokeMemory` surface (no reflection). Hamkrest assertion style per `CLAUDE.md`. Passes alongside the existing `MovieRoundTrip` / `MovieLivePlayer` / `MovieLiveRecorder` tests; full `./gradlew test` is GREEN.

## Spec interpretation

Issue #125 listed "Soft reset → execute `cpu.reset()`-equivalent" but also framed it as "RESET button" semantics. The literal `Cpu.reset()` clears RAM — that's power-cycle, not RESET button. This implementation picks the hardware-faithful interpretation (preserve RAM on soft reset) which is what every FM2 movie's soft-reset row expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #125
