### PR TITLE
test(ppu): expand greyscale/emphasis coverage to green/blue/all combos

### DIFF
--- a/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuGreyscaleEmphasisTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ppu/PpuGreyscaleEmphasisTest.kt
@@ -78,4 +78,73 @@ class PpuGreyscaleEmphasisTest {
 
         assertThat(frame.scanlines[120][128], equalTo(NesPalette.getRgb(backdropIndex)))
     }
+
+    @Test
+    fun `green emphasis attenuates red and blue channels`() {
+        val memory = Memory()
+        val ppu = Ppu(memory)
+        memory.ppuAddressedMemory.ppuInternalMemory[0x3F00] = backdropIndex.toByte()
+        memory.ppuAddressedMemory.mask.register = 0b0100_0000.toByte() // green emphasis, rendering off
+
+        val frame = runOneFrame(ppu)
+        val pixel = frame.scanlines[120][128]
+        val base = NesPalette.getRgb(backdropIndex)
+
+        val r = (pixel shr 16) and 0xFF
+        val g = (pixel shr 8) and 0xFF
+        val b = pixel and 0xFF
+        val baseR = (base shr 16) and 0xFF
+        val baseG = (base shr 8) and 0xFF
+        val baseB = base and 0xFF
+
+        assertThat("red attenuated", r < baseR, equalTo(true))
+        assertThat("green channel unchanged", g, equalTo(baseG))
+        assertThat("blue attenuated", b < baseB, equalTo(true))
+    }
+
+    @Test
+    fun `blue emphasis attenuates red and green channels`() {
+        val memory = Memory()
+        val ppu = Ppu(memory)
+        memory.ppuAddressedMemory.ppuInternalMemory[0x3F00] = backdropIndex.toByte()
+        memory.ppuAddressedMemory.mask.register = 0b1000_0000.toByte() // blue emphasis, rendering off
+
+        val frame = runOneFrame(ppu)
+        val pixel = frame.scanlines[120][128]
+        val base = NesPalette.getRgb(backdropIndex)
+
+        val r = (pixel shr 16) and 0xFF
+        val g = (pixel shr 8) and 0xFF
+        val b = pixel and 0xFF
+        val baseR = (base shr 16) and 0xFF
+        val baseG = (base shr 8) and 0xFF
+        val baseB = base and 0xFF
+
+        assertThat("red attenuated", r < baseR, equalTo(true))
+        assertThat("green attenuated", g < baseG, equalTo(true))
+        assertThat("blue channel unchanged", b, equalTo(baseB))
+    }
+
+    @Test
+    fun `all-three emphasis bits attenuate every channel`() {
+        val memory = Memory()
+        val ppu = Ppu(memory)
+        memory.ppuAddressedMemory.ppuInternalMemory[0x3F00] = backdropIndex.toByte()
+        memory.ppuAddressedMemory.mask.register = 0b1110_0000.toByte() // red+green+blue emphasis
+
+        val frame = runOneFrame(ppu)
+        val pixel = frame.scanlines[120][128]
+        val base = NesPalette.getRgb(backdropIndex)
+
+        val r = (pixel shr 16) and 0xFF
+        val g = (pixel shr 8) and 0xFF
+        val b = pixel and 0xFF
+        val baseR = (base shr 16) and 0xFF
+        val baseG = (base shr 8) and 0xFF
+        val baseB = base and 0xFF
+
+        assertThat("red attenuated", r < baseR, equalTo(true))
+        assertThat("green attenuated", g < baseG, equalTo(true))
+        assertThat("blue attenuated", b < baseB, equalTo(true))
+    }
 }


### PR DESCRIPTION
Expand the regression test added in #238 so every axis of the 8-entry emphasis table is pinned.

**What this PR adds**

Three new tests in `PpuGreyscaleEmphasisTest`, all using the same forced-blank backdrop path as the existing red-emphasis case:

- `green emphasis attenuates red and blue channels` — PPUMASK bit 6, G unchanged, R+B drop
- `blue emphasis attenuates red and green channels` — PPUMASK bit 7, B unchanged, R+G drop
- `all-three emphasis bits attenuate every channel` — PPUMASK bits 5+6+7 set, all three channels drop

Combined with the existing red-emphasis + greyscale tests, this pins all 8 entries of `NesPalette.emphasisTable` (indices 1-7 plus the no-op case).

**Verification**

- `./gradlew test --tests PpuGreyscaleEmphasisTest` — 6/6 PASS
- `./gradlew build` — green
- `./gradlew bootcheck -Prom=kirby.nes -Pframes=120` — PASS

Closes #225