### PR TITLE
feat(gamepak): surface 4-screen mirroring (iNES byte 6 bit 3) + FOUR_SCREEN

### DIFF
--- a/MAPPER_SUPPORT.md
+++ b/MAPPER_SUPPORT.md
@@ -962,8 +962,10 @@ Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 22, 24, 26, 33,
     `$0000-$0FFF` (low bit ignored, so adjacent 1 KB pages pair), R2-R5 select
     four 1 KB banks at `$1000-$1FFF`. Bit 7 of the bank-select register is ignored.
   - **Mirroring is hardwired** from the iNES header — there is no `$A000` mirroring
-    register. (DRROM Gauntlet uses 4-screen, signalled via the header's 4-screen bit;
-    the cartridge board wires it physically.)
+    register. DRROM Gauntlet uses **4-screen** VRAM, signalled by the header's
+    4-screen bit (byte 6 bit 3); the cartridge board wires the extra 2 KB physically.
+    That bit is honoured (GH #105): `currentMirroring()` returns `FOUR_SCREEN` and the
+    PPU exposes four distinct nametables instead of an H/V mirror.
   - **No scanline IRQ counter** — writes to `$C000`/`$C001` (latch/reload) and
     `$E000`/`$E001` (enable/disable) are accepted as no-ops. Mapper 206 inherits
     Mapper's default `isIrqPending() = false` and `acknowledgeIrq() = {}`.
@@ -982,9 +984,16 @@ Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 22, 24, 26, 33,
   ignored, R2-R5 1 KB), the bank-select/data protocol across the full `$8000-$FFFF`
   decode, hardwired PRG/CHR modes (writes with bits 6/7 set in `$8000` do not flip
   into mode 1 / invert), header-driven mirroring, PRG-RAM read/write, the missing
-  IRQ, CHR-RAM fallback, and save/load round-trip. End-to-end ROM boot/render
-  verification is left for a follow-up Mesen2 comparison (see `MapperVerificationTest`
-  pattern) — Gauntlet and RBI Baseball are the natural oracles.
+  IRQ, CHR-RAM fallback, and save/load round-trip. `currentMirroring()` returning
+  `FOUR_SCREEN` when the header 4-screen bit is set (and 4-screen winning over the
+  H/V bit) is covered too; the four-independent-nametable resolution itself is tested
+  in `NametableMirroringTest`. End-to-end ROM boot/render verification is left for a
+  follow-up Mesen2 comparison (see `MapperVerificationTest` pattern) — Gauntlet and
+  RBI Baseball are the natural oracles.
+- **Real-ROM boot gate:** Gauntlet's NO-INTRO dump is mislabelled mapper 4 (see the
+  `tools/rom_info.py patch-namco108` recipe); after patching to mapper 206,
+  `./gradlew bootcheck -Prom=<gauntlet.mapper206.nes> -Pframes=120` returns **PASS**
+  (loads as Mapper206, 116 NMIs in 120 frames).
 
 ---
 

--- a/src/main/kotlin/com/github/alondero/nestlin/Memory.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/Memory.kt
@@ -249,6 +249,7 @@ class Memory : DmaPort {
             Mapper.MirroringMode.VERTICAL -> com.github.alondero.nestlin.ppu.PpuInternalMemory.Mirroring.VERTICAL
             Mapper.MirroringMode.ONE_SCREEN_LOWER -> com.github.alondero.nestlin.ppu.PpuInternalMemory.Mirroring.ONE_SCREEN_LOWER
             Mapper.MirroringMode.ONE_SCREEN_UPPER -> com.github.alondero.nestlin.ppu.PpuInternalMemory.Mirroring.ONE_SCREEN_UPPER
+            Mapper.MirroringMode.FOUR_SCREEN -> com.github.alondero.nestlin.ppu.PpuInternalMemory.Mirroring.FOUR_SCREEN
         }
     }
 

--- a/src/main/kotlin/com/github/alondero/nestlin/SaveState.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/SaveState.kt
@@ -11,7 +11,7 @@ import java.io.OutputStream
  * Save state file format ("NSTL"):
  *
  *   magic       4 bytes  "NSTL" (0x4E 0x53 0x54 0x4C)
- *   version     int      currently 5; bump on breaking format change.
+ *   version     int      currently 6; bump on breaking format change.
  *                        Version 2 added a per-mapper version byte inside the
  *                        mapper block (see below) so individual mappers can
  *                        evolve their own field order without invalidating
@@ -25,6 +25,11 @@ import java.io.OutputStream
  *                        plugged into each controller port. v4 files load with
  *                        both ports defaulting to STANDARD_GAMEPAD. Issue: 2-player
  *                        support.
+ *                        Version 6 added optional 4-screen VRAM (two extra 1 KB
+ *                        nametables) inside the PPU block. These bytes are only
+ *                        present when the PPU mirroring is FOUR_SCREEN, so v4/v5
+ *                        saves — and any v6 save of a non-4-screen game — are
+ *                        byte-for-byte identical and load unchanged. GH #105.
  *   romCrc      long     CRC32 of the loaded ROM at save time
  *   romMapper   int      mapper id (validated on load)
  *   cpu         block    written by Cpu.saveState
@@ -51,7 +56,7 @@ import java.io.OutputStream
  */
 object SaveState {
     private const val MAGIC = 0x4E53544C  // "NSTL"
-    const val VERSION = 5
+    const val VERSION = 6
 
     /** Highest version this code can read. */
     private const val MIN_SUPPORTED_VERSION = 4

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/GamePak.kt
@@ -224,6 +224,18 @@ class Header(headerData: ByteArray) {
     val hasBattery: Boolean = headerData[6].toUnsignedInt() and 0x02 != 0
 
     /**
+     * iNES byte 6 bit 3 (`0x08`) — the 4-screen VRAM flag. When set, the cartridge
+     * solders on an extra 2 KB of nametable RAM so all four PPU nametable slots
+     * ($2000/$2400/$2800/$2C00) are physically distinct, and the horizontal/vertical
+     * [mirroring] bit is ignored by the board. Reported separately from [mirroring]
+     * (which stays a two-value H/V enum) so that the ~20 mappers pattern-matching
+     * `when (header.mirroring)` exhaustively don't have to grow a fourth arm each.
+     * A mapper whose board honours 4-screen (e.g. Mapper 206 / DRROM Gauntlet)
+     * checks this and returns [Mapper.MirroringMode.FOUR_SCREEN]. See GH #105.
+     */
+    val fourScreen: Boolean = headerData[6].toUnsignedInt() and 0x08 != 0
+
+    /**
      * Submapper number from the NES 2.0 header byte 8 (high nibble). For
      * iNES 1.0 headers this is byte 8 of the header (the "PRG-RAM size" byte),
      * which is unrelated; we treat it as 0 unless the header is actually NES 2.0.

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper.kt
@@ -131,6 +131,10 @@ interface Mapper {
         HORIZONTAL,
         VERTICAL,
         ONE_SCREEN_LOWER,
-        ONE_SCREEN_UPPER
+        ONE_SCREEN_UPPER,
+        // Four-screen VRAM: the cartridge supplies an extra 2 KB so all four
+        // nametables are distinct. Appended LAST so existing ordinals (0-3) —
+        // persisted by Mapper4/9/10 via values()[ord] — stay valid. See GH #105.
+        FOUR_SCREEN
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper206.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper206.kt
@@ -15,8 +15,9 @@ import java.io.DataOutput
  *     four 1 KB banks at $1000-$1FFF (MMC3 CHR mode 0). Bit 7 of the bank-select
  *     register is ignored.
  *   - Mirroring is hardwired from the iNES header — there is no $A000 mirroring
- *     register. (DRROM Gauntlet uses 4-screen, signalled via the header's 4-screen
- *     bit; the body of Namco 108 boards does not let the program change it.)
+ *     register. DRROM Gauntlet uses 4-screen VRAM, signalled via the header's
+ *     4-screen bit (byte 6 bit 3); that bit is honoured here (GH #105) and the
+ *     body of Namco 108 boards does not let the program change mirroring.
  *   - There is no scanline IRQ counter; the $C000/$C001/$E000/$E001 write pair is
  *     accepted but has no effect.
  *
@@ -152,6 +153,10 @@ class Mapper206(private val gamePak: GamePak) : Mapper {
 
     override fun currentMirroring(): Mapper.MirroringMode {
         // No $A000 mirroring register — driven entirely by the iNES header.
+        // DRROM Gauntlet wires 4-screen VRAM (header byte 6 bit 3); when that bit
+        // is set the board ignores the H/V bit and exposes four distinct
+        // nametables. See GH #105.
+        if (gamePak.header.fourScreen) return Mapper.MirroringMode.FOUR_SCREEN
         return when (gamePak.header.mirroring) {
             Header.Mirroring.HORIZONTAL -> Mapper.MirroringMode.HORIZONTAL
             Header.Mirroring.VERTICAL -> Mapper.MirroringMode.VERTICAL

--- a/src/main/kotlin/com/github/alondero/nestlin/ppu/PpuInternalMemory.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/ppu/PpuInternalMemory.kt
@@ -9,6 +9,11 @@ class PpuInternalMemory {
     private val patternTable1 = ByteArray(0x1000)
     private val nameTable0 = ByteArray(0x400)
     private val nameTable1 = ByteArray(0x400)
+    // Two extra 1 KB nametables used ONLY in FOUR_SCREEN mode (the cartridge's
+    // on-board 2 KB VRAM). In H/V/one-screen modes they stay zeroed and are not
+    // serialized. See GH #105.
+    private val nameTable2 = ByteArray(0x400)
+    private val nameTable3 = ByteArray(0x400)
     private val paletteRam = PaletteRam()
 
     var mirroring = Mirroring.HORIZONTAL
@@ -73,7 +78,11 @@ class PpuInternalMemory {
         HORIZONTAL,
         VERTICAL,
         ONE_SCREEN_LOWER,
-        ONE_SCREEN_UPPER
+        ONE_SCREEN_UPPER,
+        // Four-screen: the cartridge's extra 2 KB VRAM makes all four nametables
+        // distinct. Appended LAST so existing ordinals (persisted as
+        // `mirroring.ordinal` in saveState) are unchanged. See GH #105.
+        FOUR_SCREEN
     }
 
     private fun mapNametableAddress(addr: Int): Pair<ByteArray, Int> {
@@ -91,8 +100,16 @@ class PpuInternalMemory {
             }
             Mirroring.ONE_SCREEN_LOWER -> 0
             Mirroring.ONE_SCREEN_UPPER -> 1
+            // Four-screen: each 1 KB window maps to its own distinct table, so
+            // $2000->NT0, $2400->NT1, $2800->NT2, $2C00->NT3 with no aliasing.
+            Mirroring.FOUR_SCREEN -> normalizedAddr / 0x400
         }
-        val table = if (tableIndex == 0) nameTable0 else nameTable1
+        val table = when (tableIndex) {
+            0 -> nameTable0
+            1 -> nameTable1
+            2 -> nameTable2
+            else -> nameTable3
+        }
         return Pair(table, addr % 0x400)
     }
 
@@ -202,6 +219,14 @@ class PpuInternalMemory {
         out.write(nameTable1)
         paletteRam.saveState(out)
         out.writeInt(mirroring.ordinal)
+        // Self-describing 4-screen VRAM: only FOUR_SCREEN saves carry the two
+        // extra nametables, so pre-4-screen and non-4-screen saves are byte-for-byte
+        // identical to before and load unchanged (GH #105). The load path reads
+        // them back conditioned on the mirroring value it just read.
+        if (mirroring == Mirroring.FOUR_SCREEN) {
+            out.write(nameTable2)
+            out.write(nameTable3)
+        }
         out.writeBoolean(lastA12High)
         out.writeInt(m2CyclesSinceA12Low)
     }
@@ -213,6 +238,11 @@ class PpuInternalMemory {
         input.readFully(nameTable1)
         paletteRam.loadState(input)
         mirroring = Mirroring.values()[input.readInt()]
+        // Mirror of saveState: only a FOUR_SCREEN save carries the extra tables.
+        if (mirroring == Mirroring.FOUR_SCREEN) {
+            input.readFully(nameTable2)
+            input.readFully(nameTable3)
+        }
         lastA12High = input.readBoolean()
         m2CyclesSinceA12Low = input.readInt()
     }

--- a/src/test/kotlin/com/github/alondero/nestlin/SaveStateMigrationTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/SaveStateMigrationTest.kt
@@ -31,11 +31,12 @@ class SaveStateMigrationTest {
     private val nestest: Path = Paths.get("testroms/nestest.nes")
 
     @Test
-    fun `SaveState VERSION is 5 to record the new ports block`() {
+    fun `SaveState VERSION is 6 to record the optional 4-screen VRAM block`() {
         // Sanity check — fails fast if someone bumps or forgets the version
         // migration. The kdoc on SaveState and the load() version branch both
-        // hinge on this constant.
-        assertThat(SaveState.VERSION, equalTo(5))
+        // hinge on this constant. v6 (GH #105) adds two optional 1 KB nametables
+        // to the PPU block, written only when mirroring is FOUR_SCREEN.
+        assertThat(SaveState.VERSION, equalTo(6))
     }
 
     @Test

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/GamePakTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/GamePakTest.kt
@@ -110,6 +110,43 @@ class GamePakTest {
         assertThat(h.mapper, equalTo(0x12))
     }
 
+    // --- GH #105: 4-screen VRAM flag (iNES byte 6 bit 3). ---
+
+    @Test
+    fun fourScreenBitIsSurfacedFromByte6Bit3() {
+        // byte 6 = 0x08 -> 4-screen bit set, H/V bit (bit 0) clear.
+        val header = ByteArray(16)
+        header[0] = 0x4E; header[1] = 0x45; header[2] = 0x53; header[3] = 0x1A
+        header[6] = 0x08.toByte()
+        val h = Header(header)
+        assertThat(h.fourScreen, equalTo(true))
+    }
+
+    @Test
+    fun fourScreenIsFalseWhenBit3Clear() {
+        // byte 6 = 0x01 -> vertical mirroring, no 4-screen.
+        val header = ByteArray(16)
+        header[0] = 0x4E; header[1] = 0x45; header[2] = 0x53; header[3] = 0x1A
+        header[6] = 0x01.toByte()
+        val h = Header(header)
+        assertThat(h.fourScreen, equalTo(false))
+        // The H/V bit is decoded independently of the 4-screen bit.
+        assertThat(h.mirroring, equalTo(Header.Mirroring.VERTICAL))
+    }
+
+    @Test
+    fun fourScreenAndMirroringBitsAreIndependent() {
+        // byte 6 = 0x09 -> both bit 3 (4-screen) and bit 0 (vertical) set. The
+        // header surfaces both raw bits; deciding that 4-screen wins is the
+        // mapper's job, not the header's.
+        val header = ByteArray(16)
+        header[0] = 0x4E; header[1] = 0x45; header[2] = 0x53; header[3] = 0x1A
+        header[6] = 0x09.toByte()
+        val h = Header(header)
+        assertThat(h.fourScreen, equalTo(true))
+        assertThat(h.mirroring, equalTo(Header.Mirroring.VERTICAL))
+    }
+
     // --- GitHub issue #16: GamePak must validate iNES header magic + size. ---
     // Each test below uses `assertBadHeader { ... }` (defined at top of file)
     // so the assertion fails cleanly with the message we asked for, instead of

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper206Test.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper206Test.kt
@@ -30,16 +30,19 @@ class Mapper206Test {
     private fun createTestGamePak(
         prg8k: Int = 8,
         chr1k: Int = 32,
-        mirroring: Header.Mirroring = Header.Mirroring.VERTICAL
+        mirroring: Header.Mirroring = Header.Mirroring.VERTICAL,
+        fourScreen: Boolean = false
     ): GamePak {
         val header = ByteArray(16)
         header[0] = 'N'.code.toByte(); header[1] = 'E'.code.toByte()
         header[2] = 'S'.code.toByte(); header[3] = 0x1A.toByte()
         header[4] = (prg8k / 2).toByte()           // PRG ROM size in 16KB units
         header[5] = (chr1k / 8).toByte()           // CHR ROM size in 8KB units
-        // mapper 206 = 0xCE. flags6 = mapper-low nibble in upper 4 bits, plus bit 0 = mirror.
+        // mapper 206 = 0xCE. flags6 = mapper-low nibble in upper 4 bits, plus bit 0 = mirror,
+        // plus bit 3 = 4-screen VRAM.
         val mirrorBit = if (mirroring == Header.Mirroring.VERTICAL) 0x01 else 0x00
-        header[6] = (((206 and 0x0F) shl 4) or mirrorBit).toByte()
+        val fourScreenBit = if (fourScreen) 0x08 else 0x00
+        header[6] = (((206 and 0x0F) shl 4) or fourScreenBit or mirrorBit).toByte()
         header[7] = (206 and 0xF0).toByte()
         val prg = ByteArray(prg8k * 0x2000) { ((it / 0x2000) and 0xFF).toByte() }
         val chr = ByteArray(chr1k * 0x400) { ((it / 0x400) and 0xFF).toByte() }
@@ -271,6 +274,21 @@ class Mapper206Test {
 
         val h = Mapper206(createTestGamePak(mirroring = Header.Mirroring.HORIZONTAL))
         assertThat(h.currentMirroring(), equalTo(Mapper.MirroringMode.HORIZONTAL))
+    }
+
+    @Test
+    fun `currentMirroring returns FOUR_SCREEN when header 4-screen bit is set`() {
+        // DRROM Gauntlet: the 4-screen VRAM bit (byte 6 bit 3) makes the board
+        // expose four distinct nametables, overriding the H/V bit. See GH #105.
+        val m = Mapper206(createTestGamePak(fourScreen = true))
+        assertThat(m.currentMirroring(), equalTo(Mapper.MirroringMode.FOUR_SCREEN))
+    }
+
+    @Test
+    fun `4-screen bit wins over the H-V bit`() {
+        // Even with the vertical bit also set, 4-screen takes precedence.
+        val m = Mapper206(createTestGamePak(mirroring = Header.Mirroring.VERTICAL, fourScreen = true))
+        assertThat(m.currentMirroring(), equalTo(Mapper.MirroringMode.FOUR_SCREEN))
     }
 
     // ---- No scanline IRQ ----

--- a/src/test/kotlin/com/github/alondero/nestlin/ppu/NametableMirroringTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/ppu/NametableMirroringTest.kt
@@ -3,6 +3,10 @@ package com.github.alondero.nestlin.ppu
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
 
 class NametableMirroringTest {
 
@@ -119,5 +123,105 @@ class NametableMirroringTest {
         // NT1 should have 0x20 at offset 0 (accessed via 0x2400 or 0x2C00)
         assertThat(memory[0x2400], equalTo(0x20.toByte()))
         assertThat(memory[0x2C00], equalTo(0x20.toByte()))
+    }
+
+    // Four-screen mirroring tests (used by DRROM Gauntlet / Mapper 206, GH #105).
+    // With 4-screen VRAM there is NO mirroring: each of the four 1 KB windows
+    // ($2000/$2400/$2800/$2C00) is its own independent nametable.
+    @Test
+    fun `four-screen mirroring - all four nametables are independent`() {
+        val memory = PpuInternalMemory()
+        memory.mirroring = PpuInternalMemory.Mirroring.FOUR_SCREEN
+
+        memory[0x2000] = 0x11.toByte()  // NT0
+        memory[0x2400] = 0x22.toByte()  // NT1
+        memory[0x2800] = 0x33.toByte()  // NT2
+        memory[0x2C00] = 0x44.toByte()  // NT3
+
+        // No cross-aliasing: each window keeps its own value.
+        assertThat(memory[0x2000], equalTo(0x11.toByte()))
+        assertThat(memory[0x2400], equalTo(0x22.toByte()))
+        assertThat(memory[0x2800], equalTo(0x33.toByte()))
+        assertThat(memory[0x2C00], equalTo(0x44.toByte()))
+    }
+
+    @Test
+    fun `four-screen mirroring - 0x2000 and 0x2400 do NOT alias (unlike horizontal)`() {
+        val memory = PpuInternalMemory()
+        memory.mirroring = PpuInternalMemory.Mirroring.FOUR_SCREEN
+
+        memory[0x2000] = 0x42.toByte()
+        memory[0x2400] = 0x99.toByte()
+
+        // Under horizontal mirroring these two share NT0; under 4-screen they don't.
+        assertThat(memory[0x2000], equalTo(0x42.toByte()))
+        assertThat(memory[0x2400], equalTo(0x99.toByte()))
+    }
+
+    @Test
+    fun `four-screen mirroring - 0x2000 and 0x2800 do NOT alias (unlike vertical)`() {
+        val memory = PpuInternalMemory()
+        memory.mirroring = PpuInternalMemory.Mirroring.FOUR_SCREEN
+
+        memory[0x2000] = 0x42.toByte()
+        memory[0x2800] = 0x99.toByte()
+
+        // Under vertical mirroring these two share NT0; under 4-screen they don't.
+        assertThat(memory[0x2000], equalTo(0x42.toByte()))
+        assertThat(memory[0x2800], equalTo(0x99.toByte()))
+    }
+
+    @Test
+    fun `four-screen mirroring - offsets within a table are addressed correctly`() {
+        val memory = PpuInternalMemory()
+        memory.mirroring = PpuInternalMemory.Mirroring.FOUR_SCREEN
+
+        // Last byte of each 1 KB window is distinct and within its own table.
+        memory[0x23FF] = 0x1F.toByte()  // NT0 tail
+        memory[0x27FF] = 0x2F.toByte()  // NT1 tail
+        memory[0x2BFF] = 0x3F.toByte()  // NT2 tail
+        memory[0x2FFF] = 0x4F.toByte()  // NT3 tail
+
+        assertThat(memory[0x23FF], equalTo(0x1F.toByte()))
+        assertThat(memory[0x27FF], equalTo(0x2F.toByte()))
+        assertThat(memory[0x2BFF], equalTo(0x3F.toByte()))
+        assertThat(memory[0x2FFF], equalTo(0x4F.toByte()))
+    }
+
+    // Save-state format tests (GH #105). The two extra 4-screen nametables are
+    // written ONLY when mirroring == FOUR_SCREEN, so non-4-screen state stays
+    // byte-for-byte identical to the pre-4-screen format.
+    @Test
+    fun `four-screen state round-trips all four nametables`() {
+        val original = PpuInternalMemory()
+        original.mirroring = PpuInternalMemory.Mirroring.FOUR_SCREEN
+        original[0x2000] = 0xA1.toByte()
+        original[0x2400] = 0xB2.toByte()
+        original[0x2800] = 0xC3.toByte()
+        original[0x2C00] = 0xD4.toByte()
+
+        val bytes = ByteArrayOutputStream().also { original.saveState(DataOutputStream(it)) }.toByteArray()
+
+        val restored = PpuInternalMemory()
+        restored.loadState(DataInputStream(ByteArrayInputStream(bytes)))
+
+        assertThat(restored.mirroring, equalTo(PpuInternalMemory.Mirroring.FOUR_SCREEN))
+        assertThat(restored[0x2000], equalTo(0xA1.toByte()))
+        assertThat(restored[0x2400], equalTo(0xB2.toByte()))
+        assertThat(restored[0x2800], equalTo(0xC3.toByte()))
+        assertThat(restored[0x2C00], equalTo(0xD4.toByte()))
+    }
+
+    @Test
+    fun `non-four-screen state does not carry the extra nametables`() {
+        // A horizontal-mirroring save must be smaller than a 4-screen one by
+        // exactly the two extra 1 KB tables, proving they are omitted.
+        val horizontal = PpuInternalMemory().apply { mirroring = PpuInternalMemory.Mirroring.HORIZONTAL }
+        val fourScreen = PpuInternalMemory().apply { mirroring = PpuInternalMemory.Mirroring.FOUR_SCREEN }
+
+        val hBytes = ByteArrayOutputStream().also { horizontal.saveState(DataOutputStream(it)) }.toByteArray()
+        val fBytes = ByteArrayOutputStream().also { fourScreen.saveState(DataOutputStream(it)) }.toByteArray()
+
+        assertThat(fBytes.size - hBytes.size, equalTo(0x800))
     }
 }

--- a/src/test/kotlin/com/github/alondero/nestlin/testutil/TestRomBuilder.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/testutil/TestRomBuilder.kt
@@ -61,6 +61,12 @@ class TestRomBuilder {
     var verticalMirroring: Boolean = false
 
     /**
+     * Four-screen VRAM flag — byte 6 bit 3 (`0x08`). When set the board wires an
+     * extra 2 KB of nametable RAM and the H/V bit is ignored. See GH #105.
+     */
+    var fourScreen: Boolean = false
+
+    /**
      * PRG ROM size in KB. Must be a multiple of 16 (the iNES PRG unit).
      * Re-assigning replaces [prg] with a fresh zeroed array of the new size.
      */
@@ -148,6 +154,7 @@ class TestRomBuilder {
         header[5] = (chrKb / 8).toByte()   // 8KB CHR units (0 = CHR-RAM)
         header[6] = (((mapper and 0x0F) shl 4) or
             (if (battery) 0x02 else 0x00) or
+            (if (fourScreen) 0x08 else 0x00) or
             (if (verticalMirroring) 0x01 else 0x00)).toByte()
         // Byte 7 bits 4-7 are mapper bits D4-D7 — bit 4 included (it is NOT a flag).
         // Bits 2-3 = 0b10 marks NES 2.0.


### PR DESCRIPTION
Nestlin ignored the iNES byte 6 bit 3 (0x08) 4-screen VRAM flag, so DRROM
Gauntlet (Mapper 206) fell back to H/V mirroring with a wrong nametable
layout. Surface the flag and honour it end-to-end.

- Header: add `fourScreen: Boolean` (byte 6 bit 3). `Header.Mirroring` stays
  a two-value H/V enum so the ~20 mappers that exhaustively match on it are
  untouched; the 4-screen flag is a separate boolean.
- Append FOUR_SCREEN (last) to Mapper.MirroringMode and
  PpuInternalMemory.Mirroring, preserving existing ordinals that mappers and
  the PPU persist via values()[ord].
- PpuInternalMemory: add two extra 1 KB nametables; FOUR_SCREEN routes
  $2000/$2400/$2800/$2C00 to four distinct tables with no aliasing.
- Save state v5->6: the two extra tables are written only when mirroring is
  FOUR_SCREEN, so every pre-existing / non-4-screen save is byte-for-byte
  identical and loads unchanged (no version threading needed).
- Memory wires the mode through; Mapper206.currentMirroring() returns
  FOUR_SCREEN when the header 4-screen bit is set (winning over the H/V bit).
- TestRomBuilder gains a `fourScreen` flag.

Tests: NametableMirroringTest four-independent-table + save round-trip cases;
GamePakTest bit-3 decode; Mapper206Test FOUR_SCREEN precedence. Full suite
(1417 tests) green. Boot gate: patched Gauntlet dump (mislabelled mapper 4)
to 206 -> bootcheck PASS.

Closes #105

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
