### PR TITLE
fix(ppu): group of 4 loopy-register / timing inaccuracies (Closes #227)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/Ppu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/Ppu.kt
@@ -145,16 +145,21 @@ class Ppu(var memory: Memory) {
 
         if (renderingActive) {
             if (cycle == 0) {
-                // Copy horizontal scroll from temp register BEFORE preloading
-                with(memory.ppuAddressedMemory) {
-                    if (scanline in 0..239 || scanline == region.preRenderScanline) {
-                        vRamAddress.coarseXScroll = tempVRamAddress.coarseXScroll
-                        vRamAddress.horizontalNameTable = tempVRamAddress.horizontalNameTable
-                    }
-                }
                 // Pre-load the first two BG tiles for this scanline (reads pattern table 0/1
                 // depending on PPUCTRL bit 4 — drives A12 low for typical MMC3 setups).
                 preloadFirstTwoTiles()
+            }
+
+            // Horizontal scroll copy (v <- t) happens at NES dot 257 == Nestlin
+            // cycle 256 (issue #227). It used to fire at cycle 0 of the rendering
+            // line, which is one scanline late: a $2005/$2006 write during the
+            // sprite-fetch window (cycles 257..319 of the previous line) would be
+            // picked up for THIS scanline's BG fetch instead of the NEXT.
+            if (cycle == 256) {
+                with(memory.ppuAddressedMemory) {
+                    vRamAddress.coarseXScroll = tempVRamAddress.coarseXScroll
+                    vRamAddress.horizontalNameTable = tempVRamAddress.horizontalNameTable
+                }
             }
 
             // Sprite evaluation for the *next* scanline happens at NES dot 65. Nestlin's
@@ -318,14 +323,23 @@ class Ppu(var memory: Memory) {
      * Sprite evaluation: scan primary OAM, pick up to 8 sprites visible on the target scanline.
      * Stores their resolved tile-Y offset (with vertical-flip applied) in secondaryOam.
      * No pattern-table accesses occur here, so A12 is not affected.
+     *
+     * The hardware rotates the scan so it STARTS at the current OAMADDR (issue #227),
+     * not always at sprite 0. This is what games exploit for sprite-cycling flicker
+     * tricks (Galaga, Pac-Man, etc.) — the OAM byte read offset is preserved across
+     * the eval pass.
      */
     private fun evaluateSpritesForTargetScanline(target: Int) {
         secondaryOam.clear()
         val oam = memory.ppuAddressedMemory.objectAttributeMemory
         val spriteSize = memory.ppuAddressedMemory.controller.spriteSize()
         val spriteHeight = if (spriteSize == Control.SpriteSize.X_8_16) 16 else 8
+        // OAMADDR is a byte offset (4 bytes per sprite); divide by 4 to get the
+        // starting sprite index. The hardware scans OAM in rotated order from there.
+        val startIndex = (memory.ppuAddressedMemory.oamAddress.toUnsignedInt() shr 2) and 0x3F
 
-        for (i in 0 until 64) {
+        for (n in 0 until 64) {
+            val i = (startIndex + n) and 0x3F
             val s = oam.getSprite(i)
             val y = s.y
             // NES Y semantics: sprite at Y appears at scanlines Y+1 through Y+spriteHeight

--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/PpuAddressedMemory.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/PpuAddressedMemory.kt
@@ -23,6 +23,19 @@ class PpuAddressedMemory : NmiSource {
     var address: Byte = 0                  // $2006
     var data: Byte = 0                     // $2007
 
+    /**
+     * Internal CPU-PPU data-bus "open-bus" decay (issue #227).
+     *
+     * $2002's low 5 bits are not backed by any register; on hardware they decay
+     * to whatever byte last appeared on the internal data bus. Every PPU write
+     * ($2000-$2007) updates this value, and $2002 reads pull the low 5 bits from
+     * here. Nestlin used to return status.register's low 5 bits — always zero —
+     * which is a deterministic but inaccurate value.
+     *
+     * Default 0: a cold-boot PPU has a 0-valued bus (no previous write).
+     */
+    var openBus: Byte = 0
+
     private var writeToggle = false
 
     val ppuInternalMemory = PpuInternalMemory()
@@ -104,6 +117,7 @@ class PpuAddressedMemory : NmiSource {
         scroll = 0
         address = 0
         data = 0
+        openBus = 0
 
         writeToggle = false
     }
@@ -176,7 +190,12 @@ class PpuAddressedMemory : NmiSource {
             1 -> mask.register
             2 -> {
                 writeToggle = false
-                val value = status.register
+                // Open-bus decay: bits 5-7 come from the status register (sprite
+                // overflow, sprite-0 hit, vblank); bits 0-4 come from the open-bus
+                // value (last byte written to any PPU register). Nestlin used to
+                // return the full status.register, leaving the low 5 bits always
+                // zero (issue #227).
+                val value = ((status.register.toInt() and 0xE0) or (openBus.toInt() and 0x1F)).toSignedByte()
                 status.clearVBlank()
                 // Reading $2002 also clears the NMI flag?
                 // NESdev: "Reading $2002... will also acknowledge the interrupt"
@@ -214,6 +233,10 @@ class PpuAddressedMemory : NmiSource {
 
     operator fun set(addr: Int, value: Byte) {
 //        println("Setting PPU Addressed data ${addr.toHexString()}, with ${value.toHexString()}")
+        // Every PPU write places the byte on the internal data bus. Subsequent
+        // reads of registers with undefined bits pull those bits from this open-bus
+        // value (issue #227). $2002 reads in particular use bits 0-4 from here.
+        openBus = value
         when (addr) {
             0 -> {
                 val previousNmiEnabled = controller.generateNmi()

--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/VramAddress.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/VramAddress.kt
@@ -59,17 +59,24 @@ class VramAddress {
         fineYScroll++
 
         if (fineYScroll > 7) {
-            coarseYScroll++
             fineYScroll = 0
 
-            if (coarseYScroll > 29) {
-                // Y Scroll now out of bounds
-                if (coarseYScroll < 32) {
-                    //  Hasn't overflowed therefore switch vertical nametable
+            // Canonical loopy-register vertical-wrap algorithm (nesdev wiki):
+            // check coarseYScroll BEFORE incrementing. Only the 29 -> 0 transition
+            // toggles the vertical nametable; 31 -> 0 wraps silently. The 30 -> 31
+            // transition is a plain increment (no toggle, no reset) — the previous
+            // implementation toggled AND zeroed at 30, which is wrong.
+            when (coarseYScroll) {
+                29 -> {
+                    coarseYScroll = 0
                     verticalNameTable = !verticalNameTable
                 }
-
-                coarseYScroll = 0
+                31 -> {
+                    coarseYScroll = 0
+                }
+                else -> {
+                    coarseYScroll++
+                }
             }
         }
     }

--- a/src/test/kotlin/com/github/alondero/nestlin/ppu/Issue227LoopyRegisterTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ppu/Issue227LoopyRegisterTest.kt
@@ -1,0 +1,338 @@
+package com.github.alondero.nestlin.ppu
+
+import com.github.alondero.nestlin.Memory
+import com.github.alondero.nestlin.toSignedByte
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for GitHub issue #227 — grouped PPU loopy-register /
+ * timing inaccuracies found during the 2026-07 subsystem accuracy review.
+ *
+ * Each test maps to one of the six bullets in the issue. Tests that already
+ * pass without code changes confirm a fix landed in a prior commit
+ * (notably ae4329d, "PPUMASK layer gating, sprite overflow, greyscale/
+ * emphasis, $2007 palette buffer, $2006 fine-Y, Frame IntArray"). Tests
+ * that fail mark bugs still in the codebase.
+ */
+class Issue227LoopyRegisterTest {
+
+    // ---- 1. $2006 first write must clear fine-Y bit 2 (already fixed) -----
+
+    @Test
+    fun `first $2006 write clears stale fine Y bit 2 from a prior $2005`() {
+        val ppu = PpuAddressedMemory()
+        // A $2005 second write can set fineY up to 7 (bit 2 set)...
+        ppu[5] = 0x07.toSignedByte()   // first $2005: fine X = 7
+        ppu[5] = 0xE7.toSignedByte()   // second $2005: coarse Y = 0x1C, fine Y = 7 (bit 2 set)
+
+        // ...but the first $2006 write only carries fineY bits 0-1 and hardware
+        // forces bit 14 of t (fineY bit 2) to ZERO.
+        ppu[6] = 0x00.toSignedByte()
+
+        assertThat("bit 14 of t forced zero", ppu.tempVRamAddress.fineYScroll, equalTo(0))
+    }
+
+    // ---- 2. coarse-Y == 30 edge case in incrementVerticalPosition -------
+
+    @Test
+    fun `coarse Y 30 advances to 31 on next increment, no toggle`() {
+        // Hardware sequence when coarse Y starts at 30 (set via $2006):
+        //   fineY overflows -> coarseY++ -> coarseY becomes 31
+        // The 30 -> 31 transition is JUST an increment; the toggle fires when
+        // coarse Y wraps from 29 -> 0, and the 31 -> 0 wrap is silent.
+        // Nestlin currently does the wrong thing: it toggles AND zeroes at 30.
+        val addr = VramAddress()
+        addr.coarseYScroll = 30
+        addr.fineYScroll = 7  // overflow so the increment reaches coarseY
+        addr.verticalNameTable = false
+
+        addr.incrementVerticalPosition()
+
+        assertThat("30 should advance to 31", addr.coarseYScroll, equalTo(31))
+        assertThat("30 -> 31 must NOT toggle nametable", addr.verticalNameTable, equalTo(false))
+    }
+
+    @Test
+    fun `coarse Y 31 wraps to 0 on next increment, no toggle`() {
+        val addr = VramAddress()
+        addr.coarseYScroll = 31
+        addr.fineYScroll = 7
+        addr.verticalNameTable = false
+
+        addr.incrementVerticalPosition()
+
+        assertThat("31 should wrap to 0", addr.coarseYScroll, equalTo(0))
+        assertThat("31 -> 0 must NOT toggle nametable", addr.verticalNameTable, equalTo(false))
+    }
+
+    @Test
+    fun `coarse Y 29 wraps to 0 with vertical nametable toggle`() {
+        val addr = VramAddress()
+        addr.coarseYScroll = 29
+        addr.fineYScroll = 7
+        addr.verticalNameTable = false
+
+        addr.incrementVerticalPosition()
+
+        assertThat("29 should wrap to 0", addr.coarseYScroll, equalTo(0))
+        assertThat("29 -> 0 MUST toggle nametable", addr.verticalNameTable, equalTo(true))
+    }
+
+    @Test
+    fun `normal coarse Y 28 advances to 29 with no wrap or toggle`() {
+        val addr = VramAddress()
+        addr.coarseYScroll = 28
+        addr.fineYScroll = 7
+        addr.verticalNameTable = false
+
+        addr.incrementVerticalPosition()
+
+        assertThat("28 should advance to 29", addr.coarseYScroll, equalTo(29))
+        assertThat("28 -> 29 must NOT toggle", addr.verticalNameTable, equalTo(false))
+    }
+
+    // ---- 3. $2007 palette read leaves nametable byte in the buffer (already fixed) ----
+
+    @Test
+    fun `palette read fills the read buffer with the nametable under the palette`() {
+        val ppu = PpuAddressedMemory()
+        ppu.ppuInternalMemory[0x2F00] = 0xAB.toSignedByte()   // nametable "under" $3F00
+        ppu.ppuInternalMemory[0x3F00] = 0x21.toSignedByte()   // backdrop palette
+
+        // First $2006 write: high byte of 0x3F00 = 0x3F (upper 6 bits of v).
+        // Second $2006 write: low byte = 0x00 (lower 8 bits of v).
+        ppu[6] = 0x3F.toSignedByte()
+        ppu[6] = 0x00.toSignedByte()
+
+        val paletteValue = ppu[7]
+        assertThat("palette returned immediately", paletteValue, equalTo(0x21.toSignedByte()))
+
+        // Move to 0x2000; the FIRST read returns the buffer, which must hold
+        // the nametable byte from under the palette, not the palette value.
+        ppu[6] = 0x20.toSignedByte()
+        ppu[6] = 0x00.toSignedByte()
+
+        val buffered = ppu[7]
+        assertThat("buffer held nametable-under-palette", buffered, equalTo(0xAB.toSignedByte()))
+    }
+
+    // ---- 4. OAMADDR must offset sprite-evaluation start (not always sprite 0) ----
+
+    @Test
+    fun `sprite evaluation starts at the current OAMADDR not sprite 0`() {
+        // 9 in-range sprites on scanline 100 at indices 0..8.
+        // With OAMADDR = 0: scan starts at sprite 0; the first 8 fill secondary OAM,
+        // sprite 8 is the 9th in-range and triggers overflow. Sprite 0 IS in slot 0.
+        // With OAMADDR = 4 (= sprite 1): scan starts at sprite 1; sprites 1..8 fill
+        // secondary OAM. Sprite 0 (encountered last after the wraparound) is the
+        // 9th in-range and triggers overflow. Sprite 0 is NOT in secondary OAM.
+        //
+        // We verify this via sprite-0 hit, which fires only when an OPAQUE sprite-0
+        // pixel overlaps an OPAQUE background pixel. We place sprite 0 at column 10
+        // and give it opaque pixels; everything else is off-screen-X. We put an
+        // opaque background tile at scanline 100 col 10.
+        //
+        // Bug (OAMADDR ignored): sprite 0 always in secondary OAM -> hit fires.
+        // Fix (OAMADDR respected): with OAMADDR=4, sprite 0 is overflowed -> no hit.
+        val memory = Memory()
+        val ppu = Ppu(memory)
+
+        // CHR: opaque tile 0 (pattern table 0) — all bits set, so every pixel opaque.
+        val chr = ByteArray(0x2000)
+        for (i in 0..7) {
+            chr[i] = 0xFF.toSignedByte()
+            chr[8 + i] = 0xFF.toSignedByte()
+        }
+        memory.ppuAddressedMemory.ppuInternalMemory.loadChrRom(chr)
+
+        // Background palette index 1 -> non-backdrop colour so the bg pixel is opaque.
+        memory.ppuAddressedMemory.ppuInternalMemory[0x3F11] = 0x30.toSignedByte()
+        memory.ppuAddressedMemory.ppuInternalMemory[0x3F10] = 0x10.toSignedByte()
+
+        // Fill nametable with tile 0 (every tile is opaque).
+        for (addr in 0x2000..0x23BF) memory.ppuAddressedMemory.ppuInternalMemory[addr] = 0x00.toSignedByte()
+        // Fill attribute table with "palette 1" (set bits 0,1 for top-left quadrant).
+        for (addr in 0x23C0..0x23FF) memory.ppuAddressedMemory.ppuInternalMemory[addr] = 0x00.toSignedByte()
+
+        // OAM: 9 in-range sprites at Y=99 (visible on scanlines 100..107).
+        // Sprite 0 has X=10 (the only one we can see). The rest are off-screen-X.
+        val oam = memory.ppuAddressedMemory.objectAttributeMemory
+        for (i in 0..8) {
+            oam[i * 4 + 0] = 99.toSignedByte()  // Y
+            oam[i * 4 + 1] = 0x00.toSignedByte() // tile
+            oam[i * 4 + 2] = 0x00.toSignedByte() // ATTR: opaque, in front
+            oam[i * 4 + 3] = if (i == 0) 10.toSignedByte() else 200.toSignedByte()
+        }
+        // Off-screen all the rest.
+        for (i in 9 until 64) oam[i * 4] = 0xF0.toSignedByte()
+
+        // OAMADDR = 4 (start at sprite 1). With the fix, sprite 0 gets overflowed.
+        memory.ppuAddressedMemory.oamAddress = 4.toSignedByte()
+
+        // Render with bg AND sprites visible.
+        memory.ppuAddressedMemory.mask.register = 0b0001_1000.toByte()
+
+        // Tick up to 4 frames to let sprite evaluation pick up the new OAMADDR.
+        var guard = 4 * 89342
+        while (guard-- > 0) ppu.tick()
+
+        // With the bug, sprite 0 is always in secondary OAM and renders at col 10
+        // every scanline where bg is opaque. Sprite-0 hit fires. With the fix, sprite
+        // 0 is overflowed on each eval cycle and never renders -> sprite-0 hit does
+        // NOT fire.
+        assertThat("sprite-0 hit must not fire when OAMADDR rotates sprite 0 out",
+            memory.ppuAddressedMemory.status.sprite0Hit(), equalTo(false))
+    }
+
+    @Test
+    fun `sprite evaluation with OAMADDR 0 puts sprite 0 in secondary OAM and triggers hit`() {
+        // Companion test to the one above: same setup but OAMADDR=0. Sprite 0 IS in
+        // secondary OAM, so the hit fires. This is the regression guard — if we
+        // accidentally break OAMADDR=0 too, this catches it.
+        val memory = Memory()
+        val ppu = Ppu(memory)
+
+        val chr = ByteArray(0x2000)
+        for (i in 0..7) {
+            chr[i] = 0xFF.toSignedByte()
+            chr[8 + i] = 0xFF.toSignedByte()
+        }
+        memory.ppuAddressedMemory.ppuInternalMemory.loadChrRom(chr)
+        memory.ppuAddressedMemory.ppuInternalMemory[0x3F11] = 0x30.toSignedByte()
+        memory.ppuAddressedMemory.ppuInternalMemory[0x3F10] = 0x10.toSignedByte()
+        for (addr in 0x2000..0x23BF) memory.ppuAddressedMemory.ppuInternalMemory[addr] = 0x00.toSignedByte()
+        for (addr in 0x23C0..0x23FF) memory.ppuAddressedMemory.ppuInternalMemory[addr] = 0x00.toSignedByte()
+
+        val oam = memory.ppuAddressedMemory.objectAttributeMemory
+        for (i in 0..8) {
+            oam[i * 4 + 0] = 99.toSignedByte()
+            oam[i * 4 + 1] = 0x00.toSignedByte()
+            oam[i * 4 + 2] = 0x00.toSignedByte()
+            oam[i * 4 + 3] = if (i == 0) 10.toSignedByte() else 200.toSignedByte()
+        }
+        for (i in 9 until 64) oam[i * 4] = 0xF0.toSignedByte()
+
+        memory.ppuAddressedMemory.oamAddress = 0.toSignedByte()
+        memory.ppuAddressedMemory.mask.register = 0b0001_1000.toByte()
+
+        var guard = 4 * 89342
+        while (guard-- > 0) ppu.tick()
+
+        assertThat("sprite-0 hit must fire when sprite 0 is in secondary OAM",
+            memory.ppuAddressedMemory.status.sprite0Hit(), equalTo(true))
+    }
+
+    // ---- 5. Horizontal scroll copy timed at dot 257 of the prior line ----
+
+    @Test
+    fun `horizontal scroll is copied from t to v at dot 257 not at cycle 0`() {
+        // Hardware: at NES dot 257 (== Nestlin cycle 256) of each rendering-enabled
+        // scanline, v's horizontal bits are loaded from t. The previous line's
+        // t-update thus takes effect for the NEXT visible scanline. Nestlin used
+        // to do this copy at cycle 0 of the rendering line instead — the same
+        // value, just one scanline late, so a $2005/$2006 write during the
+        // sprite-fetch window of scanline N was picked up by scanline N+1 instead
+        // of N+2.
+        //
+        // Test: set t.coarseX = 10, then tick to the pre-render line's cycle 257
+        // (Nestlin cycle 256, after the copy fires). v.coarseX should equal 10
+        // immediately. With the old code, v.coarseX would still be 0 here because
+        // the copy wouldn't fire until cycle 0 of the NEXT scanline — and even
+        // then, preloadFirstTwoTiles and fetchData have already advanced it past
+        // 10 by the time we observe it.
+        val memory = Memory()
+        val ppu = Ppu(memory)
+        memory.ppuAddressedMemory.mask.register = 0b0000_1000.toByte() // rendering on
+        memory.ppuAddressedMemory.tempVRamAddress.coarseXScroll = 10
+
+        // Tick to cycle 257 of the pre-render line. The cycle-256 copy fires
+        // on the tick that takes us from cycle 256 to cycle 257, so check
+        // v.coarseX at cycle 257 — strictly after the copy, before fetchData's
+        // cycle-326/334 increments and before preloadFirstTwoTiles at cycle 0
+        // of the next scanline.
+        var guard = 4 * 89342
+        while (guard-- > 0) {
+            ppu.tick()
+            if (ppu.currentScanline == ppu.region.preRenderScanline && ppu.currentCycle == 257) break
+        }
+        require(guard > 0) { "never reached pre-render cycle 257" }
+
+        assertThat("v.coarseX reflects t.coarseX from pre-render dot-257 copy",
+            memory.ppuAddressedMemory.vRamAddress.coarseXScroll, equalTo(10))
+    }
+
+    @Test
+    fun `dot-257 copy preserves v coarse X across a scanline with no $2005 writes`() {
+        // Setup: t.coarseX = 5. After the pre-render dot-257 copy, v.coarseX = 5.
+        // Tick to the next cycle 257 (of scanline 0); the copy fires again but t
+        // is unchanged, so v.coarseX stays 5. This sanity-checks that the copy
+        // doesn't destabilise v mid-line.
+        val memory = Memory()
+        val ppu = Ppu(memory)
+        memory.ppuAddressedMemory.mask.register = 0b0000_1000.toByte()
+        memory.ppuAddressedMemory.tempVRamAddress.coarseXScroll = 5
+
+        // Advance to pre-render cycle 257 (copy has fired).
+        var guard = 4 * 89342
+        while (guard-- > 0) {
+            ppu.tick()
+            if (ppu.currentScanline == ppu.region.preRenderScanline && ppu.currentCycle == 257) break
+        }
+        require(guard > 0)
+        assertThat("v.coarseX = 5 immediately after pre-render dot-257 copy",
+            memory.ppuAddressedMemory.vRamAddress.coarseXScroll, equalTo(5))
+
+        // Tick to scanline 0, cycle 257 (the next dot-257). The copy fires
+        // again; with no $2005 write in between, v.coarseX must still equal
+        // t.coarseX = 5. Intermediate fetchData/preloadFirstTwoTiles increments
+        // are reset by the dot-257 copy, which is exactly the invariant we want.
+        while (guard-- > 0) {
+            ppu.tick()
+            if (ppu.currentScanline == 0 && ppu.currentCycle == 257) break
+        }
+        require(guard > 0)
+        assertThat("dot-257 copy at scanline 0 cycle 257 leaves v.coarseX = 5",
+            memory.ppuAddressedMemory.vRamAddress.coarseXScroll, equalTo(5))
+    }
+
+    // ---- 6. $2002 open-bus: low 5 bits decay, not the status register ----
+
+    @Test
+    fun `$2002 read returns open-bus decay in low 5 bits, not status register`() {
+        val ppu = PpuAddressedMemory()
+        // Status low 5 bits are undefined hardware-wise — open-bus decay of the
+        // most recent PPU write. Write some non-zero value to a PPU register,
+        // then read $2002 and check the low 5 bits reflect the bus.
+        ppu[0] = 0xAB.toSignedByte() // PPUCTRL: high bits now carry 0xAB onto the bus
+        val result = ppu[2]
+        // bits 5-7 from status register (likely 0), bits 0-4 from open-bus = $AB & 0x1F = 0x0B
+        assertThat("low 5 bits = open bus (0xAB & 0x1F)",
+            result.toInt() and 0x1F, equalTo(0x0B))
+    }
+
+    @Test
+    fun `$2002 read updates the open-bus decay to the next register write`() {
+        val ppu = PpuAddressedMemory()
+        ppu[0] = 0xFF.toSignedByte() // $2000 write: bus = $FF
+        // Read $2002 — low 5 bits = 0xFF & 0x1F = 0x1F (open bus)
+        assertThat(ppu[2].toInt() and 0x1F, equalTo(0x1F))
+
+        ppu[1] = 0x00.toSignedByte() // $2001 write: bus = $00
+        // Read $2002 — low 5 bits now = 0x00 & 0x1F = 0x00 (open bus decayed)
+        assertThat(ppu[2].toInt() and 0x1F, equalTo(0x00))
+    }
+
+    @Test
+    fun `$2002 read still exposes status bits 5 to 7 correctly`() {
+        val ppu = PpuAddressedMemory()
+        // Set vblank + sprite 0 hit + sprite overflow so bits 5-7 are all 1.
+        ppu[0] = 0xAB.toSignedByte() // bus = 0xAB (low 5 = 0x0B)
+        ppu.status.register = 0b1110_0000.toSignedByte()
+        val result = ppu[2]
+        assertThat("bit 7 = vblank", (result.toInt() shr 7) and 1, equalTo(1))
+        assertThat("bit 6 = sprite 0 hit", (result.toInt() shr 6) and 1, equalTo(1))
+        assertThat("bit 5 = sprite overflow", (result.toInt() shr 5) and 1, equalTo(1))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes 4 of the 6 grouped PPU loopy-register / timing inaccuracies from issue #227. The remaining 2 (006 fine-Y bit 2 and 007 palette read buffer) were already addressed in commit ae4329d; this PR lands the rest plus a regression test file covering the whole group.

### Bugs fixed

1. **`006` first write clears fine-Y bit 2** — already fixed in ae4329d (verified by test)
2. **`coarse-Y == 30` wraps correctly** — `incrementVerticalPosition` now uses the canonical nesdev "check BEFORE increment" algorithm. 30 advances to 31 on the next scanline (no toggle, no reset); 29→0 still toggles; 31→0 wraps silently.
3. **`007` palette read buffer** — already fixed in ae4329d (verified by test)
4. **OAMADDR offsets sprite-evaluation start** — `evaluateSpritesForTargetScanline` now starts the scan at `oamAddress / 4` instead of sprite 0. Enables sprite-cycling / flicker tricks (Galaga, Pac-Man) that rely on a rotated OAM scan.
5. **Horizontal scroll copy at dot 257, not cycle 0** — `tick()` now copies v ← t for horizontal bits at cycle 256 (dot 257) of the rendering scanline, not at cycle 0. `005`/`006` writes during the sprite-fetch window now affect the NEXT scanline's BG fetch, not the current one.
6. **`002` open-bus decay** — every `000`-`007` write updates a new `openBus` field; `002` reads return `(status & 0xE0) | (openBus & 0x1F)` so bits 0-4 reflect hardware open-bus decay instead of always-zero.

### Files

- `src/main/kotlin/com/github/alondero/nestlin/ppu/VramAddress.kt` — fix issue 2
- `src/main/kotlin/com/github/alondero/nestlin/ppu/Ppu.kt` — fix issues 4 and 5
- `src/main/kotlin/com/github/alondero/nestlin/ppu/PpuAddressedMemory.kt` — fix issue 6
- `src/test/kotlin/com/github/alondero/nestlin/ppu/Issue227LoopyRegisterTest.kt` — 13 new regression tests (NEW)

### Verification

- `./gradlew build` — green
- `./gradlew test` — green (3m 10s)
- `./gradlew test --tests "com.github.alondero.nestlin.ppu.*"` — green
- `./gradlew test --tests "com.github.alondero.nestlin.ppu.Issue227LoopyRegisterTest"` — green (13/13)

Closes #227