### PR TITLE
GH #99: MapperStateSnapshot equals/hashCode include chrRam + prgRam content

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/MapperState.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/MapperState.kt
@@ -24,6 +24,11 @@ data class MapperStateSnapshot(
         if (banks != other.banks) return false
         if (registers != other.registers) return false
         if (irqState != other.irqState) return false
+        // ByteArray needs content comparison, not the reference identity that
+        // Kotlin's === would use. contentEquals on a nullable receiver treats
+        // two nulls as equal and one-null-one-non-null as unequal (issue #99).
+        if (!chrRam.contentEquals(other.chrRam)) return false
+        if (!prgRam.contentEquals(other.prgRam)) return false
 
         return true
     }
@@ -34,6 +39,8 @@ data class MapperStateSnapshot(
         result = 31 * result + banks.hashCode()
         result = 31 * result + registers.hashCode()
         result = 31 * result + (irqState?.hashCode() ?: 0)
+        result = 31 * result + (chrRam?.contentHashCode() ?: 0)
+        result = 31 * result + (prgRam?.contentHashCode() ?: 0)
         return result
     }
 }

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/MapperStateSnapshotTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/MapperStateSnapshotTest.kt
@@ -1,0 +1,102 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [MapperStateSnapshot]'s equality contract (issue #99).
+ *
+ * `equals`/`hashCode` are hand-written (not data-class-generated) because [ByteArray]
+ * fields need content comparison, not reference identity. The regression this guards
+ * against: two snapshots with identical banking registers but divergent CHR-RAM or
+ * PRG-RAM comparing as equal, which would silently green-light any future
+ * `assertThat(mapper.snapshot(), equalTo(expected))` RAM round-trip assertion.
+ */
+class MapperStateSnapshotTest {
+
+    private fun snapshot(
+        chrRam: ByteArray? = null,
+        prgRam: ByteArray? = null
+    ) = MapperStateSnapshot(
+        mapperId = 1,
+        type = "TEST",
+        banks = mapOf("prg" to 0),
+        registers = mapOf("ctrl" to 0),
+        irqState = null,
+        chrRam = chrRam,
+        prgRam = prgRam
+    )
+
+    // ---- chrRam ----
+
+    @Test
+    fun `snapshots with identical chrRam contents are equal`() {
+        val a = snapshot(chrRam = byteArrayOf(0, 1, 2))
+        val b = snapshot(chrRam = byteArrayOf(0, 1, 2))
+        assertThat(a == b, equalTo(true))
+        assertThat(a.hashCode() == b.hashCode(), equalTo(true))
+    }
+
+    @Test
+    fun `snapshots differing by a single chrRam byte are not equal`() {
+        val a = snapshot(chrRam = byteArrayOf(0, 1, 2))
+        val b = snapshot(chrRam = byteArrayOf(0, 1, 3))
+        assertThat(a == b, equalTo(false))
+    }
+
+    @Test
+    fun `one null and one non-null chrRam are not equal`() {
+        val a = snapshot(chrRam = byteArrayOf(0, 1, 2))
+        val b = snapshot(chrRam = null)
+        assertThat(a == b, equalTo(false))
+        assertThat(b == a, equalTo(false))
+    }
+
+    // ---- prgRam ----
+
+    @Test
+    fun `snapshots with identical prgRam contents are equal`() {
+        val a = snapshot(prgRam = byteArrayOf(9, 8, 7))
+        val b = snapshot(prgRam = byteArrayOf(9, 8, 7))
+        assertThat(a == b, equalTo(true))
+        assertThat(a.hashCode() == b.hashCode(), equalTo(true))
+    }
+
+    @Test
+    fun `snapshots differing by a single prgRam byte are not equal`() {
+        val a = snapshot(prgRam = byteArrayOf(9, 8, 7))
+        val b = snapshot(prgRam = byteArrayOf(9, 8, 6))
+        assertThat(a == b, equalTo(false))
+    }
+
+    @Test
+    fun `one null and one non-null prgRam are not equal`() {
+        val a = snapshot(prgRam = byteArrayOf(9, 8, 7))
+        val b = snapshot(prgRam = null)
+        assertThat(a == b, equalTo(false))
+        assertThat(b == a, equalTo(false))
+    }
+
+    // ---- both null (the current case for mappers that don't expose RAM) ----
+
+    @Test
+    fun `snapshots with both RAM fields null are equal`() {
+        assertThat(snapshot() == snapshot(), equalTo(true))
+        assertThat(snapshot().hashCode() == snapshot().hashCode(), equalTo(true))
+    }
+
+    // ---- non-RAM fields still gate equality ----
+
+    @Test
+    fun `snapshots differing only by banks are not equal`() {
+        val a = snapshot(chrRam = byteArrayOf(0, 1, 2))
+        val b = MapperStateSnapshot(
+            mapperId = 1, type = "TEST",
+            banks = mapOf("prg" to 1),   // differs
+            registers = mapOf("ctrl" to 0), irqState = null,
+            chrRam = byteArrayOf(0, 1, 2), prgRam = null
+        )
+        assertThat(a == b, equalTo(false))
+    }
+}


### PR DESCRIPTION
Closes #99

## Problem

`MapperStateSnapshot.equals()`/`hashCode()` compared `mapperId`, `type`, `banks`, `registers`, and `irqState` but **silently omitted `chrRam` and `prgRam`**. Two snapshots with identical banking but divergent CHR-RAM or PRG-RAM contents compared as equal — a silent footgun for any future test using `equalTo(snapshot)` to verify a RAM round-trip.

## Fix

Two-line addition to `src/main/kotlin/com/github/alondero/nestlin/gamepak/MapperState.kt`:

- `equals` now compares `chrRam` and `prgRam` byte-by-byte via the stdlib nullable-receiver `ByteArray?.contentEquals()` (which correctly handles all three null cases: both-null equal, one-null-one-non-null unequal, content-diff unequal).
- `hashCode` includes `chrRam?.contentHashCode()` and `prgRam?.contentHashCode()` so the equals/hashCode contract holds.

The comment in source flags *why* content comparison is required (data-class `===` on array fields is reference identity, which would re-introduce the bug) so the next maintainer cannot accidentally regress this.

## Test plan

New `MapperStateSnapshotTest` with 8 cases covering:
- Identical chrRam / prgRam contents → equal, hashCodes match
- Single-byte chrRam / prgRam diff → not equal
- null vs non-null chrRam / prgRam → not equal (both directions)
- Both null → equal
- Non-RAM fields (banks) still gate equality (regression guard)

## Verification

- `./gradlew build` — BUILD SUCCESSFUL
- `./gradlew test` (full unit suite, 1336 tests) — 0 failures, 0 errors
- `./gradlew bootcheck -Prom=X:/src/nestlin/testroms/kirby.nes -Pframes=120` — BOOTCHECK VERDICT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)