### PR TITLE
tools/rom_info: add patch-sunsoft2 for NO-INTRO Mapper 68 mislabel

### DIFF
--- a/tools/rom_info.py
+++ b/tools/rom_info.py
@@ -16,6 +16,9 @@ Subcommands:
     patch-namco108 <rom.nes>          emit a sibling COPY with the NO-INTRO
                                        Namco 108 header patch applied
                                        (mapper 4 -> mapper 206)
+    patch-sunsoft2 <rom.nes>          emit a sibling COPY with the NO-INTRO
+                                       Sunsoft-2 / Sunsoft-4 header patch
+                                       applied (mapper 4 -> mapper 68)
     vectors      <rom.nes>            NMI / RESET / IRQ vectors from the
                                        fixed last bank
     addr         <rom.nes> --cpu-addr 0xXXXX [--bank N|last]
@@ -89,6 +92,21 @@ KNOWN_MISLABEL_FAMILIES = {
             "family": "Namco 108 / DxROM",
             "known_titles": "Gauntlet, Ring King, RBI Baseball, Mappy-Land",
             "patch_recipe": "byte6 = (b6 & 0x0F) | 0xE0; byte7 = (b7 & 0x0F) | 0xC0",
+        },
+        {
+            # NO-INTRO labels these titles as MMC3 (mapper 4); the actual
+            # board is the Sunsoft-2 / Sunsoft-4 IC, which the NESdev wiki
+            # and Mesen2 (Sunsoft4.h) both call mapper 68. The patch flips
+            # the mapper bits in bytes 6/7 without touching mirroring or
+            # battery flags (low nibbles of byte 6) or format/reserved bits
+            # (low nibble of byte 7). See memory file
+            # 'mapper68-sunsoft4-impl-2026-06-27.md' for the implementation
+            # context (Mesen2 was the oracle over the original Sunsoft-2
+            # prose in issue #134).
+            "actual_mapper": 68,
+            "family": "Sunsoft-2 / Sunsoft-4 (NESdev mapper 68)",
+            "known_titles": "Valkyrie no Bouken (Legend of Valkyrie), Mito Koumon II",
+            "patch_recipe": "byte6 = (b6 & 0x0F) | 0x40; byte7 = (b7 & 0x0F) | 0x40",
         },
     ],
 }
@@ -606,6 +624,64 @@ def patch_namco108(src: str, dst: Optional[str] = None) -> Tuple[Path, dict]:
     return out, diff
 
 
+def patch_sunsoft2(src: str, dst: Optional[str] = None) -> Tuple[Path, dict]:
+    """Emit a patched COPY of a NO-INTRO Sunsoft-2 dump with mapper 68 header.
+
+    Returns (output_path, diff_dict) where diff_dict summarises what changed.
+    NEVER modifies the source file. If `dst` is None the output is written
+    next to the source with the suffix `.mapper68.nes`.
+
+    The patch recipe (issue #204, byte-accurate to Mesen2's expected mapper
+    68 header for Sunsoft-2 / Sunsoft-4 titles like The Legend of Valkyrie):
+        byte6 = (b6 & 0x0F) | 0x40
+        byte7 = (b7 & 0x0F) | 0x40
+
+    Distinct from Namco 108 (which OR's 0xE0 / 0xC0): mapper 68's high nibble
+    is 0x4 in BOTH bytes (mapper = (4<<0) | (4<<4) = 0x44), whereas Namco
+    108 uses 0xE0 / 0xC0 (mapper = 0xE | (0xC<<4) = 0xCE). Mirroring, battery,
+    and format bits (low nibbles of bytes 6/7) are preserved untouched.
+    """
+    p = Path(src)
+    if not p.is_file():
+        raise BadRomFile(f"Not a file: {src}")
+    with open(p, "rb") as f:
+        data = bytearray(f.read())
+    if len(data) < INES_HEADER_SIZE or data[0:4] != INES_MAGIC:
+        raise BadRomFile(f"{src} is not a valid iNES file")
+    if dst is None:
+        dst = str(p.with_name(p.stem + ".mapper68" + p.suffix))
+    out = Path(dst)
+
+    old_b6, old_b7 = data[6], data[7]
+    new_b6 = (old_b6 & 0x0F) | 0x40
+    new_b7 = (old_b7 & 0x0F) | 0x40
+    data[6] = new_b6
+    data[7] = new_b7
+
+    with open(out, "wb") as f:
+        f.write(data)
+
+    # Decode both before/after for the diff summary (mirrors patch_namco108).
+    original = bytearray(data)
+    original[6] = old_b6
+    original[7] = old_b7
+    before = decode_bytes(bytes(original), source=str(p), full_crc=True)
+    after = decode_bytes(bytes(data), source=str(out), full_crc=True)
+    diff = {
+        "source": str(p),
+        "output": str(out),
+        "byte6_before": f"0x{old_b6:02X}",
+        "byte6_after": f"0x{new_b6:02X}",
+        "byte7_before": f"0x{old_b7:02X}",
+        "byte7_after": f"0x{new_b7:02X}",
+        "mapper_before": before.mapper,
+        "mapper_after": after.mapper,
+        "crc32_before": f"0x{before.crc32:08X}",
+        "crc32_after": f"0x{after.crc32:08X}",
+    }
+    return out, diff
+
+
 # =============================================================================
 # CLI (argparse subcommands)
 # =============================================================================
@@ -632,6 +708,7 @@ def build_parser() -> argparse.ArgumentParser:
             "  rom_info.py info game.nes\n"
             "  rom_info.py scan S:\\\\Media\\\\Nintendo\\\\NES\\\\Games --mapper 33\n"
             "  rom_info.py patch-namco108 game.nes --out game.mapper206.nes\n"
+            "  rom_info.py patch-sunsoft2 game.nes --out game.mapper68.nes\n"
             "  rom_info.py vectors game.nes\n"
             "  rom_info.py addr game.nes --cpu-addr 0xEA40 --bank last\n"
         ),
@@ -656,6 +733,12 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Emit a sibling COPY with the NO-INTRO Namco 108 header patch (mapper 4 -> 206).")
     pp.add_argument("rom", help="Source .nes file (will NOT be modified).")
     pp.add_argument("--out", default=None, help="Output path (default: <stem>.mapper206.nes).")
+
+    # patch-sunsoft2
+    pp2 = sub.add_parser("patch-sunsoft2",
+                         help="Emit a sibling COPY with the NO-INTRO Sunsoft-2 / Sunsoft-4 header patch (mapper 4 -> 68).")
+    pp2.add_argument("rom", help="Source .nes file (will NOT be modified).")
+    pp2.add_argument("--out", default=None, help="Output path (default: <stem>.mapper68.nes).")
 
     # vectors
     pv = sub.add_parser("vectors", help="Read NMI/RESET/IRQ vectors from the fixed last bank.")
@@ -747,6 +830,10 @@ def main(argv: Optional[List[str]] = None) -> int:
             _print_scan(scan_library(root, mapper=args.mapper), args.mapper)
         elif args.cmd == "patch-namco108":
             out, diff = patch_namco108(args.rom, args.out)
+            for k, v in diff.items():
+                print(f"{k}: {v}")
+        elif args.cmd == "patch-sunsoft2":
+            out, diff = patch_sunsoft2(args.rom, args.out)
             for k, v in diff.items():
                 print(f"{k}: {v}")
         elif args.cmd == "vectors":

--- a/tools/test_rom_info.py
+++ b/tools/test_rom_info.py
@@ -158,6 +158,25 @@ class PlainInesDecodeTest(unittest.TestCase):
         self.assertIn("patch recipe", w.lower())
         self.assertIn("if your rom", w.lower())
 
+    def test_mapper_4_sunsoft2_verification_prompt(self):
+        # As of issue #204 the mapper-4 family includes Sunsoft-2/Sunsoft-4
+        # titles (NESdev mapper 68). The full warning list should mention
+        # both Namco 108 AND Sunsoft-2 alongside their respective patch
+        # recipes. Most mapper-4 games are still real MMC3, so the warning
+        # is a heads-up, not a mislabel claim.
+        rom = make_rom(b6=0x40, b7=0x00)
+        h = rom_info.decode_bytes(rom, full_crc=False)
+        self.assertEqual(h.mapper, 4)
+        warnings_text = " ".join(h.mislabel_warnings).lower()
+        self.assertIn("namco 108", warnings_text)
+        self.assertIn("sunsoft", warnings_text)
+        # Both patch recipes must appear so the user can copy/paste.
+        self.assertIn("0xe0", warnings_text)
+        self.assertIn("0x40", warnings_text)
+        # And both target mappers must be named (206 and 68).
+        self.assertIn("206", " ".join(h.mislabel_warnings))
+        self.assertIn("68", " ".join(h.mislabel_warnings))
+
 
 # ---------------------------------------------------------------------------
 # Header decode — NES 2.0
@@ -517,6 +536,129 @@ class PatchNamco108Test(unittest.TestCase):
                 rom_info.patch_namco108(bad)
         finally:
             os.unlink(bad)
+
+
+# ---------------------------------------------------------------------------
+# Sunsoft-2 patch (mapper 4 -> 68; issue #204)
+# ---------------------------------------------------------------------------
+
+class PatchSunsoft2Test(unittest.TestCase):
+
+    def test_patch_changes_byte7_only_when_byte6_already_0x40(self):
+        # Valkyrie's actual header pattern: b6 = 0x40 (mapper low nibble 4,
+        # horizontal mirroring, no battery), b7 = 0x00. After the patch,
+        # b6 stays 0x40 (only the high nibble is touched), b7 becomes 0x40.
+        rom = make_rom(b6=0x40, b7=0x00)
+        p = write_temp_rom(rom)
+        try:
+            out, diff = rom_info.patch_sunsoft2(str(p))
+            try:
+                self.assertEqual(diff["byte6_before"], "0x40")
+                self.assertEqual(diff["byte6_after"], "0x40")
+                self.assertEqual(diff["byte7_before"], "0x00")
+                self.assertEqual(diff["byte7_after"], "0x40")
+                self.assertEqual(diff["mapper_after"], 68)
+                # Output must decode as mapper 68.
+                h = rom_info.decode_header(str(out), full_crc=False)
+                self.assertEqual(h.mapper, 68)
+            finally:
+                if out.exists():
+                    out.unlink()
+        finally:
+            p.unlink()
+
+    def test_patch_sets_both_high_nibbles_to_4(self):
+        # Variant with battery flag (b6 bit 1) + vertical mirroring flag
+        # already set in the low nibble — the recipe must PRESERVE them.
+        rom = make_rom(b6=0x43, b7=0x0C)  # battery + vertical; format bits in b7
+        p = write_temp_rom(rom)
+        try:
+            out, diff = rom_info.patch_sunsoft2(str(p))
+            try:
+                self.assertEqual(diff["byte6_after"], "0x43",
+                                 "low nibble of byte 6 (mirroring + battery) must be preserved")
+                self.assertEqual(diff["byte7_after"], "0x4C",
+                                 "low nibble of byte 7 (format bits) must be preserved")
+                h = rom_info.decode_header(str(out), full_crc=False)
+                self.assertEqual(h.mapper, 68)
+                self.assertTrue(h.has_battery,
+                                "battery flag (b6 bit 1) must survive the patch")
+                self.assertEqual(h.mirroring, "vertical",
+                                 "mirroring flag (b6 bit 0) must survive the patch")
+            finally:
+                if out.exists():
+                    out.unlink()
+        finally:
+            p.unlink()
+
+    def test_patch_preserves_other_bytes(self):
+        rom = make_rom(b6=0x40, b7=0x00, fill_prg=0xCD)
+        p = write_temp_rom(rom)
+        try:
+            out, _ = rom_info.patch_sunsoft2(str(p))
+            try:
+                with open(out, "rb") as f:
+                    patched = f.read()
+                # Header bytes 0..5 (magic + bank counts) must be unchanged.
+                self.assertEqual(patched[0:6], rom[0:6])
+                # Header bytes 8..15 must be unchanged.
+                self.assertEqual(patched[8:16], rom[8:16])
+                # PRG body must be unchanged.
+                self.assertEqual(patched[16:], rom[16:])
+            finally:
+                if out.exists():
+                    out.unlink()
+        finally:
+            p.unlink()
+
+    def test_patch_does_not_modify_source(self):
+        # The "never touches the source" guarantee is the whole point of
+        # using a sibling copy; lock it in with a hash check.
+        rom = make_rom(b6=0x40, b7=0x00)
+        p = write_temp_rom(rom)
+        try:
+            source_hash_before = zlib.crc32(rom) & 0xFFFFFFFF
+            out, _ = rom_info.patch_sunsoft2(str(p))
+            try:
+                with open(p, "rb") as f:
+                    source_bytes_after = f.read()
+                source_hash_after = zlib.crc32(source_bytes_after) & 0xFFFFFFFF
+                self.assertEqual(source_hash_after, source_hash_before)
+                # And the file on disk is byte-identical to the original.
+                self.assertEqual(source_bytes_after, rom)
+            finally:
+                if out.exists():
+                    out.unlink()
+        finally:
+            p.unlink()
+
+    def test_patch_rejects_non_ines(self):
+        with tempfile.NamedTemporaryFile(suffix=".nes", delete=False) as f:
+            f.write(b"NOPE\x00" + b"\x00" * 100)
+            bad = f.name
+        try:
+            with self.assertRaises(rom_info.BadRomFile):
+                rom_info.patch_sunsoft2(bad)
+        finally:
+            os.unlink(bad)
+
+    def test_patch_output_default_suffix_is_mapper68(self):
+        # The default output path appends ".mapper68" before the extension,
+        # mirroring the .mapper206 convention for Namco 108. Lock the naming
+        # in so a future refactor can't silently change it (test pipelines
+        # rely on the predictable suffix).
+        rom = make_rom(b6=0x40, b7=0x00)
+        p = write_temp_rom(rom, suffix=".nes")
+        try:
+            out, _ = rom_info.patch_sunsoft2(str(p))
+            try:
+                self.assertTrue(out.name.endswith(".mapper68.nes"),
+                                f"expected .mapper68.nes suffix, got {out.name}")
+            finally:
+                if out.exists():
+                    out.unlink()
+        finally:
+            p.unlink()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #204

## What

Adds a `patch-sunsoft2` subcommand to `tools/rom_info.py` that emits a sibling COPY of a NO-INTRO Sunsoft-2 / Sunsoft-4 dump with the mapper-4 -> mapper-68 header patch applied. Distinct bit pattern from the existing `patch-namco108` (mapper 4 -> 206):
- Namco 108:    byte6 = (b6 & 0x0F) | 0xE0;  byte7 = (b7 & 0x0F) | 0xC0
- Sunsoft-2:    byte6 = (b6 & 0x0F) | 0x40;  byte7 = (b7 & 0x0F) | 0x40

Mirroring, battery, and format bits (low nibbles) are preserved untouched in both recipes.

Also extends `KNOWN_MISLABEL_FAMILIES` so `info` and `scan` warn about the Sunsoft-2 family alongside the existing Namco 108 entry.

## Why

Issue #204 documented that NO-INTRO labels Sunsoft-2 / Sunsoft-4 titles (NESdev mapper 68, Mesen2 Sunsoft4.h) as MMC3 (mapper 4) — same kind of header mislabel as Namco 108 -> mapper 4. Without a patch tool, the Mapper 68 implementation could not be exercised against its canonical acceptance title (`The Legend of Valkyrie`) because the iNES header was mislabeled.

## Verification

End-to-end via `./gradlew bootcheck` against the patched Valkyrie ROM:
```
rom=S:\Media\Nintendo NES\Games\Valkyrie no Bouken - Toki no Kagi Densetsu (Japan) (Translated En).mapper68.nes
BOOTCHECK VERDICT: PASS
  loaded             : true   (Mapper68)
  framesRun          : 180
  maxNonBlankRatio   : 0.6216
  distinctChrStates  : 3
  nmiCount           : 176    irqCount: 0
  distinctFramePCs   : 11
```

This satisfies issue #134's "reaches a rendered title screen" acceptance criteria via a real canonical Mapper 68 title.

## Tests

- 6 new unit tests in `tools/test_rom_info.py` mirroring `PatchNamco108Test`: happy path, low-nibble preservation (battery + mirroring), other-bytes-preserved, source-untouched, bad-input rejection, default output suffix.
- 1 extended test confirming `info` mentions BOTH mapper-4 families (Namco 108 + Sunsoft-2).
- 50/50 rom_info.py unit tests pass.
- `./gradlew test check --rerun-tasks` BUILD SUCCESSFUL.

## Items #5 of #204 already resolved

The CLAUDE.md Mapper 65 omission was fixed by commit 5d5d982 (GH #136 MMC6 merge), which added 65, 113, 119 to the active-mappers line while touching the file. Confirmed via `git show master:CLAUDE.md`. No work needed.

## Diff

```
tools/rom_info.py      |  87 ++++++++++++++++++++++++++++++
tools/test_rom_info.py | 142 +++++++++++++++++++++++++++++++++++++++++++++++++
2 files changed, 229 insertions(+)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)