### PR TITLE
Fix Mapper 2 UOROM PRG bank selection

### DIFF
--- a/MAPPER_SUPPORT.md
+++ b/MAPPER_SUPPORT.md
@@ -23,18 +23,17 @@ Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 22, 24, 26, 33,
   - **Consecutive-write ignore (issue #235, 2026-07-19):** the serial port ignores a data write that lands within one CPU cycle of the previous serial write (the 6502 read-modify-write dummy/real write pair), so only the first bit shifts. The bit-7 reset is never ignored (Shinsenden). Cycle stamped via `tickCpuCycle()`; matches Mesen2 `MMC1.h`.
 - **Banking Fix Applied (2026-04-15):** Mode 3 and mode 2 had inverted fixed/switchable assignments per MMC1 spec
 
-## Mapper 2 (CNROM/UNROM)
+## Mapper 2 (UxROM: UNROM/UOROM)
 **Status:** Working
 
-- **CNROM (original):** 8KB CHR bank switching, fixed PRG at $8000-$FFFF
-- **UNROM (commercial variant):** 16KB PRG bank switching at $8000-$BFFF via $8000-$FFFF writes
-  - Bits 0-2 of value written select the 16KB PRG bank (0-7 for 128KB ROM)
-  - $8000-$BFFF: switchable 16KB PRG bank window
-  - $C000-$FFFF: fixed to last PRG bank (bank 7 for 128KB, bank 3 for 64KB)
-  - Same CHR banking as CNROM (bits 0-1 for CHR bank selection)
-- **Games:** Castlevania, Contra, 1943, DuckTales, California Games (UNROM); original CNROM games
-- **PRG Banking:** $8000-$BFFF switchable, $C000-$FFFF fixed to last bank
-- **CHR Banking:** 8KB banks, switch via bits 0-1 of $8000-$9FFF writes
+- **PRG banking:** writes anywhere in `$8000-$FFFF` select the 16KB bank at `$8000-$BFFF`; `$C000-$FFFF` stays fixed to the last bank
+  - UNROM uses up to 3 bank bits (8 banks / 128KB)
+  - UOROM uses up to 4 bank bits (16 banks / 256KB)
+  - The full written value is retained and resolved modulo the available PRG-bank count, matching Mesen2 and safely wrapping oversized selectors
+- **CHR:** standard boards provide fixed 8KB CHR-RAM; the implementation retains its legacy optional banked CHR-ROM path for nonstandard dumps
+- **Mirroring:** fixed from the cartridge header
+- **Games:** Castlevania, Contra, 1943, DuckTales, California Games (UNROM); Paperboy 2 (UOROM)
+- **Issue #232 (2026-07-20):** removed the 3-bit-only PRG mask so all 16 UOROM banks are reachable; Paperboy 2's Mesen2 boot trace writes banks `$0E` and `$0D`, and its CHR RAM matches Mesen2 at frame 120
 
 ## Mapper 3 (NINA-003/006)
 **Status:** Working

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper2.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper2.kt
@@ -5,50 +5,46 @@ import java.io.DataInput
 import java.io.DataOutput
 
 /**
- * Mapper 2 (CNROM/UNROM) - CHR and PRG bank switching.
+ * Mapper 2 (UxROM: UNROM/UOROM) - 16KB PRG bank switching.
  *
- * CNROM cartridges have:
- * - Fixed PRG ROM at $8000-$FFFF
- * - CHR ROM switched in 8KB banks via $8000-$9FFF writes
- * - Fixed mirroring based on header
+ * - `$8000-$BFFF`: switchable 16KB PRG bank.
+ * - `$C000-$FFFF`: fixed to the last 16KB PRG bank.
+ * - UNROM boards expose up to 3 bank bits (128KB); UOROM exposes 4 (256KB).
+ * - Bank values wrap to the available PRG size, matching Mesen2's page mapping.
+ * - Mirroring is fixed by the cartridge header.
  *
- * UNROM (variant used by many commercial games like Castlevania, Contra):
- * - 16KB PRG bank switching at $8000-$BFFF via writes to $8000-$FFFF
- * - $C000-$FFFF fixed to last PRG bank (bank 7 for 128KB, bank 3 for 64KB)
- * - CHR banking: bits 0-2 of written value select bank
+ * Standard UxROM boards provide 8KB of CHR-RAM. The optional banked CHR-ROM
+ * path is retained for compatibility with existing nonstandard dumps.
  */
 class Mapper2(private val gamePak: GamePak) : Mapper {
 
     private val programRom = gamePak.programRom
     private val chrRom = gamePak.chrRom
-    // CNROM/UNROM: when CHR-ROM is empty, the chip exposes 8KB of CHR-RAM
-    // (some CNROM homebrew relies on this).
+    // UxROM exposes 8KB of CHR-RAM when the cart ships no CHR ROM.
     private val chrMemory: ChrMemory = ChrMemory.default(chrRom)
     private val prgBankCount = programRom.size / 0x4000
     private var chrBank = 0
-    // UNROM: $8000-$BFFF switchable, $C000-$FFFF fixed to last bank
+    // $8000-$BFFF switchable, $C000-$FFFF fixed to last bank.
     private var prgBank = (prgBankCount - 1).coerceAtLeast(1)
 
+    private fun prgByte(bankIndex: Int, windowBase: Int, address: Int): Byte {
+        return programRom[((bankIndex * 0x4000) + (address - windowBase)) % programRom.size]
+    }
+
     override fun cpuRead(address: Int): Byte {
-        return when {
-            address < 0x8000 -> 0
-            address < 0xC000 -> {
-                val bankOffset = prgBank * 0x4000
-                val offset = address - 0x8000
-                programRom[bankOffset + offset]
-            }
-            else -> {
-                val bankOffset = (prgBankCount - 1) * 0x4000
-                val offset = address - 0xC000
-                programRom[bankOffset + offset]
-            }
+        if (address < 0x8000) return 0
+        return if (address < 0xC000) {
+            prgByte(prgBank, 0x8000, address)
+        } else {
+            prgByte(prgBankCount - 1, 0xC000, address)
         }
     }
 
     override fun cpuWrite(address: Int, value: Byte) {
         if (address in 0x8000..0xFFFF) {
-            prgBank = value.toUnsignedInt() and 0x07
-            chrBank = (value.toUnsignedInt() shr 3) and 0x03
+            val v = value.toUnsignedInt()
+            prgBank = v
+            chrBank = (v shr 3) and 0x03
         }
     }
 
@@ -73,6 +69,15 @@ class Mapper2(private val gamePak: GamePak) : Mapper {
             Header.Mirroring.VERTICAL -> Mapper.MirroringMode.VERTICAL
         }
     }
+
+    override fun snapshot(): MapperStateSnapshot = MapperStateSnapshot(
+        mapperId = 2,
+        type = "UxROM",
+        banks = mapOf("prgBank" to prgBank, "chrBank" to chrBank),
+        registers = emptyMap(),
+        irqState = null,
+        chrRam = chrMemory.snapshotBytes()
+    )
 
     override val saveStateVersion: Int = 2
 

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper2RegressionTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/Mapper2RegressionTest.kt
@@ -1,0 +1,33 @@
+package com.github.alondero.nestlin.compare
+
+import com.github.alondero.nestlin.gamepak.Mapper2
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+
+/**
+ * Structured-state regression for issue #232 using Paperboy 2, a 256 KiB UOROM.
+ *
+ * OAM is not asserted because unused sprite bytes retain different power-on
+ * values in the two emulators. CHR RAM is stable across the capture offset and
+ * proves that the correctly banked program populated the same pattern data.
+ */
+class Mapper2RegressionTest : MapperRegressionTestBase() {
+
+    private val frameNumber = 120
+
+    private fun paperboy2Rom(): Path = resolveRom(
+        "NESTLIN_PAPERBOY2_ROM",
+        "S:/Media/Nintendo NES/Games/Paperboy 2 (USA).nes"
+    )
+
+    @Test
+    fun `uorom PRG bank switches during paperboy 2 boot`() {
+        assertBankSwitchesDuringBoot(paperboy2Rom(), frameNumber, "prgBank", Mapper2::class.java)
+    }
+
+    @Test
+    @RequiresMesen2
+    fun `paperboy 2 CHR RAM matches mesen2 at frame N`() {
+        assertChrMatchesMesen2(paperboy2Rom(), frameNumber, "paperboy-2")
+    }
+}

--- a/src/test/kotlin/com/github/alondero/nestlin/compare/MapperRegressionTestBase.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/compare/MapperRegressionTestBase.kt
@@ -2,6 +2,7 @@ package com.github.alondero.nestlin.compare
 
 import com.github.alondero.nestlin.Nestlin
 import com.github.alondero.nestlin.ppu.Frame
+import com.github.alondero.nestlin.testutil.failTest
 import com.github.alondero.nestlin.ui.FrameListener
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assumptions.assumeTrue
@@ -140,17 +141,46 @@ abstract class MapperRegressionTestBase {
 
         println("$reportName frame $frame render-output: ${if (problems.isEmpty()) "MATCH" else "MISMATCH"}")
         if (problems.isNotEmpty()) {
-            // JUnit 5's fail(Supplier<String>) overload has a phantom <V> type
-            // variable Kotlin cannot infer for a multi-line string concat — bypass
-            // fail() and throw AssertionFailedError directly (that's what
-            // fail(String) does internally anyway).
             val failMessage = "Render output diverged from Mesen2 oracle:\n  " +
                 problems.joinToString("\n  ") +
                 (if (divergence.classifications.isNotEmpty())
                     "\nLIKELY CAUSE:\n  " + divergence.classifications.joinToString("\n  ")
                  else "") +
                 "\nSee: ${reportsDir.resolve("divergence-report.txt")}"
-            throw org.opentest4j.AssertionFailedError(failMessage)
+            failTest(failMessage)
         }
+    }
+
+    /**
+     * CHR-only Mesen2 oracle for games whose OAM is structurally incomparable
+     * between captures — for example, an NMI handler rewrites it between frame
+     * boundaries, or unused sprite bytes retain different power-on values. The
+     * full snapshot + diff still go to
+     * `build/reports/state-diffs/<reportName>-frame-<frame>/` alongside the
+     * focused assertion.
+     */
+    protected fun assertChrMatchesMesen2(rom: Path, frame: Int, reportName: String) {
+        val reportsDir = Paths.get("build/reports/state-diffs/$reportName-frame-$frame")
+
+        val nestlinState = NestlinStateCapturer.captureState(rom, frame)
+        val mesen2State = Mesen2StateCapturer.captureState(rom, frame)
+
+        Files.createDirectories(reportsDir)
+        val fullDiff = StateComparator.compare(nestlinState, mesen2State)
+        StateComparator.writeReport(fullDiff, nestlinState, mesen2State, reportsDir.resolve("diff-report.txt"))
+        DivergenceLocalizer.report(nestlinState, mesen2State, reportsDir)
+
+        val chrDiffs = nestlinState.chr.indices.filter {
+            nestlinState.chr[it] != mesen2State.chr[it]
+        }
+        if (chrDiffs.isNotEmpty()) {
+            val sample = chrDiffs.take(8).joinToString(", ") {
+                "[0x%04X] N=0x%02X M=0x%02X".format(it, nestlinState.chr[it], mesen2State.chr[it])
+            }
+            val diffPath = reportsDir.resolve("diff-report.txt").toString()
+            val message = "CHR diverged from Mesen2 oracle in " + chrDiffs.size + " byte(s): " + sample + " | " + diffPath
+            failTest(message)
+        }
+        println("$reportName frame $frame CHR: MATCH")
     }
 }

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper2Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper2Test.kt
@@ -1,0 +1,52 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.github.alondero.nestlin.toSignedByte
+import com.github.alondero.nestlin.toUnsignedInt
+import com.github.alondero.nestlin.testutil.testGamePak
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+class Mapper2Test {
+
+    private fun newMapper(prgKb: Int): Mapper2 {
+        val gamePak = testGamePak {
+            mapper = 2
+            this.prgKb = prgKb
+            chrKb = 0
+            stampPrgBanks(windowKb = 16)
+        }
+        return gamePak.createMapper() as Mapper2
+    }
+
+    @Test
+    fun `UOROM can select all 16 PRG banks`() {
+        val mapper = newMapper(prgKb = 256)
+
+        for (bank in 0..15) {
+            mapper.cpuWrite(0x8000, bank.toSignedByte())
+            assertThat("bank $bank", mapper.cpuRead(0x8000).toUnsignedInt(), equalTo(bank))
+        }
+    }
+
+    @Test
+    fun `C000 window remains fixed to the last PRG bank`() {
+        val mapper = newMapper(prgKb = 256)
+
+        mapper.cpuWrite(0x8000, 8.toSignedByte())
+
+        assertThat(mapper.cpuRead(0x8000).toUnsignedInt(), equalTo(8))
+        assertThat(mapper.cpuRead(0xC000).toUnsignedInt(), equalTo(15))
+    }
+
+    @Test
+    fun `oversized bank number wraps modulo PRG bank count`() {
+        val mapper = newMapper(prgKb = 64)
+
+        mapper.cpuWrite(0x8000, 5.toSignedByte())
+        assertThat(mapper.cpuRead(0x8000).toUnsignedInt(), equalTo(1))
+
+        mapper.cpuWrite(0xFFFF, 0xFF.toSignedByte())
+        assertThat(mapper.cpuRead(0x8000).toUnsignedInt(), equalTo(3))
+    }
+}


### PR DESCRIPTION
## Summary

- retain Mapper 2's full bank-select value and wrap switchable PRG reads to the available ROM size
- expose UxROM bank state to diagnostics and add focused coverage for all 16 UOROM banks, oversized selectors, and the fixed last-bank window
- add a Paperboy 2 boot/Mesen2 regression and document the corrected UNROM/UOROM behavior
- centralize the existing CHR-only Mesen2 comparison pattern for games whose OAM is not a stable cross-emulator oracle

## Verification

- `./gradlew build` — PASS
- `./gradlew test --tests "com.github.alondero.nestlin.gamepak.Mapper2Test" --tests "com.github.alondero.nestlin.testutil.TestAssertsLintTest"` — PASS
- `./gradlew testMesenComparison --tests "com.github.alondero.nestlin.compare.Mapper2RegressionTest"` — PASS; Paperboy 2 active 8 KiB CHR RAM matches Mesen2 at frame 120
- `./gradlew bootcheck -Prom="S:/Media/Nintendo NES/Games/Paperboy 2 (USA).nes" -Pframes=120` — PASS; rendering enabled by frame 18, five PRG states observed
- full `./gradlew testMesenComparison` still has unrelated pre-existing worktree/oracle failures, tracked separately in #253

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)
