### PR TITLE
fix(mapper3): index PRG with `% programRom.size` so 16KB-CNROM does not crash

### DIFF
--- a/MAPPER_SUPPORT.md
+++ b/MAPPER_SUPPORT.md
@@ -39,9 +39,9 @@ Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 22, 24, 26, 33,
 ## Mapper 3 (NINA-003/006)
 **Status:** Working
 
-- **Games:** Paperboy
+- **Games:** Paperboy (32KB-PRG); Joust (16KB-PRG)
 - **Behavior:** 8KB CHR ROM bank switching via $8000-$9FFF (bits 0-1)
-- **PRG:** Fixed 32KB at $8000-$FFFF
+- **PRG:** Fixed 16KB or 32KB at $8000-$FFFF. In 16KB mode the chip ignores A14, so $C000-$FFFF mirrors $8000-$BFFF. Issue #231 fixed the 16KB crash by switching the CPU-window read from `and 0x7FFF` to `% programRom.size`.
 
 ## Mapper 4 (MMC3/TxROM)
 **Status:** Supported

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper3.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper3.kt
@@ -8,7 +8,9 @@ import java.io.DataOutput
  * Mapper 3 (CNROM) - 8KB CHR bank switching. Used by Star Soldier,
  * Solomon's Key, Gradius and many other early commercial games.
  *
- * - Fixed PRG ROM at $8000-$FFFF (16 or 32KB)
+ * - Fixed PRG ROM at $8000-$FFFF (16 or 32KB). Real CNROM's address
+ *   decoder ignores A14 in 16KB mode, so $C000-$FFFF mirrors $8000-$BFFF;
+ *   the modulo below produces that naturally. See issue #231.
  * - CHR ROM switched in 8KB banks via a write to ANY address in the
  *   $8000-$FFFF window (the bank register is mirrored across the whole
  *   PRG space; some games — Star Soldier writes to $D030 — exploit this
@@ -32,8 +34,11 @@ class Mapper3(private val gamePak: GamePak) : Mapper {
     var writeTrace: MutableList<Write>? = null
 
     override fun cpuRead(address: Int): Byte {
-        // PRG fixed at $8000-$FFFF (32KB)
-        return programRom[(address - 0x8000) and 0x7FFF]
+        // PRG fixed at $8000-$FFFF (16 or 32KB). Use `% programRom.size`
+        // rather than `and 0x7FFF` so 16KB images don't index past their
+        // ROM at $C000..$FFFF — the modulo wraps those offsets into the
+        // 16KB mirror, matching real CNROM behaviour. See issue #231.
+        return programRom[(address - 0x8000) % programRom.size]
     }
 
     override fun cpuWrite(address: Int, value: Byte) {

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper3Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper3Test.kt
@@ -88,4 +88,62 @@ class Mapper3Test {
         m.cpuWrite(0xFFFF, 3.toSignedByte())
         assertThat(m.ppuRead(0x0000).toUnsignedInt(), equalTo(3))
     }
+
+    /**
+     * Regression for issue #231 — 16KB-PRG CNROM must not index past programRom
+     * when the CPU reads $C000-$FFFF. Real CNROM ignores A14 in 16KB mode, so
+     * $C000-$FFFF mirrors $8000-$BFFF. The previous implementation masked with
+     * `and 0x7FFF`, which produces offsets 0x4000..0x7FFF and throws
+     * ArrayIndexOutOfBoundsException against a 16KB array. Many homebrew and
+     * some licensed CNROM titles (e.g. Cybernoid's 32KB-PRG variant's sister
+     * boards) ship as 16KB; the latent crash only manifests for those.
+     */
+    @Test
+    fun `16KB PRG does not crash reading $C000-$FFFF (issue 231)`() {
+        // Real CNROM with 16KB PRG ignores A14, so $C000 mirrors $8000
+        // (offset 0). Stamp byte 0 of PRG with a sentinel and verify that
+        // a high-window read returns the SAME byte as a low-window read
+        // (rather than a zero-fill from a wrap-around sentinel return).
+        val prg = ByteArray(0x4000).also { it[0] = 0x5A.toByte() }
+        val gp = GamePak(buildIne(prg, makeStampedChr(banks8k = 1)))
+        val m = gp.createMapper() as Mapper3
+
+        // Pre-fix: cpuRead(0xC000) throws ArrayIndexOutOfBoundsException.
+        // Post-fix: returns the same byte as cpuRead(0x8000).
+        assertThat(m.cpuRead(0x8000).toUnsignedInt(), equalTo(0x5A))
+        assertThat(m.cpuRead(0xC000).toUnsignedInt(), equalTo(0x5A))
+    }
+
+    @Test
+    fun `16KB PRG mirrors $C000-$FFFF from $8000-$BFFF byte-for-byte (issue 231)`() {
+        // Stamp every byte of the 16KB PRG with its low byte so the mirror
+        // assertion can verify the full $8000-$FFFF range, not just one byte.
+        val prg = ByteArray(0x4000) { i -> (i and 0xFF).toByte() }
+        val gp = GamePak(buildIne(prg, makeStampedChr(banks8k = 1)))
+        val m = gp.createMapper() as Mapper3
+
+        for (addr in 0x8000..0xFFFF) {
+            val mirroredLowByte = (addr - 0x8000).toByte()  // A14 ignored
+            assertThat(
+                m.cpuRead(addr).toUnsignedInt(),
+                equalTo(mirroredLowByte.toUnsignedInt()),
+                message = { "16KB PRG mirror: addr=\$${addr.toString(16)}" },
+            )
+        }
+    }
+
+    @Test
+    fun `32KB PRG still works (sanity check the fix)`() {
+        val prg = ByteArray(0x8000) { i -> (i and 0xFF).toByte() }
+        val gp = GamePak(buildIne(prg, makeStampedChr(banks8k = 1)))
+        val m = gp.createMapper() as Mapper3
+
+        // No mirroring in 32KB mode — $C000-$FFFF reads the upper 16KB.
+        for (addr in 0x8000..0xFFFF) {
+            assertThat(
+                m.cpuRead(addr).toUnsignedInt(),
+                equalTo((addr - 0x8000).toByte().toUnsignedInt()),
+            )
+        }
+    }
 }


### PR DESCRIPTION
cpuRead masked the address with `and 0x7FFF`, which is correct only when
PRG is 32KB. For 16KB-PRG CNROM (e.g. Joust), reads at $C000-$FFFF
produced offsets 0x4000-0x7FFF and threw ArrayIndexOutOfBoundsException
because programRom has length 0x4000. Real CNROM ignores A14 in 16KB
mode, so $C000-$FFFF mirrors $8000-$BFFF — `% programRom.size` produces
that mirror naturally, matching the convention used by 14+ other mappers
(Mapper4/Mapper11/Mapper68/Mapper33/Vrc4/...).

Regression test in Mapper3Test covers three cases:
- 16KB PRG does not crash reading $C000-$FFFF
- 16KB PRG mirrors the full $8000-$FFFF window byte-for-byte
- 32KB PRG still works (the Star Soldier / Solomon's Key / Gradius path)

Bootcheck verified on Joust (USA), a 16KB-PRG CNROM, with PASS verdict
(120 frames run, rendering enabled, 119 NMIs, CHR bank switching
observed). Closes #231.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
