### PR TITLE
fix(mapper4): clamp fixed PRG bank indices

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper4.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper4.kt
@@ -82,7 +82,7 @@ open class Mapper4(private val gamePak: GamePak) : Mapper {
         return when (address and 0xE000) {
             0x8000 -> {
                 // $8000-$9FFF: second-to-last (fixed) in mode 1, R6 (prgBank6, switchable) in mode 0
-                val bank = if (prgMode) (prgBankCount - 2) else prgBank6
+                val bank = if (prgMode) (prgBankCount - 2).coerceAtLeast(0) else prgBank6
                 programRom[(bank * 0x2000 + (address - 0x8000)) % programRom.size]
             }
             0xA000 -> {
@@ -91,12 +91,13 @@ open class Mapper4(private val gamePak: GamePak) : Mapper {
             }
             0xC000 -> {
                 // $C000-$DFFF: R8 (second-to-last) or R6 depending on prgMode
-                val bank = if (prgMode) prgBank6 else (prgBankCount - 2)
+                val bank = if (prgMode) prgBank6 else (prgBankCount - 2).coerceAtLeast(0)
                 programRom[(bank * 0x2000 + (address - 0xC000)) % programRom.size]
             }
             0xE000 -> {
                 // $E000-$FFFF: always last bank (fixed)
-                programRom[((prgBankCount - 1) * 0x2000 + (address - 0xE000)) % programRom.size]
+                val bank = (prgBankCount - 1).coerceAtLeast(0)
+                programRom[(bank * 0x2000 + (address - 0xE000)) % programRom.size]
             }
             else -> 0
         }

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper4PrgBankingTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper4PrgBankingTest.kt
@@ -1,0 +1,51 @@
+package com.github.alondero.nestlin.gamepak
+
+import com.github.alondero.nestlin.testutil.testGamePak
+import com.github.alondero.nestlin.toUnsignedInt
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+/** Regression coverage for Mapper 4 program-ROM fixed-bank selection. */
+class Mapper4PrgBankingTest {
+
+    @Test
+    fun `one 8KB PRG bank clamps the second-to-last fixed bank to zero in both modes`() {
+        val mapper = mapperWithPrgBankCount(1)
+
+        // Power-on PRG mode: the fixed second-to-last bank is at $C000.
+        assertThat(mapper.cpuRead(0xC000).toUnsignedInt(), equalTo(0))
+
+        // PRG mode 1 swaps that fixed bank into $8000.
+        mapper.cpuWrite(0x8000, 0x40)
+        assertThat(mapper.cpuRead(0x8000).toUnsignedInt(), equalTo(0))
+    }
+
+    @Test
+    fun `zero derived PRG banks clamps the last fixed bank to zero`() {
+        val mapper = mapperWithPrgBankCount(0)
+
+        assertThat(mapper.cpuRead(0xE000).toUnsignedInt(), equalTo(0))
+    }
+
+    /**
+     * iNES represents PRG ROM in 16KB units, so [GamePak] cannot naturally
+     * construct the issue's latent one-8KB-bank state. Start from its smallest
+     * valid image, then override Mapper 4's derived 8KB count so the test still
+     * exercises the real [Mapper4.cpuRead] fixed-bank indexing path.
+     */
+    private fun mapperWithPrgBankCount(prgBankCount: Int): Mapper4 {
+        val gamePak = testGamePak {
+            mapper = 4
+            prgKb = 16
+            chrKb = 8
+            stampPrgBanks(windowKb = 8)
+        }
+        return Mapper4(gamePak).also { mapper ->
+            Mapper4::class.java.getDeclaredField("prgBankCount").apply {
+                isAccessible = true
+                setInt(mapper, prgBankCount)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- clamp Mapper 4's second-to-last fixed PRG bank to bank 0 when fewer than two 8 KB banks are available
- clamp the fixed last-bank index before converting it to a byte offset
- add regression coverage for both MMC3 PRG modes and the fixed `$E000-$FFFF` window

## Verification

- `tools/run-diag.ps1 -TestClass Mapper4PrgBankingTest` (red before fix; 2/2 green after fix)
- `./gradlew build`
- `./gradlew bootcheck -Prom=X:/src/nestlin/testroms/kirby.nes -Pframes=120` — `BOOTCHECK VERDICT: PASS`
- `git diff --check`

The optional full `testMesenComparison` lane was also attempted. Its unrelated known worktree-path and oracle failures remain tracked in #253; no Mapper 4 production failure was observed.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)