### PR TITLE
Fix BRK B-flag push (Closes #9)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/Cpu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/Cpu.kt
@@ -382,11 +382,20 @@ class ProcessorStatus(
         negative = false
     }
 
+    /**
+     * Serialise the flag bits into the pushed-status byte. Note the
+     * "magical" bits: bit 5 is always 1 (the unused flag is hardwired on
+     * the die), and bit 4 (the B/break flag) only exists in the *pushed*
+     * byte — not as stored state. BRK and PHP force B=1; IRQ and NMI
+     * force B=0. The caller sets [breakCommand] before calling and is
+     * responsible for resetting it (BRK does so explicitly; PHP is a
+     * separate follow-up — issue #9 is scoped to BRK).
+     */
     fun asByte() =
         ((if (negative) (1 shl 7) else 0) or
          (if (overflow) (1 shl 6) else 0) or
-         (1 shl 5) or // Special logic needed for the B flag...
-         (0 shl 4) or
+         (1 shl 5) or
+         (if (breakCommand) (1 shl 4) else 0) or
          (if (decimalMode) (1 shl 3) else 0) or
          (if (interruptDisable) (1 shl 2) else 0) or
          (if (zero) (1 shl 1) else 0) or

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/Opcode.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/Opcode.kt
@@ -220,6 +220,12 @@ class NopImplied : Opcode(cycles = 2) {
  * BRK/IRQ discriminator) and increments PC past BRK's padding byte
  * before pushing. Deduplicating would require parameterising both,
  * which adds more complexity than the ~10 lines save.
+ *
+ * The `breakCommand` flag is reset after the push: bit 4 only exists in
+ * the *pushed* byte, never as stored state. Leaving it `true` would make
+ * a subsequent `asByte()` call (e.g., from `saveState`) report B=1 in a
+ * status byte that isn't really being pushed — issue #9 / regression
+ * test `brkResetsBreakCommandAfterPush`.
  */
 class Break : Opcode(cycles = 7) {
     override val mnemonic = "BRK"
@@ -231,6 +237,7 @@ class Break : Opcode(cycles = 7) {
             cpu.push((this and 0xFF).toSignedByte())
         }
         cpu.push(cpu.processorStatus.asByte())
+        cpu.processorStatus.breakCommand = false
         cpu.registers.programCounter = cpu.memory[0xFFFE, 0xFFFF]
         cpu.processorStatus.interruptDisable = true
         cpu.workCyclesLeft = 7

--- a/src/test/kotlin/com/github/alondero/nestlin/cpu/Issue9BrkBFlagPushTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/cpu/Issue9BrkBFlagPushTest.kt
@@ -1,0 +1,163 @@
+package com.github.alondero.nestlin.cpu
+
+import com.github.alondero.nestlin.Memory
+import com.github.alondero.nestlin.testutil.FakeInterruptController
+import com.github.alondero.nestlin.toSignedByte
+import com.github.alondero.nestlin.toSignedShort
+import com.github.alondero.nestlin.toUnsignedInt
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Issue #9 — BRK B-flag is never pushed correctly.
+ *
+ * The 6502's "B" flag (bit 4 of P) doesn't exist as stored state — it only
+ * manifests in the *pushed* status byte. PHP and BRK force bit 4 = 1; IRQ
+ * and NMI force bit 4 = 0. This is how a handler (or kernel) can tell a
+ * software BRK apart from a hardware interrupt.
+ *
+ * `ProcessorStatus.breakCommand` was created for exactly this — BRK sets it
+ * to `true` before calling `asByte()`, but `asByte()` ignored the field
+ * and hardcoded `(0 shl 4)`. Result: BRK pushed status with bit 4 = 0,
+ * indistinguishable from an IRQ/NMI on the stack. The nestest golden log
+ * doesn't exercise BRK lines, so this slipped through `GoldenLogTest`.
+ *
+ * These tests pin the correct behaviour at three levels:
+ *  1. `asByte()` — direct unit test on the serializer.
+ *  2. BRK — the bug under fix (bit 4 must be 1 in the pushed byte).
+ *  3. IRQ — pins the inverse discriminator (bit 4 must be 0); this is the
+ *     whole point of the B flag and the reason the fix must not flip it
+ *     for interrupts.
+ *
+ * Note: PHP (0x08) shares `asByte()` and would today push bit 4 = 0
+ * because PHP does not set `breakCommand` — the 6502 spec says PHP must
+ * push B = 1. That is a *separate* bug; this PR is scoped to BRK per
+ * issue #9. The PHP fix should follow the same pattern (set
+ * `breakCommand = true` in the push lambda, reset after push).
+ */
+class Issue9BrkBFlagPushTest {
+
+    private fun freshCpu() = Cpu(Memory.createWithApu().first).apply { reset() }
+
+    // ===== asByte() — direct unit test on the serializer =================
+
+    @Test
+    fun asByteIncludesBreakCommandAtBit4() {
+        val status = ProcessorStatus().apply {
+            // Pick an unambiguous baseline: all "stored" flags cleared so any
+            // bit in the output came from `breakCommand` and the always-set
+            // bit 5 / always-clear bit 4 (pre-fix).
+            carry = false
+            zero = false
+            interruptDisable = false
+            decimalMode = false
+            overflow = false
+            negative = false
+            breakCommand = false
+        }
+
+        // No B flag → bit 4 clear.
+        val withoutB = status.asByte().toUnsignedInt() and 0x10
+        assertThat(withoutB, equalTo(0))
+
+        // B flag set → bit 4 set (the always-set bit 5 stays set).
+        status.breakCommand = true
+        val withB = status.asByte().toUnsignedInt() and 0x10
+        assertThat(withB, equalTo(0x10))
+        // Bit 5 is always 1 (the unused-but-pushed flag).
+        assertThat(status.asByte().toUnsignedInt() and 0x20, equalTo(0x20))
+    }
+
+    // ===== BRK pushes status with B flag set (the bug under fix) =========
+
+    @Test
+    fun brkPushesStatusWithBFlagSet() {
+        val cpu = freshCpu()
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x00.toSignedByte() // BRK opcode
+        // BRK skips a padding byte; supply one so the PC arithmetic doesn't
+        // bounce off unmapped memory when reading PC+1.
+        cpu.memory[0x0001] = 0xAA.toSignedByte()
+        // IRQ vector — the BRK handler's PC source. Point at $0000 so the
+        // next instruction is a known NOP-like state (here: another BRK).
+        cpu.memory[0xFFFE] = 0x00.toSignedByte()
+        cpu.memory[0xFFFF] = 0x00.toSignedByte()
+        // Stack pointer starts at $FD so the three pushes land at $01FD,
+        // $01FC, $01FB (PC high, PC low, status — see `Cpu.push`).
+        cpu.registers.stackPointer = 0xFD.toSignedByte()
+        // Pick a baseline P without bit 4 so the assertion is unambiguous.
+        cpu.processorStatus.apply {
+            carry = false
+            zero = false
+            interruptDisable = false
+            decimalMode = false
+            overflow = false
+            negative = false
+        }
+
+        cpu.tick()
+
+        // The pushed status byte is at $01FB (3 bytes pushed: PCh, PCl, P).
+        val pushedStatus = cpu.memory[0x01FB].toUnsignedInt()
+        // The fix: bit 4 (B) must be 1 — this is the BRK/IRQ discriminator.
+        assertThat(pushedStatus and 0x10, equalTo(0x10))
+        // And bit 5 (the always-pushed unused flag) must still be 1.
+        assertThat(pushedStatus and 0x20, equalTo(0x20))
+        // The I flag must be set after BRK.
+        assertThat(cpu.processorStatus.interruptDisable, equalTo(true))
+    }
+
+    @Test
+    fun brkResetsBreakCommandAfterPush() {
+        // `breakCommand` is "magic" transient state — it should only be true
+        // during the push, not linger. A follow-up PHP would otherwise push
+        // a polluted byte. This pins the hygiene invariant.
+        val cpu = freshCpu()
+        cpu.registers.programCounter = 0x0000.toSignedShort()
+        cpu.memory[0x0000] = 0x00.toSignedByte() // BRK
+        cpu.memory[0x0001] = 0x00.toSignedByte() // padding
+        cpu.memory[0xFFFE] = 0x00.toSignedByte()
+        cpu.memory[0xFFFF] = 0x00.toSignedByte()
+        cpu.registers.stackPointer = 0xFD.toSignedByte()
+
+        cpu.tick()
+
+        assertThat(cpu.processorStatus.breakCommand, equalTo(false))
+    }
+
+    // ===== IRQ pushes status with B flag clear (preserves the discriminator)
+
+    @Test
+    fun irqPushesStatusWithBFlagClear() {
+        // IRQ uses the same dispatchInterrupt path as NMI. If this test
+        // passes, the discriminator is intact for both — that's the whole
+        // point of the B flag.
+        val fakeController = FakeInterruptController()
+        val cpu = Cpu(Memory.createWithApu().first, fakeController).apply {
+            reset()
+            registers.programCounter = 0x0000.toSignedShort()
+            // IRQ has no 1-instruction latency in the fake — it's dispatched
+            // on the same tick it's armed, as long as I is clear. The NOPs
+            // give the (un-executed) interrupted-instruction slot a sane value
+            // and the IRQ vector handler a known landing pad.
+            for (addr in 0x0000..0x000F) memory[addr] = 0xEA.toSignedByte()
+            memory[0xFFFE] = 0x80.toSignedByte()
+            memory[0xFFFF] = 0x00.toSignedByte()
+            for (addr in 0x0080..0x008F) memory[addr] = 0xEA.toSignedByte()
+            // I flag must be clear or IRQ is suppressed at pendingInterrupt.
+            registers.stackPointer = 0xFD.toSignedByte()
+            processorStatus.interruptDisable = false
+        }
+
+        // IRQ has no 1-instruction latency in the fake; armed == dispatched.
+        fakeController.armIrq()
+        cpu.tick()
+
+        val pushedStatus = cpu.memory[0x01FB].toUnsignedInt()
+        // IRQ pushes status with bit 4 (B) clear — that's the discriminator.
+        assertThat(pushedStatus and 0x10, equalTo(0))
+        // Bit 5 still set (always-pushed unused flag).
+        assertThat(pushedStatus and 0x20, equalTo(0x20))
+    }
+}


### PR DESCRIPTION
Closes #9

## Summary

`ProcessorStatus.asByte()` hardcoded bit 4 (the B / break flag) to 0, so BRK pushed status with bit 4 = 0 — indistinguishable on the stack from an IRQ/NMI. The `breakCommand` field existed and BRK was setting it; `asByte()` just wasn't reading it. This is the BRK/IRQ discriminator that a handler (or kernel) uses to tell software BRK from hardware interrupt.

## Changes

- **`Cpu.kt`** — `asByte()` now reads bit 4 from `breakCommand`. New kdoc explains the B flag's "magical" transient semantics (it only exists in the pushed byte, never as stored state).
- **`Opcode.kt`** — `Break.evaluate` resets `breakCommand = false` after the push. Without this, the transient flag leaks into subsequent `asByte()` calls (e.g., a later `saveState` snapshot would incorrectly report B=1).
- **`Issue9BrkBFlagPushTest.kt`** — new test class with 4 cases:
  1. `asByteIncludesBreakCommandAtBit4` — direct unit test on the serializer.
  2. `brkPushesStatusWithBFlagSet` — the bug under fix.
  3. `brkResetsBreakCommandAfterPush` — state-hygiene invariant.
  4. `irqPushesStatusWithBFlagClear` — pins the inverse discriminator so the fix doesn't accidentally flip it for interrupts.

## Verification

- Test-first approach: regression test ran first, 3 of 4 cases failed (proving the bug).
- After fix: all 4 cases pass.
- Full suite: `./gradlew test` → 1333 tests, 0 failures, 0 errors. Two pre-existing skips (`AkiraFreezeRegressionTest`, `StarSoldierMapper3RegressionTest`) require Mesen2, expected absent in this worktree.
- `./gradlew build` → BUILD SUCCESSFUL.

## Out of scope

PHP (0x08) shares `asByte()` and also pushes bit 4 = 0 because PHP does not set `breakCommand` — the 6502 spec says PHP must push B = 1. The same-shape fix applies: set `breakCommand = true` in PHP's push lambda, reset after push. Flagged in the test file's kdoc; deferred to a separate PR to keep this one tight to issue #9.

## On the issue's "golden log filter" claim

The issue mentions a line-59 filter `contains("=")` masking the bug, but that filter doesn't exist in the current `GoldenLogTest.kt` — the filter text is stale, probably from an older codebase version. The current filter targets opcode 0x29 (ANC). And `nestest.log` has zero BRK lines anyway — no filter would have caught this. The dedicated regression test pins BRK behaviour permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)