### PR TITLE
@ fix(mapper): defend Mapper4 cpuRead against 1-bank (8KB) PRG (Closes #98)

### DIFF
--- a/MAPPER_SUPPORT.md
+++ b/MAPPER_SUPPORT.md
@@ -59,6 +59,16 @@ Active mapper list: **0, 1, 2, 3, 4, 5 (stub), 7, 9, 10, 11, 16, 22, 24, 26, 33,
   - CHR banking (normal mode): R0-R1 = 2KB at $0000-$0FFF, R2-R5 = four 1KB at $1000-$1FFF
   - CHR banking (inverted mode): R2-R5 = four 1KB at $0000-$0FFF, R0-R1 = 2KB at $1000-$1FFF
   - Scanline IRQ via PPU A12 rising edge detection (wired 2026-04-17)
+- **Edge cases / quirks:**
+  - **1-bank (8KB) PRG ROM (issue #98):** the `(prgBankCount - 2)` expressions in
+    `cpuRead` for the $8000/$C000 windows are wrapped with `coerceAtLeast(0)`. With
+    prgBankCount = 1, the formula `-1` would otherwise produce a negative array
+    index and throw `ArrayIndexOutOfBoundsException`. No commercial MMC3 game has
+    a 1-bank PRG (the smallest MMC3 titles ship 32KB+), so this is a defensive
+    guard, not a real-game fix. Mirrors the existing `coerceAtLeast(0)` in
+    `Mapper206.cpuRead`. Regression test lives in `Mapper4ChrBankingTest`
+    (uses reflection to shrink `programRom` to 8KB, since the normal GamePak
+    constructor rejects iNES byte 4 = 0 per GH #212).
 - **Fixes Applied (2026-05-18):**
   - PPU sprite-fetch pipeline rewritten: sprite evaluation now happens at cycle 65 (no pattern reads) and sprite tile fetches happen at cycles 257-320 of the previous scanline, matching real PPU. Removed eager sprite reads at cycle 0 that were producing a second spurious A12 rising edge per scanline.
   - 8x16 sprite mode: pattern table now resolved per-sprite (PPUCTRL bit 3 was being used for all sprites, which is only correct for 8x8 mode).

--- a/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper4.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/gamepak/Mapper4.kt
@@ -82,7 +82,7 @@ open class Mapper4(private val gamePak: GamePak) : Mapper {
         return when (address and 0xE000) {
             0x8000 -> {
                 // $8000-$9FFF: second-to-last (fixed) in mode 1, R6 (prgBank6, switchable) in mode 0
-                val bank = if (prgMode) (prgBankCount - 2) else prgBank6
+                val bank = if (prgMode) (prgBankCount - 2).coerceAtLeast(0) else prgBank6
                 programRom[(bank * 0x2000 + (address - 0x8000)) % programRom.size]
             }
             0xA000 -> {
@@ -91,7 +91,7 @@ open class Mapper4(private val gamePak: GamePak) : Mapper {
             }
             0xC000 -> {
                 // $C000-$DFFF: R8 (second-to-last) or R6 depending on prgMode
-                val bank = if (prgMode) prgBank6 else (prgBankCount - 2)
+                val bank = if (prgMode) prgBank6 else (prgBankCount - 2).coerceAtLeast(0)
                 programRom[(bank * 0x2000 + (address - 0xC000)) % programRom.size]
             }
             0xE000 -> {

--- a/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper4ChrBankingTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/gamepak/Mapper4ChrBankingTest.kt
@@ -110,4 +110,89 @@ class Mapper4ChrBankingTest {
         mmc3Write(mapper, 0x80 or 1, 185)
         assertThat(mapper.ppuRead(0x1800).toUnsignedInt(), equalTo(184))
     }
+
+    // ---- Issue #98: latent crash on 1-bank (8KB) PRG ROM ----
+
+    /**
+     * Build a valid iNES GamePak then shrink [Mapper4.programRom] to 8KB via
+     * reflection so `prgBankCount == 1`. This is the only path to exercise the
+     * `(prgBankCount - 2)` defensive branch in [Mapper4.cpuRead] — the normal
+     * GamePak constructor rejects iNES byte 4 = 0 (GH #212: zero-PRG dump
+     * protection), so an 8KB programRom cannot be created through the public
+     * API. The smallest valid iNES PRG is 16KB (byte 4 = 1), which gives
+     * `prgBankCount = 2` and never trips the bug.
+     *
+     * Pre-fix this threw `ArrayIndexOutOfBoundsException`: with prgBankCount = 1
+     * the fixed-bank formula `prgBankCount - 2` is -1, and the array index
+     * `(-1 * 0x2000 + offset) % programRom.size` produces a negative remainder
+     * (Kotlin's `%` is sign-of-dividend) that is out of bounds. The fix mirrors
+     * Mapper206: wrap the index with `coerceAtLeast(0)`.
+     */
+    private fun mapper4WithOneBankPrg(): Mapper4 {
+        val header = ByteArray(16).apply {
+            this[0] = 'N'.code.toByte(); this[1] = 'E'.code.toByte()
+            this[2] = 'S'.code.toByte(); this[3] = 0x1A.toByte()
+            this[4] = 1                            // 1 × 16KB PRG (minimum allowed)
+            this[5] = 1                            // 1 × 8KB CHR
+            this[6] = (4 shl 4).toByte()           // mapper 4, low nibble
+            this[7] = 0                            // mapper 4, high nibble
+        }
+        // 16KB PRG + 8KB CHR — GamePak will accept this. We then replace
+        // Mapper4.programRom with an 8KB array to force prgBankCount = 1.
+        val gp = GamePak(header + ByteArray(0x4000) + ByteArray(0x2000))
+        val mapper = Mapper4(gp)
+
+        val programRomField = Mapper4::class.java.getDeclaredField("programRom")
+        programRomField.isAccessible = true
+        programRomField.set(mapper, ByteArray(0x2000))
+
+        val prgBankCountField = Mapper4::class.java.getDeclaredField("prgBankCount")
+        prgBankCountField.isAccessible = true
+        prgBankCountField.setInt(mapper, 1)
+
+        return mapper
+    }
+
+    @Test
+    fun `1-bank PRG does not throw on cpuRead of 8000 and A000 windows`() {
+        // The switchable windows (R6 at $8000, R7 at $A000) don't reference
+        // prgBankCount, so they were never broken — but the issue's test plan
+        // explicitly asks we cover them too, since they're part of the same
+        // defense-in-depth sweep.
+        val mapper = mapper4WithOneBankPrg()
+        mapper.cpuRead(0x8000)
+        mapper.cpuRead(0x9FFF)
+        mapper.cpuRead(0xA000)
+        mapper.cpuRead(0xBFFF)
+    }
+
+    @Test
+    fun `1-bank PRG does not throw on cpuRead of C000 window in prgMode 0`() {
+        // $C000 with prgMode = 0: bank = (prgBankCount - 2) = -1 → CRASH pre-fix.
+        val mapper = mapper4WithOneBankPrg()
+        // Default prgMode is false (constructor). The fixed-bank path is the
+        // one that exercises prgBankCount - 2.
+        mapper.cpuRead(0xC000)
+        mapper.cpuRead(0xDFFF)
+    }
+
+    @Test
+    fun `1-bank PRG does not throw on cpuRead of 8000 window in prgMode 1`() {
+        // $8000 with prgMode = 1: bank = (prgBankCount - 2) = -1 → CRASH pre-fix.
+        val mapper = mapper4WithOneBankPrg()
+        // Set prgMode via the standard $8000 bank-select write.
+        mapper.cpuWrite(0x8000, 0x40.toSignedByte())    // bankSelect=0, prgMode=1
+        mapper.cpuRead(0x8000)
+        mapper.cpuRead(0x9FFF)
+    }
+
+    @Test
+    fun `1-bank PRG does not throw on cpuRead of E000 window`() {
+        // $E000 uses (prgBankCount - 1), which is 0 when prgBankCount = 1 —
+        // so this window was already safe. Listed in the issue's test plan
+        // for completeness; we assert it stays non-throwing.
+        val mapper = mapper4WithOneBankPrg()
+        mapper.cpuRead(0xE000)
+        mapper.cpuRead(0xFFFF)
+    }
 }


### PR DESCRIPTION
@
Closes #98

`Mapper4.cpuRead` computed the fixed-bank index as `(prgBankCount - 2)`
for the $8000 / $C000 windows. With a 1-bank (8KB) PRG, `prgBankCount = 1`,
so the index is -1. The array access `(-1 * 0x2000 + offset) % size` then
produces a negative remainder (Kotlin `%` is sign-of-dividend) and throws
`ArrayIndexOutOfBoundsException`. Mirror `Mapper206` and wrap both sites
with `coerceAtLeast(0)`.

The `$E000` window uses `(prgBankCount - 1)`, which is 0 when
`prgBankCount = 1` — already safe.

No commercial MMC3 game has a 1-bank PRG (smallest are 32KB+) so this is a
defensive guard, not a real-game fix.

### Verification

Added 4 regression tests in `Mapper4ChrBankingTest` covering all four CPU
windows with a 1-bank PRG. The helper uses reflection to shrink
`programRom` to 8KB, since `GamePak` validation (GH #212) rejects iNES byte 4
= 0 and the smallest valid PRG is 16KB (`prgBankCount = 2`). Test comments
explain the reflection necessity for future readers.

- `./gradlew test --tests Mapper4ChrBankingTest` — 8 tests pass (4 new).
- `./gradlew build` (includes test + lint) — green.
- Full `./gradlew test` (3m 14s, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@