### PR TITLE
Wire Mapper 19 N163 CHR-as-nametable mode to extended CHR-RAM

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/Memory.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Memory.kt
@@ -205,6 +205,20 @@ class Memory : DmaPort {
         }
         ppuAddressedMemory.ppuInternalMemory.chrWriteDelegate = { addr, v -> m.ppuWrite(addr, v) }
 
+        // Nametable override: PPU reads/writes at $2000-$2FFF consult the
+        // mapper first, so mappers that own part of the nametable area
+        // (Mapper 19's CHR-as-NT, future 4-screen modes) can claim the byte.
+        // The mapper returns null / false for "not mine" — the request falls
+        // through to PpuInternalMemory's standard CIRAM mirroring. This is
+        // the second half of the CHR/namespacing plumbing — the first half
+        // is `chrReadDelegate` above for the $0000-$1FFF CHR range.
+        ppuAddressedMemory.ppuInternalMemory.nametableReadDelegate = { addr ->
+            m.readNametableOverride(addr)
+        }
+        ppuAddressedMemory.ppuInternalMemory.nametableWriteDelegate = { addr, v ->
+            m.writeNametableOverride(addr, v)
+        }
+
         // Wire A12 edge detection for MMC3 scanline IRQ
         ppuAddressedMemory.ppuInternalMemory.a12EdgeListener = { rising -> m.notifyA12Edge(rising) }
         ppuAddressedMemory.ppuInternalMemory.resetA12State()

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper.kt
@@ -22,6 +22,28 @@ interface Mapper {
     fun currentMirroring(): MirroringMode
 
     /**
+     * Optional PPU nametable ($2000-$2FFF) override for read. Return non-null
+     * to take ownership of the byte (e.g. Mapper 19's CHR-as-nametable extension
+     * redirects the read to its internal CHR-RAM); return null to fall through
+     * to PpuInternalMemory's standard CIRAM-backed mirroring.
+     *
+     * [address] is the FULL PPU address ($2000-$2FFF, not normalised). This is
+     * distinct from [ppuRead] which only covers the CHR range $0000-$1FFF —
+     * the PPU's two read paths converge in [com.github.alondero.nestlin.ppu.PpuInternalMemory],
+     * which consults this hook before the standard table/offset resolution.
+     *
+     * Default no-op (every existing mapper inherits "no nametable override").
+     */
+    fun readNametableOverride(address: Int): Byte? = null
+
+    /**
+     * Mirror of [readNametableOverride] for writes. Return `true` to consume
+     * the write (no fall-through to the standard CIRAM backing); `false` to
+     * let PpuInternalMemory's standard write happen.
+     */
+    fun writeNametableOverride(address: Int, value: Byte): Boolean = false
+
+    /**
      * CPU data-bus value, set by [Memory] before each `cpuRead` call. Open-
      * bus reads (i.e. addresses the mapper has no byte of its own to return
      * for) should return this value, matching real 6502 hardware where

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper19.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper19.kt
@@ -94,6 +94,18 @@ class Mapper19(private val gamePak: GamePak) : Mapper {
     // the same `ppuRead` dispatch.
     private val chrMemory: ChrMemory = ChrMemory.default(chrRom, chrRamSize = 0x3000)
 
+    // Extended CHR-RAM (4KB at offsets $2000-$2FFF of the chip's internal RAM).
+    // Always present — real N163 hardware has internal RAM here regardless of
+    // whether the cartridge carries external CHR-ROM. When CHR-as-nametable
+    // mode is active (chrBanks[i] has bit 8 set), the lower 1KB backs NT A
+    // ($2000-$23FF) and the upper 1KB backs NT B ($2400-$27FF). The other 2KB
+    // is reserved for banks 10/11 in non-NT mode (extended CHR pattern data).
+    //
+    // We keep this separate from [chrMemory] because [chrMemory] collapses to
+    // ROM-only when chrRom is non-empty — the extended region has no CHR-ROM
+    // backing on real hardware, so it must be RAM regardless.
+    private val extendedChrRam: ByteArray = ByteArray(0x1000)
+
     // 4 × 2KB PRG-RAM pages at $6000-$7FFF. _writeProtect gates writes per
     // page; reads are always live.
     private val prgRam = ByteArray(0x2000)
@@ -281,25 +293,20 @@ class Mapper19(private val gamePak: GamePak) : Mapper {
         val bankIndex = a ushr 10   // 0..7
         val bank = chrBanks[bankIndex]
         if (bank and 0x100 != 0) {
-            // Nametable-extension: bit 0 selects the lower ($2000) or
-            // upper ($2400) nametable. We don't have a real nametable
-            // backing store wired to the mapper (the PPU's own internal
-            // nametable RAM is the source of truth), so we return a
-            // deterministic placeholder. Real cartridges use this in
-            // conjunction with extended CHR-RAM to give the PPU a 4-screen
-            // arrangement; surfacing it as 0 is honest about not modelling
-            // that — but the standard 8-bank decode below covers the games
-            // the regression test exercises.
+            // CHR-as-nametable mode. Bit 0 of the stored bank value selects
+            // which NT slot (A = $2000-$23FF, B = $2400-$27FF) this 1KB CHR
+            // window now mirrors. Both slots are backed by the chip's internal
+            // CHR-RAM at extended offsets 0x000 (NT A) and 0x400 (NT B).
             //
-            // TODO(extended-nametable): plumb through to the PPU's
-            // nametable RAM when a game actually uses this mode. Until
-            // then, log so a divergence surfaces rather than silently
-            // rendering wrong tiles.
-            System.err.println(
-                "Mapper 19: nametable-extended CHR bank $bankIndex read at PPU " +
-                    "\$${address.toString(16)}; not yet wired to nametable RAM."
-            )
-            return 0
+            // Wiring (issue #234): a PPU read at $0000-$03FF in NT mode
+            // returns the same byte as a PPU read at $2000-$23FF (or $2400-
+            // $27FF), because both windows now read from [extendedChrRam].
+            // Games that use this mode (Namco-published titles like Splatterhouse
+            // Wanpaku Graffiti, Rolling Thunder, etc.) get a 4-screen
+            // arrangement where the "fourth screen" lives in the chip's
+            // internal RAM instead of cartridge CIRAM.
+            val ntOffset = (bank and 0x01) * 0x400
+            return extendedChrRam[ntOffset + (a and 0x03FF)]
         }
         val rom = chrRom
         return if (rom.isNotEmpty()) {
@@ -315,13 +322,50 @@ class Mapper19(private val gamePak: GamePak) : Mapper {
         val bankIndex = a ushr 10
         val bank = chrBanks[bankIndex]
         if (bank and 0x100 != 0) {
-            // Same TODO as ppuRead — nametable-extended CHR windows aren't
-            // currently backed by the PPU's nametable RAM.
+            // Mirror of [ppuRead]'s NT-mode branch: a PPU write at $0000-$03FF
+            // in NT mode lands in [extendedChrRam] at the same offset a PPU
+            // write at $2000-$23FF (or $2400-$27FF) would land via
+            // [writeNametableOverride]. This is what makes the two PPU
+            // windows stay synchronised for the 4-screen arrangement.
+            val ntOffset = (bank and 0x01) * 0x400
+            extendedChrRam[ntOffset + (a and 0x03FF)] = value
             return
         }
         if (chrRom.isEmpty()) {
             chrMemory.write(bankIndex * 0x0400 + (a and 0x03FF), value)
         }
+    }
+
+    override fun readNametableOverride(address: Int): Byte? {
+        // PPU reads at $2000-$2FFF route through here when a mapper owns part
+        // of the nametable area. Banks 8-11 cover $2000/$2400/$2800/$2C00 in
+        // 1KB slots. When bank N (8..11) is in NT mode (bit 8 of [chrBanks]N
+        // is set), the corresponding PPU window reads from [extendedChrRam]
+        // at the NT A / NT B slot; otherwise we return null so the standard
+        // PpuInternalMemory CIRAM-backed read proceeds unchanged.
+        val a = address - 0x2000
+        if (a < 0 || a >= 0x1000) return null
+        val bankIndex = 8 + (a ushr 10)
+        val bank = chrBanks[bankIndex]
+        if (bank and 0x100 == 0) return null
+        val ntOffset = (bank and 0x01) * 0x400
+        return extendedChrRam[ntOffset + (a and 0x03FF)]
+    }
+
+    override fun writeNametableOverride(address: Int, value: Byte): Boolean {
+        // Mirror of [readNametableOverride]. Returning `true` consumes the
+        // write (no fall-through to PpuInternalMemory's CIRAM mirroring) so
+        // the standard table/offset write at [PpuInternalMemory.set] is
+        // skipped — the extended 4KB RAM is the sole source of truth for
+        // this NT slot while it's in NT mode.
+        val a = address - 0x2000
+        if (a < 0 || a >= 0x1000) return false
+        val bankIndex = 8 + (a ushr 10)
+        val bank = chrBanks[bankIndex]
+        if (bank and 0x100 == 0) return false
+        val ntOffset = (bank and 0x01) * 0x400
+        extendedChrRam[ntOffset + (a and 0x03FF)] = value
+        return true
     }
 
     // ---- Mirroring ----------------------------------------------------------
@@ -370,6 +414,13 @@ class Mapper19(private val gamePak: GamePak) : Mapper {
             "prgBank2" to prgBank2
         )
         for (i in 0 until 12) banks["chrBank$i"] = chrBanks[i]
+        // chrMemory already covers the 8KB standard + 4KB extended window
+        // (or ROM bytes when CHR-ROM is present); we tack on the dedicated
+        // NT-extension 4KB so a divergence dump shows both surfaces. The
+        // extra 4KB is fine for human inspection — `MapperStateSnapshot.chrRam`
+        // is documented as "for the debug snapshot", not a fixed-size contract.
+        val baseChrRam = chrMemory.snapshotBytes()
+        val combined = if (baseChrRam != null) baseChrRam + extendedChrRam else null
         return MapperStateSnapshot(
             mapperId = 19,
             type = "Namco 163",
@@ -384,14 +435,20 @@ class Mapper19(private val gamePak: GamePak) : Mapper {
                 "irqCounter" to irqCounter,
                 "irqPending" to if (irqPending) 1 else 0
             ),
-            chrRam = chrMemory.snapshotBytes(),
+            chrRam = combined,
             prgRam = prgRam.copyOf()
         )
     }
 
     // ---- Save state --------------------------------------------------------
 
-    override val saveStateVersion: Int = 3
+    // v4: issue #234 — extended CHR-RAM (4KB) backing the CHR-as-nametable
+    // mode is now wired and must round-trip through save state. v3 dumps
+    // predated the wiring and have no [extendedChrRam] bytes to read — the
+    // version bump makes the [SaveState.IncompatibleSaveStateException] the
+    // load path raises on a v3 file loud rather than silently deserialising
+    // garbage (and re-zeros extendedChrRam by accident).
+    override val saveStateVersion: Int = 4
 
     override fun saveState(out: DataOutput) {
         super.saveState(out)
@@ -407,6 +464,7 @@ class Mapper19(private val gamePak: GamePak) : Mapper {
         out.writeInt(prgRamPageWriteProtectMask)
         out.write(prgRam)
         chrMemory.serialize(out)
+        out.write(extendedChrRam)
         audio.saveState(out)
     }
 
@@ -424,6 +482,7 @@ class Mapper19(private val gamePak: GamePak) : Mapper {
         prgRamPageWriteProtectMask = input.readInt()
         input.readFully(prgRam)
         chrMemory.deserialize(input)
+        input.readFully(extendedChrRam)
         audio.loadState(input)
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/PpuInternalMemory.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/PpuInternalMemory.kt
@@ -17,6 +17,24 @@ class PpuInternalMemory {
     var chrReadDelegate: ((Int) -> Byte)? = null
     var chrWriteDelegate: ((Int, Byte) -> Unit)? = null
 
+    // Optional nametable override ($2000-$2FFF). When a mapper (e.g. Mapper 19
+    // CHR-as-nametable mode) wants to redirect a nametable read/write to its own
+    // backing — typically because the chip's internal CHR-RAM is doubling as NT
+    // RAM — it installs these and returns `true` / non-null to claim the access.
+    // null / false means "fall through to the standard CIRAM-backed read".
+    //
+    // The split between read & write mirrors chrReadDelegate / chrWriteDelegate
+    // so the mapper's `ppuRead` (which only covers $0000-$1FFF CHR) can co-exist
+    // with the mapper's `readNametableOverride` (which covers $2000-$2FFF) —
+    // both delegate paths converge in this class.
+    //
+    // The READ lambda returns `Byte?` (nullable) so the mapper can signal
+    // "I don't own this address" by returning null — the caller's `?: run {...}`
+    // then falls through to the standard CIRAM mirroring. A non-null Byte is
+    // the mapper's authoritative read result.
+    var nametableReadDelegate: ((Int) -> Byte?)? = null
+    var nametableWriteDelegate: ((Int, Byte) -> Boolean)? = null
+
     // A12 edge detection for MMC3 scanline IRQ
     private var lastA12High: Boolean = false
     // Tracks how many M2 (CPU) cycles A12 has been continuously low
@@ -89,8 +107,13 @@ class PpuInternalMemory {
         }
         in 0x2000..0x2FFF -> {
             emitA12(addr)
-            val (table, offset) = mapNametableAddress(addr)
-            table[offset]
+            // Nametable override: mappers that own part of the nametable area
+            // (e.g. Mapper 19's CHR-as-NT mode) return non-null to claim the
+            // read. See `Mapper.readNametableOverride`.
+            nametableReadDelegate?.invoke(addr) ?: run {
+                val (table, offset) = mapNametableAddress(addr)
+                table[offset]
+            }
         }
         in 0x3000..0x3EFF -> this[addr - 0x1000] // Mirror of 0x2000 - 0x2EFF
         else /*in 0x3F00..0x3FFF*/ -> paletteRam[addr % 0x020]
@@ -109,8 +132,14 @@ class PpuInternalMemory {
             }
             in 0x2000..0x2FFF -> {
                 emitA12(addr)
-                val (table, offset) = mapNametableAddress(addr)
-                table[offset] = value
+                // Mirror of the read path — see `Mapper.writeNametableOverride`.
+                // Returning `true` from the delegate consumes the write (no
+                // fall-through to the standard CIRAM mirroring); `false` (or a
+                // null delegate) lets the standard table/offset write happen.
+                if (nametableWriteDelegate?.invoke(addr, value) != true) {
+                    val (table, offset) = mapNametableAddress(addr)
+                    table[offset] = value
+                }
             }
             in 0x3000..0x3EFF -> this[addr - 0x1000] = value // Mirror of 0x2000 - 0x2EFF
             else /*in 0x3F00..0x3FFF*/ -> paletteRam[addr % 0x020] = value

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper19Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper19Test.kt
@@ -1,5 +1,6 @@
 package com.github.alondero.nestlin.gamepak
 
+import com.github.alondero.nestlin.ppu.PpuInternalMemory
 import com.github.alondero.nestlin.testutil.testGamePak
 import com.github.alondero.nestlin.toSignedByte
 import com.github.alondero.nestlin.toUnsignedInt
@@ -164,20 +165,20 @@ class Mapper19Test {
     // ---- CHR nametable extension (value >= 0xE0) ----
 
     @Test
-    fun `CHR bank value with bit 7 set routes to a nametable sentinel`() {
-        // Per spec: a value >= 0xE0 + !lowChrNtMode → that 1KB CHR window
-        // becomes a nametable instead of CHR. We don't model the nametable
-        // backing yet (TODO in Mapper19.ppuRead), but the read should NOT
-        // return the value as if it were a CHR bank number (e.g. 0xE0 = 224,
-        // which would index way past the 8KB CHR ROM).
+    fun `CHR bank value with bit 7 set routes to the extended CHR-RAM nametable`() {
+        // Issue #234: a value >= 0xE0 + !lowChrNtMode turns that 1KB CHR window
+        // into a nametable mirror backed by the chip's extended 4KB CHR-RAM.
+        // Previously this branch logged and returned 0; now the read goes
+        // through to the NT slot. With a fresh extendedChrRam, the read still
+        // returns 0 — but for the *right* reason (uninitialised RAM) instead
+        // of a sentinel placeholder.
         val m = newN163(prgKb = 128, chrKb = 8)
-        m.cpuWrite(0x8000, 0xE0.toSignedByte())    // value >= 0xE0 → nametable
-        m.cpuWrite(0x9000, 0x05.toSignedByte())     // normal bank for comparison
-        // The two windows should NOT both read the same byte: $E0 is a
-        // nametable flag, $05 is a CHR bank. The fact that we return 0
-        // for the nametable (and 5 for the CHR) is what matters here.
-        assertThat("PPU \$0000 (nametable-extended) is NOT chr bank 224", m.ppuRead(0x0000).toUnsignedInt(), equalTo(0))
-        assertThat("PPU \$0800 (chr bank 5) still works", m.ppuRead(0x0800).toUnsignedInt(), equalTo(5))
+        m.cpuWrite(0x8000, 0xE0.toSignedByte())    // value >= 0xE0 → NT mode
+        m.cpuWrite(0x9000, 0x05.toSignedByte())    // normal CHR bank for control
+        assertThat("PPU \$0000 (NT-mode) reads from extended CHR-RAM (fresh = 0)",
+            m.ppuRead(0x0000).toUnsignedInt(), equalTo(0))
+        assertThat("PPU \$0800 (chr bank 5) still works",
+            m.ppuRead(0x0800).toUnsignedInt(), equalTo(5))
     }
 
     @Test
@@ -199,6 +200,133 @@ class Mapper19Test {
         val chrBank0 = snap.banks["chrBank0"] ?: 0
         assertThat("chrBank0 stored as plain CHR bank (no nt sentinel)",
             chrBank0 and 0x100, equalTo(0))
+    }
+
+    // ---- CHR-as-nametable wiring (issue #234) --------------------------------
+    //
+    // The CHR-as-nametable trick has TWO coupled surfaces that must agree:
+    //   (a) PPU reads at $0000-$03FF (CHR bank 0 in NT mode) read from the
+    //       extended CHR-RAM "NT A" slot.
+    //   (b) PPU reads at $2000-$23FF (when CHR bank 8 is in NT mode with bit 0=0)
+    //       read from the SAME extended CHR-RAM "NT A" slot.
+    //
+    // Both surfaces must observe the same byte at the same offset — that's the
+    // whole point of the trick (one window of internal RAM accessible from
+    // both a CHR address and a NT address). Without this wiring, the game
+    // writes nametable data to one address and reads back through the other
+    // and gets 0, so the screen renders wrong.
+
+    @Test
+    fun `CHR bank 0 in NT mode bit 0 = 0 reads from extended CHR-RAM NT A slot`() {
+        // After issue #234, NT-mode bank 0 (value 0xE0) routes the PPU read
+        // at $0000-$03FF to extendedChrRam[0x000-0x3FF]. The bit-0=0 case is
+        // NT A, so we offset 0x000 (not 0x400).
+        val m = newN163(prgKb = 128, chrKb = 0)
+        m.cpuWrite(0x8000, 0xE0.toSignedByte())    // bank 0 → NT mode, bit 0 = 0 (NT A)
+        m.ppuWrite(0x0050, 0xAB.toSignedByte())    // writes to NT A offset 0x050
+        assertThat("PPU \$0050 reads back 0xAB from NT A slot",
+            m.ppuRead(0x0050).toUnsignedInt(), equalTo(0xAB))
+    }
+
+    @Test
+    fun `CHR bank 0 in NT mode bit 0 = 1 reads from extended CHR-RAM NT B slot`() {
+        // NT-mode bank 0 with bit 0=1 routes to NT B at extendedChrRam[0x400-0x7FF].
+        // The two slots are distinct — a write to one doesn't bleed into the
+        // other (which would defeat the 4-screen arrangement).
+        val m = newN163(prgKb = 128, chrKb = 0)
+        m.cpuWrite(0x8000, 0xE1.toSignedByte())    // bank 0 → NT mode, bit 0 = 1 (NT B)
+        m.ppuWrite(0x0100, 0xCD.toSignedByte())    // writes to NT B offset 0x100
+        assertThat("PPU \$0100 reads back 0xCD from NT B slot",
+            m.ppuRead(0x0100).toUnsignedInt(), equalTo(0xCD))
+        // Also verify NT A is independent — write to NT A offset 0x100 and
+        // confirm NT B at the same offset is unaffected.
+        m.cpuWrite(0x8000, 0xE0.toSignedByte())    // bank 0 → NT A
+        m.ppuWrite(0x0100, 0x11.toSignedByte())    // writes NT A offset 0x100
+        assertThat("PPU \$0100 with NT A reads 0x11 (independent from NT B)",
+            m.ppuRead(0x0100).toUnsignedInt(), equalTo(0x11))
+        m.cpuWrite(0x8000, 0xE1.toSignedByte())    // bank 0 → NT B
+        assertThat("PPU \$0100 with NT B still reads 0xCD (unaffected)",
+            m.ppuRead(0x0100).toUnsignedInt(), equalTo(0xCD))
+    }
+
+    @Test
+    fun `CHR bank 8 in NT mode redirects PPU 2000 reads to NT A extended CHR-RAM`() {
+        // Banks 8-11 live at the extended CHR/nametable register range
+        // ($C000-$D800) and per the wiki "always select CHR banks for PPU
+        // $2000-$2FFF". When bank 8 is in NT mode (value 0xE0), PPU reads at
+        // $2000-$23FF go to extendedChrRam via readNametableOverride —
+        // bypassing the standard PpuInternalMemory CIRAM.
+        val m = newN163(prgKb = 128, chrKb = 0)
+        m.cpuWrite(0xC000, 0xE0.toSignedByte())    // bank 8 → NT A
+        assertThat("readNametableOverride(\$2000) returns the NT slot byte",
+            m.readNametableOverride(0x2000)?.toUnsignedInt(), equalTo(0))
+        assertThat("readNametableOverride(\$2001) reads from extended CHR-RAM",
+            m.readNametableOverride(0x2001)?.toUnsignedInt(), equalTo(0))
+    }
+
+    @Test
+    fun `writeNametableOverride writes to extended CHR-RAM when bank 8 is in NT mode`() {
+        // Mirror of the read path: when bank 8 (PPU $2000-$23FF) is in NT
+        // mode, a PPU write at $2000-$23FF lands in extendedChrRam, NOT in
+        // PpuInternalMemory's nameTable0. The override returns `true` to
+        // signal the write was consumed.
+        val m = newN163(prgKb = 128, chrKb = 0)
+        m.cpuWrite(0xC000, 0xE0.toSignedByte())    // bank 8 → NT A
+        val consumed = m.writeNametableOverride(0x2050, 0xAB.toSignedByte())
+        assertThat("writeNametableOverride returns true (consumed) when bank 8 is NT",
+            consumed, equalTo(true))
+        assertThat("readNametableOverride(\$2050) reads back 0xAB",
+            m.readNametableOverride(0x2050)?.toUnsignedInt(), equalTo(0xAB))
+    }
+
+    @Test
+    fun `writeNametableOverride is no-op when bank 8 is NOT in NT mode`() {
+        // When bank 8's value is below 0xE0, the bank is a regular CHR bank
+        // (or unused) and the PPU $2000-$23FF path should fall through to
+        // PpuInternalMemory's CIRAM. The override returns `false` to signal
+        // "I didn't consume this".
+        val m = newN163(prgKb = 128, chrKb = 0)
+        m.cpuWrite(0xC000, 0x05.toSignedByte())    // bank 8 → plain CHR bank (not NT)
+        val consumed = m.writeNametableOverride(0x2050, 0xAB.toSignedByte())
+        assertThat("writeNametableOverride returns false (passthrough) when bank 8 is not NT",
+            consumed, equalTo(false))
+        assertThat("readNametableOverride returns null (passthrough)",
+            m.readNametableOverride(0x2050), equalTo(null))
+    }
+
+    @Test
+    fun `CHR bank 0 in NT mode and CHR bank 8 in NT mode see the same extended CHR-RAM byte`() {
+        // The whole point of the CHR-as-NT trick: writing to PPU $0000-$03FF
+        // (bank 0 in NT mode) and reading back at PPU $2000-$23FF (bank 8 in
+        // NT mode, bit 0=0) must return the same byte, because both windows
+        // address the SAME NT A slot in extendedChrRam. Without this, games
+        // can't coordinate the "extra screen" between the CHR-side and
+        // NT-side writes.
+        val m = newN163(prgKb = 128, chrKb = 0)
+        m.cpuWrite(0x8000, 0xE0.toSignedByte())    // bank 0 → NT A
+        m.cpuWrite(0xC000, 0xE0.toSignedByte())    // bank 8 → NT A
+        // Write via the CHR window (bank 0 in NT mode), read via the NT
+        // window (bank 8 in NT mode) — must match.
+        m.ppuWrite(0x0080, 0x77.toSignedByte())
+        assertThat("PPU \$2080 (NT side) reflects the CHR-side write",
+            m.readNametableOverride(0x2080)?.toUnsignedInt(), equalTo(0x77))
+        // And the inverse: write via the NT window, read via the CHR window.
+        m.writeNametableOverride(0x2090, 0x88.toSignedByte())
+        assertThat("PPU \$0090 (CHR side) reflects the NT-side write",
+            m.ppuRead(0x0090).toUnsignedInt(), equalTo(0x88))
+    }
+
+    @Test
+    fun `CHR bank 4 in NT mode bit 0 = 0 reads from extended CHR-RAM NT A slot`() {
+        // Banks 4-7 are gated by highChrNtMode (bit 7 of $E800), which is
+        // independent of lowChrNtMode (bit 6). Default state is highChrNtMode
+        // = 0, so banks 4-7 honor NT mode like banks 0-3. Bit 0=0 still
+        // selects NT A.
+        val m = newN163(prgKb = 128, chrKb = 0)
+        m.cpuWrite(0xA000, 0xE0.toSignedByte())    // bank 4 → NT mode, bit 0 = 0 (NT A)
+        m.ppuWrite(0x1050, 0xEE.toSignedByte())
+        assertThat("PPU \$1050 (bank 4 NT mode) reads back 0xEE from NT A slot",
+            m.ppuRead(0x1050).toUnsignedInt(), equalTo(0xEE))
     }
 
     // ---- PRG-RAM ($6000-$7FFF) and write-protect ----
@@ -385,6 +513,47 @@ class Mapper19Test {
             ex.message!!.contains("Mapper19"), equalTo(true))
     }
 
+    @Test
+    fun `extended CHR-RAM survives save and load round-trip`() {
+        // Issue #234: extendedChrRam backs the CHR-as-nametable mode and
+        // must round-trip through save state. Without this, restoring a save
+        // taken mid-game would zero the 4KB of NT-extension data and the
+        // screen would render wrong until the game re-wrote it (which games
+        // typically don't do between save and load).
+        val m = newN163(prgKb = 128, chrKb = 0)
+        m.cpuWrite(0x8000, 0xE0.toSignedByte())    // bank 0 → NT A
+        m.cpuWrite(0xA000, 0xE1.toSignedByte())    // bank 4 → NT B
+        m.cpuWrite(0xC000, 0xE0.toSignedByte())    // bank 8 → NT A
+        m.cpuWrite(0xC800, 0xE1.toSignedByte())    // bank 9 → NT B
+        // Write a few distinct bytes across both NT slots.
+        m.ppuWrite(0x0005, 0x11.toSignedByte())    // NT A offset 5 (via bank 0)
+        m.ppuWrite(0x03FF, 0x22.toSignedByte())    // NT A offset 0x3FF (via bank 0)
+        m.writeNametableOverride(0x240A, 0x33.toSignedByte())    // NT B offset 0xA (via bank 9)
+
+        val baos = ByteArrayOutputStream()
+        val out = DataOutputStream(baos)
+        m.saveState(out)
+        out.flush()
+        val bytes = baos.toByteArray()
+
+        val m2 = newN163(prgKb = 128, chrKb = 0)
+        val inp = DataInputStream(ByteArrayInputStream(bytes))
+        m2.loadState(inp)
+
+        // NT A bytes (bank 0 still in NT mode bit 0=0)
+        assertThat("NT A offset 5 restored",
+            m2.ppuRead(0x0005).toUnsignedInt(), equalTo(0x11))
+        assertThat("NT A offset 0x3FF restored",
+            m2.ppuRead(0x03FF).toUnsignedInt(), equalTo(0x22))
+        // NT B byte (bank 9 still in NT mode bit 0=1 — bank 9 owns the
+        // $2400-$27FF PPU window that readNametableOverride dispatches on)
+        assertThat("NT B offset 0xA restored (via readNametableOverride)",
+            m2.readNametableOverride(0x240A)?.toUnsignedInt(), equalTo(0x33))
+        // Bytes we DIDN'T write are still 0
+        assertThat("NT A offset 0 untouched",
+            m2.ppuRead(0x0000).toUnsignedInt(), equalTo(0))
+    }
+
     // ---- Snapshot ----
 
     @Test
@@ -396,6 +565,116 @@ class Mapper19Test {
         assertThat("mapperId", snap.mapperId, equalTo(19))
         assertThat("prgBank0", snap.banks["prgBank0"], equalTo(5))
         assertThat("chrBank0", snap.banks["chrBank0"], equalTo(3))
+    }
+
+    // ---- End-to-end wiring through PpuInternalMemory (issue #234) -----------
+    //
+    // These tests replicate the delegate wiring that `Memory.readCartridge`
+    // installs (`ppuInternalMemory.nametableReadDelegate = ...` +
+    // `nametableWriteDelegate = ...`). Going through `PpuInternalMemory` (not
+    // calling Mapper19 directly) catches bugs that a direct-call test would
+    // miss — e.g. an off-by-one in `mapNametableAddress`, a typo in the
+    // delegate lambda, or the fallback path incorrectly skipping the override.
+    //
+    // The "usage trace" framing: a game running N163's CHR-as-NT mode reads
+    // and writes nametables through PPU $2000-$2FFF during normal operation
+    // (CPU $2007 PPUDATA + PPU rendering-time $2000-$2FFF fetches). After
+    // issue #234 those accesses route through Mapper19's extended CHR-RAM,
+    // not PpuInternalMemory's CIRAM, and the test below proves that.
+
+    @Test
+    fun `end-to-end - PPU 2000 reads hit the mapper's extended CHR-RAM when bank 8 is NT`() {
+        // Wiring: same pattern Memory.kt:readCartridge uses. We don't go
+        // through Memory here because that pulls in the full CPU + APU +
+        // PPU stack — overkill for a delegate round-trip test.
+        val mapper = newN163(prgKb = 128, chrKb = 0)
+        val ppuMem = PpuInternalMemory()
+        ppuMem.nametableReadDelegate = { addr -> mapper.readNametableOverride(addr) }
+        ppuMem.nametableWriteDelegate = { addr, v -> mapper.writeNametableOverride(addr, v) }
+        mapper.cpuWrite(0xC000, 0xE0.toSignedByte())   // bank 8 → NT A
+
+        // CPU-side path: PPUDATA write via $2007. PpuInternalMemory.set is
+        // called for the vramAddress'd PPU address — write to $2000 lands
+        // there because vRamAddress is 0 by default.
+        ppuMem[0x2000] = 0x42.toSignedByte()
+        // Re-read goes through the delegate → mapper.readNametableOverride →
+        // extendedChrRam[0x000], NOT the standard CIRAM. Verify both paths
+        // agree on the source so a regression that bypassed the override
+        // would surface as "CIRAM and override return different bytes".
+        assertThat("PPU \$2000 read goes through the override (round-trip)",
+            ppuMem[0x2000].toUnsignedInt(), equalTo(0x42))
+        assertThat("mapper.readNametableOverride(\$2000) returns 0x42 (owning the byte)",
+            mapper.readNametableOverride(0x2000)?.toUnsignedInt(), equalTo(0x42))
+    }
+
+    @Test
+    fun `end-to-end - PPU 2000 reads fall through to CIRAM when bank 8 is NOT NT`() {
+        // Negative case: with bank 8 in normal (non-NT) mode, the delegate
+        // returns null/false and the standard CIRAM path runs. Without this
+        // we couldn't distinguish a wired-up mapper from one that always
+        // returns a value.
+        val mapper = newN163(prgKb = 128, chrKb = 0)
+        val ppuMem = PpuInternalMemory()
+        ppuMem.nametableReadDelegate = { addr -> mapper.readNametableOverride(addr) }
+        ppuMem.nametableWriteDelegate = { addr, v -> mapper.writeNametableOverride(addr, v) }
+        mapper.cpuWrite(0xC000, 0x05.toSignedByte())   // bank 8 → plain CHR bank (not NT)
+
+        // With no override, writes go to nameTable0 (via mapNametableAddress).
+        ppuMem[0x2000] = 0x42.toSignedByte()
+        // Re-read through the delegate path: should still be 0x42 (came
+        // from CIRAM, not extended CHR-RAM, so the mapper.readNametableOverride
+        // returns null and we see the same byte via fall-through).
+        assertThat("ppu \$2000 reads back 0x42 from CIRAM (no override)",
+            ppuMem[0x2000].toUnsignedInt(), equalTo(0x42))
+        // And confirm Mapper19's extended CHR-RAM was untouched (still 0).
+        assertThat("mapper's readNametableOverride(\$2000) is null (no claim)",
+            mapper.readNametableOverride(0x2000), equalTo(null))
+    }
+
+    @Test
+    fun `end-to-end - CHR and NT sides share extended CHR-RAM`() {
+        // The "4-screen" arrangement: writes at PPU $0000-$03FF (CHR side,
+        // bank 0 in NT mode) and reads at PPU $2000-$23FF (NT side, bank 8
+        // in NT mode with bit 0=0) must agree, because both windows address
+        // the same NT A slot. This is the headline test for issue #234.
+        val mapper = newN163(prgKb = 128, chrKb = 0)
+        val ppuMem = PpuInternalMemory()
+        ppuMem.nametableReadDelegate = { addr -> mapper.readNametableOverride(addr) }
+        ppuMem.nametableWriteDelegate = { addr, v -> mapper.writeNametableOverride(addr, v) }
+        mapper.cpuWrite(0x8000, 0xE0.toSignedByte())   // bank 0 → NT A
+        mapper.cpuWrite(0xC000, 0xE0.toSignedByte())   // bank 8 → NT A
+
+        // Write via PPU $2000-$23FF (NT side, the typical PPU rendering fetch).
+        ppuMem[0x2010] = 0xAB.toSignedByte()
+        // Read via PPU $0000-$03FF (CHR side, same backing slot).
+        assertThat("CHR side reads 0xAB written through NT side",
+            mapper.ppuRead(0x0010).toUnsignedInt(), equalTo(0xAB))
+
+        // Inverse: write via PPU $0000-$03FF (CHR side), read via $2000-$23FF.
+        mapper.ppuWrite(0x0020, 0xCD.toSignedByte())
+        assertThat("NT side reads 0xCD written through CHR side",
+            ppuMem[0x2020].toUnsignedInt(), equalTo(0xCD))
+    }
+
+    @Test
+    fun `end-to-end - bit 0 selects NT A vs NT B (independent slots)`() {
+        // Banks 8 and 9 can simultaneously point to NT A and NT B (or both
+        // to NT A, or both to NT B). The two NT slots are independent —
+        // writes to one don't bleed into the other. This is what makes the
+        // 4-screen arrangement actually give 4 distinct screens of RAM.
+        val mapper = newN163(prgKb = 128, chrKb = 0)
+        val ppuMem = PpuInternalMemory()
+        ppuMem.nametableReadDelegate = { addr -> mapper.readNametableOverride(addr) }
+        ppuMem.nametableWriteDelegate = { addr, v -> mapper.writeNametableOverride(addr, v) }
+        mapper.cpuWrite(0xC000, 0xE0.toSignedByte())   // bank 8 ($2000) → NT A
+        mapper.cpuWrite(0xC800, 0xE1.toSignedByte())   // bank 9 ($2400) → NT B
+
+        ppuMem[0x2010] = 0x11.toSignedByte()    // writes to NT A
+        ppuMem[0x2410] = 0x22.toSignedByte()    // writes to NT B
+        assertThat("NT A reads 0x11 (independent of NT B)",
+            ppuMem[0x2010].toUnsignedInt(), equalTo(0x11))
+        assertThat("NT B reads 0x22 (independent of NT A)",
+            ppuMem[0x2410].toUnsignedInt(), equalTo(0x22))
     }
 
     // ---- Helpers ----


### PR DESCRIPTION
Mapper19.ppuRead/ppuWrite had a bank-and-0x100 branch that logged and
returned 0, leaving the chip CHR-as-nametable / 4-screen extension
unwired. Games writing value >= 0xE0 to a CHR bank register had no
backing for the resulting NT slot, so the PPU read 0 instead of the
intended internal CHR-RAM byte. Likely contributor to the Mapper19
render divergence tracked in #217.

Architecture: add a nametableReadDelegate / nametableWriteDelegate
seam to PpuInternalMemory, parallel to the existing chrReadDelegate
and chrWriteDelegate. Expose readNametableOverride and
writeNametableOverride on the Mapper interface. Default is no-op so
every existing mapper inherits no override. Mapper 19 opts in: when
chrBanks[i] has the NT-mode flag (bit 8) set, the CHR-side window
reads from a new dedicated 4KB extendedChrRam which is always RAM
regardless of chrRom presence because real N163 hardware has internal
RAM here. The NT-side window reads from the same buffer via the
override hooks. Bit 0 of the stored bank value selects NT A (lower
1KB) or NT B (upper 1KB).

Tests: 5 unit tests for the new wiring plus 4 end-to-end tests
through PpuInternalMemory delegate seam plus 1 save/load round-trip
test for extendedChrRam. Updated the pre-existing nametable sentinel
test to reflect that the read now goes through extended CHR-RAM.
Save-state version bumped 3 to 4 so old saves fail loudly per the docs.

Closes #234
