### PR TITLE
fix(mapper1): ignore MMC1 serial writes on consecutive CPU cycles

### DIFF
--- a/MAPPER_SUPPORT.md
+++ b/MAPPER_SUPPORT.md
@@ -20,6 +20,7 @@ Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 22, 24, 26, 33,
   - PRG mode 0/1: 32KB mode (both 16KB banks switch together)
   - CHR ROM loaded via mapper delegate into pattern tables
   - **PRG RAM ($6000-$7FFF):** 8KB RAM supported (Added 2026-04-27)
+  - **Consecutive-write ignore (issue #235, 2026-07-19):** the serial port ignores a data write that lands within one CPU cycle of the previous serial write (the 6502 read-modify-write dummy/real write pair), so only the first bit shifts. The bit-7 reset is never ignored (Shinsenden). Cycle stamped via `tickCpuCycle()`; matches Mesen2 `MMC1.h`.
 - **Banking Fix Applied (2026-04-15):** Mode 3 and mode 2 had inverted fixed/switchable assignments per MMC1 spec
 
 ## Mapper 2 (CNROM/UNROM)

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper1.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper1.kt
@@ -24,6 +24,16 @@ class Mapper1(private val gamePak: GamePak) : Mapper {
     private var chrBank1 = 0
     private var prgBank = 0
 
+    // MMC1 serial-port consecutive-write guard (issue #235). tickCpuCycle()
+    // advances cpuCycle once per CPU (M2) cycle; each serial-port write stamps
+    // its cycle in lastSerialWriteCycle. A data write landing within one CPU
+    // cycle of the previous serial write is the 6502 read-modify-write
+    // dummy/real write pair, which real MMC1 shifts only once — see cpuWrite.
+    // These are transient (not save-state persisted): save states are taken at
+    // instruction boundaries, never mid-RMW, so resetting them on load is safe.
+    private var cpuCycle = 0L
+    private var lastSerialWriteCycle = NO_SERIAL_WRITE
+
     // CHR bus: backed by ROM when present, otherwise 8KB of CHR-RAM.
     private val chrMemory: ChrMemory = ChrMemory.default(gamePak.chrRom)
     // Held for save-state/snapshot compatibility (the snapshot field exposes
@@ -86,9 +96,23 @@ class Mapper1(private val gamePak: GamePak) : Mapper {
         }
         if (address < 0x8000) return
 
+        // MMC1's serial port ignores a data write that lands within one CPU
+        // cycle of the previous serial-port write. The 6502 executes
+        // read-modify-write instructions (INC/DEC/ASL/ROR/...) as a dummy write
+        // of the unmodified byte followed by the real write on the very next
+        // cycle; real MMC1 shifts only the first, so without this guard the
+        // second write corrupts the 5-bit shift register (e.g. Bill & Ted).
+        // The bit-7 reset is NEVER ignored — matches Mesen2 MMC1.h / nesdev and
+        // fixes Shinsenden. The cycle stamp is updated unconditionally.
+        val isReset = value.toUnsignedInt() and 0x80 != 0
+        val consecutive = lastSerialWriteCycle != NO_SERIAL_WRITE &&
+            (cpuCycle - lastSerialWriteCycle) < 2L
+        lastSerialWriteCycle = cpuCycle
+        if (consecutive && !isReset) return
+
         // MMC1 uses a 5-bit shift register protocol
         // Bit 7 of the value controls whether this is a "reset" write
-        if (value.toUnsignedInt() and 0x80 != 0) {
+        if (isReset) {
             // Bit 7 set: reset shift register and force PRG mode 3
             shiftReg = 0x10
             controlReg = (controlReg.toUnsignedInt() or 0x0C).toByte()
@@ -111,6 +135,11 @@ class Mapper1(private val gamePak: GamePak) : Mapper {
             }
             shiftReg = 0x10  // Reset to marker value
         }
+    }
+
+    /** Advances the serial-port cycle clock; see the consecutive-write guard in [cpuWrite]. */
+    override fun tickCpuCycle() {
+        cpuCycle++
     }
 
     override fun ppuRead(address: Int): Byte {
@@ -196,5 +225,11 @@ class Mapper1(private val gamePak: GamePak) : Mapper {
             chrRam = chrMemory.snapshotBytes(),
             prgRam = prgRam.copyOf()
         )
+    }
+
+    private companion object {
+        /** Sentinel: no serial-port write has happened yet (guards against a
+         *  spurious "consecutive" verdict on the very first write). */
+        const val NO_SERIAL_WRITE = Long.MIN_VALUE
     }
 }

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper1SuromTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper1SuromTest.kt
@@ -36,9 +36,18 @@ class Mapper1SuromTest {
         return pak.createMapper() as Mapper1
     }
 
-    /** Drive MMC1's 5-write serial load (LSB first) into the register at [addr]. */
+    /**
+     * Drive MMC1's 5-write serial load (LSB first) into the register at [addr].
+     *
+     * Each write is spaced two CPU cycles from the previous one so the
+     * consecutive-write guard (issue #235) accepts every bit — real software
+     * issues each of the 5 writes as a separate STA, several cycles apart.
+     */
     private fun write5(m: Mapper1, addr: Int, value: Int) {
-        for (i in 0 until 5) m.cpuWrite(addr, (((value shr i) and 1)).toSignedByte())
+        for (i in 0 until 5) {
+            repeat(2) { m.tickCpuCycle() }
+            m.cpuWrite(addr, (((value shr i) and 1)).toSignedByte())
+        }
     }
 
     private fun setControl(m: Mapper1, value: Int) = write5(m, 0x8000, value)   // $8000-$9FFF

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper1Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper1Test.kt
@@ -28,6 +28,16 @@ class Mapper1Test {
         return GamePak(header + prgRom + chrRom)
     }
 
+    // A single MMC1 serial-port write, spaced far enough from the previous one
+    // that the consecutive-write guard (issue #235) accepts it. Real software
+    // performs each of the 5 bit-writes with a separate STA, so the CPU cycle
+    // count always advances by several cycles between them; these unit tests
+    // model that by advancing the mapper clock before every write.
+    private fun Mapper1.reg(addr: Int, value: Int) {
+        repeat(2) { tickCpuCycle() }
+        cpuWrite(addr, value.toByte())
+    }
+
     @Test
     fun `5-write shift register completes and writes correct value`() {
         val gamePak = createTestGamePak()
@@ -35,11 +45,11 @@ class Mapper1Test {
 
         // Write 5 bits to the shift register at $8000
         // Bit 0 of each value forms the 5-bit result
-        mapper.cpuWrite(0x8000, 0x01)  // bit 0 = 1
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x01)  // bit 0 = 1
-        mapper.cpuWrite(0x8000, 0x01)  // bit 0 = 1
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0 - completes register
+        mapper.reg(0x8000, 0x01)  // bit 0 = 1
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x01)  // bit 0 = 1
+        mapper.reg(0x8000, 0x01)  // bit 0 = 1
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0 - completes register
 
         // The 5-bit value should be 0b10011 = 0x13
         // We can verify by checking PRG banking - PRG bank register is at $E000-$FFFF
@@ -51,18 +61,18 @@ class Mapper1Test {
         val mapper = Mapper1(gamePak)
 
         // Write some bits first
-        mapper.cpuWrite(0x8000, 0x01)
-        mapper.cpuWrite(0x8000, 0x01)
+        mapper.reg(0x8000, 0x01)
+        mapper.reg(0x8000, 0x01)
 
         // Reset write with bit 7 set
-        mapper.cpuWrite(0x8000, 0x80.toByte())
+        mapper.reg(0x8000, 0x80)
 
         // After reset, write 5 bits to control register and verify
-        mapper.cpuWrite(0x8000, 0x01)  // bit 0 = 1
-        mapper.cpuWrite(0x8000, 0x01)  // bit 0 = 1
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x01)  // bit 0 = 1
-        mapper.cpuWrite(0x8000, 0x01)  // bit 0 = 1, completes
+        mapper.reg(0x8000, 0x01)  // bit 0 = 1
+        mapper.reg(0x8000, 0x01)  // bit 0 = 1
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x01)  // bit 0 = 1
+        mapper.reg(0x8000, 0x01)  // bit 0 = 1, completes
 
         // Control register should be 0x1D = 0b11101
         // But we only verify PRG mode 3 works (last bank fixed at $C000)
@@ -82,11 +92,11 @@ class Mapper1Test {
 
         // Write to PRG bank register ($E000) to switch bank
         // Use 5-write protocol to set PRG bank to 1
-        mapper.cpuWrite(0xE000, 0x01)  // bit 0 = 1
-        mapper.cpuWrite(0xE000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0xE000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0xE000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0xE000, 0x00)  // bit 0 = 0, completes - bank = 0
+        mapper.reg(0xE000, 0x01)  // bit 0 = 1
+        mapper.reg(0xE000, 0x00)  // bit 0 = 0
+        mapper.reg(0xE000, 0x00)  // bit 0 = 0
+        mapper.reg(0xE000, 0x00)  // bit 0 = 0
+        mapper.reg(0xE000, 0x00)  // bit 0 = 0, completes - bank = 0
 
         val switchableBank1 = mapper.cpuRead(0x8000)
         val fixedBank1 = mapper.cpuRead(0xC000)
@@ -104,11 +114,11 @@ class Mapper1Test {
         // Control register is at $8000-$9FFF
         // Bit 4 = 0 for 8KB CHR mode
         // Write 0x00 to control register (CHR mode 0, PRG mode 3, etc.)
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x00)  // completes, control = 0
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x00)  // completes, control = 0
 
         // CHR bank 0 = 0
         val pt0Byte = mapper.ppuRead(0x0000)
@@ -127,11 +137,11 @@ class Mapper1Test {
         // Set CHR mode 1 (4KB banking) via control register
         // Bit 4 = 1 for 4KB CHR mode
         // Write 0x10 to control register
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x10)  // completes, control = 0x10 (bit 4 set)
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x10)  // completes, control = 0x10 (bit 4 set)
 
         // CHR bank 0 should affect $0000-$0FFF
         // CHR bank 1 should affect $1000-$1FFF
@@ -165,30 +175,82 @@ class Mapper1Test {
 
         // Switch to horizontal mirroring (control bits 0-1 = 3)
         // Control register at $8000
-        mapper.cpuWrite(0x8000, 0x01)  // bit 0 = 1
-        mapper.cpuWrite(0x8000, 0x01)  // bit 0 = 1
-        mapper.cpuWrite(0x8000, 0x01)  // bit 0 = 1
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x03)  // completes, control = 0x13
+        mapper.reg(0x8000, 0x01)  // bit 0 = 1
+        mapper.reg(0x8000, 0x01)  // bit 0 = 1
+        mapper.reg(0x8000, 0x01)  // bit 0 = 1
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x03)  // completes, control = 0x13
 
         assertThat(mapper.currentMirroring(), equalTo(Mapper.MirroringMode.HORIZONTAL))
 
         // Switch to one-screen lower (control bits 0-1 = 0)
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x00)  // completes, control = 0x00
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x00)  // completes, control = 0x00
 
         assertThat(mapper.currentMirroring(), equalTo(Mapper.MirroringMode.ONE_SCREEN_LOWER))
 
         // Switch to one-screen upper (control bits 0-1 = 1)
-        mapper.cpuWrite(0x8000, 0x01)  // bit 0 = 1
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x00)  // bit 0 = 0
-        mapper.cpuWrite(0x8000, 0x01)  // completes, control = 0x01
+        mapper.reg(0x8000, 0x01)  // bit 0 = 1
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x00)  // bit 0 = 0
+        mapper.reg(0x8000, 0x01)  // completes, control = 0x01
 
         assertThat(mapper.currentMirroring(), equalTo(Mapper.MirroringMode.ONE_SCREEN_UPPER))
+    }
+
+    // --- Issue #235: MMC1 serial-port consecutive-write ignore -------------
+    //
+    // Real MMC1 ignores a data write that lands within one CPU cycle of the
+    // previous serial-port write. The 6502 runs read-modify-write instructions
+    // (INC/DEC/ASL/ROR/...) as a dummy write of the unmodified byte followed by
+    // the real write on the very next cycle; hardware shifts only the first.
+    // We observe the raw shift register via snapshot() so the assertion is on
+    // the exact number of bits shifted, independent of which register completes.
+
+    private fun shiftReg(mapper: Mapper1) = mapper.snapshot().registers["shiftReg"]
+
+    @Test
+    fun `serial write on the immediately-following CPU cycle is ignored`() {
+        val mapper = Mapper1(createTestGamePak())
+
+        // First write on its own cycle: shiftReg 0x10 -> 0x18 (one bit shifted).
+        repeat(2) { mapper.tickCpuCycle() }
+        mapper.cpuWrite(0x8000, 0x01)
+        assertThat("first write shifts one bit", shiftReg(mapper), equalTo(0x18))
+
+        // Second write on the very next cycle is the RMW dummy/real pair — ignored.
+        mapper.tickCpuCycle()
+        mapper.cpuWrite(0x8000, 0x01)
+        assertThat("consecutive write does not shift again", shiftReg(mapper), equalTo(0x18))
+    }
+
+    @Test
+    fun `serial writes at least two cycles apart both shift`() {
+        val mapper = Mapper1(createTestGamePak())
+
+        repeat(2) { mapper.tickCpuCycle() }
+        mapper.cpuWrite(0x8000, 0x01)          // 0x10 -> 0x18
+        repeat(2) { mapper.tickCpuCycle() }
+        mapper.cpuWrite(0x8000, 0x01)          // 0x18 -> 0x1C (second bit shifts)
+
+        assertThat(shiftReg(mapper), equalTo(0x1C))
+    }
+
+    @Test
+    fun `bit-7 reset is honoured even on the immediately-following cycle`() {
+        val mapper = Mapper1(createTestGamePak())
+
+        repeat(2) { mapper.tickCpuCycle() }
+        mapper.cpuWrite(0x8000, 0x01)          // 0x10 -> 0x18
+        // Reset write on the next cycle: the consecutive-write guard must NOT
+        // suppress a bit-7 reset (matches Mesen2 / nesdev; fixes Shinsenden).
+        mapper.tickCpuCycle()
+        mapper.cpuWrite(0x8000, 0x80.toByte())
+
+        assertThat("shift register reset to marker", shiftReg(mapper), equalTo(0x10))
     }
 }


### PR DESCRIPTION
## Summary

Real MMC1 (Mapper 1) ignores a serial-port **data** write that lands within one CPU cycle of the previous serial write. The 6502 executes read-modify-write instructions (`INC`/`DEC`/`ASL`/`ROR`/…) as a *dummy* write of the unmodified byte followed by the *real* write on the very next cycle; real hardware shifts only the first, so an unguarded emulator shifts both and corrupts the 5-bit shift register.

`Mapper1.cpuWrite` tracked no CPU cycle, so it had no protection (issue #235).

## Changes

- **`Mapper1.kt`**: added a `cpuCycle` counter advanced by a new `tickCpuCycle()` override; each serial write stamps `lastSerialWriteCycle` **unconditionally** and a data write is ignored when it is `<2` cycles after the previous one. The **bit-7 reset is never ignored** (the *Shinsenden* exception). Faithful to the Mesen2 `MMC1.h` oracle.
- **`Mapper1Test.kt` / `Mapper1SuromTest.kt`**: the existing tests fired their 5 serial writes with no cycle advance — an impossible "all on one cycle" pattern the new guard correctly suppresses. They now space each write via `tickCpuCycle()`, exactly as real software does.
- **New regression tests**: consecutive-cycle write shifts only one bit (`0x10→0x18`, not `0x1C`); a ≥2-cycle gap shifts both; bit-7 reset is honoured even on the immediately-following cycle.
- **`MAPPER_SUPPORT.md`**: documented the quirk under the MMC1 section.

## Notes

Nestlin's CPU is a "fat instruction" model and its RMW opcodes issue a single write, so this bug can't corrupt state through the CPU *today* — the fix is hardware-faithful defensive behaviour, which is why the issue asked for a direct mapper-level regression test. Cycle counters are intentionally **not** save-state persisted (save states are taken at instruction boundaries, never mid-RMW), keeping `saveStateVersion` at 2 so existing MMC1 `.nstl` files still load.

## Verification

- `./gradlew test` → **BUILD SUCCESSFUL** (full unit + lint suite).
- `./gradlew bootcheck -Prom=.../lolo1.nes` → **BOOTCHECK VERDICT: WARN** (accepted, not FAIL; the MMC1 integration tests confirm lolo1 boots and renders non-black).

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)