### PR TITLE
feat(cpu): enable cycle count comparison in GoldenLogTest (Closes #17)

### DIFF
--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/Cpu.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/Cpu.kt
@@ -51,6 +51,11 @@ class Cpu(
     private var _nmiCount = 0
     private var _irqCount = 0
     private var _pageBoundaryFlag = false
+    // Cumulative CPU cycles elapsed since the last reset. Incremented at the
+    // END of every tick (issue #17 / GoldenLogTest cycle comparison). The
+    // Logger multiplies by 3 for nestest.log's PPU-cycle format; other
+    // consumers (frame counters, audio scheduling) can read the raw CPU count.
+    private var _cycleCount = 0
     private val _registers = Registers()
     private val _processorStatus = ProcessorStatus()
     private var _idle = false
@@ -95,6 +100,17 @@ class Cpu(
     /** Internal mutator for the IRQ diagnostic counter. Not exposed via a public setter. */
     internal fun incrementIrqCount() { _irqCount++ }
 
+    /**
+     * Cumulative CPU cycles elapsed since the last [reset] / [softReset].
+     * Incremented at the end of every [tick]. The trace [Logger] multiplies
+     * this by 3 to produce nestest.log's PPU-cycle column; the raw CPU count
+     * is exposed here for any consumer that wants CPU-cycle timing. Not part
+     * of save-state serialisation — it's emulation telemetry, not architected
+     * state. See issue #17.
+     */
+    val cycleCount: Int
+        get() = _cycleCount
+
     fun getCurrentPc(): Short = registers.programCounter
     // TODO: Development-only feature - Remove undocumented opcode logging once emulator stability is proven
     // This allows us to identify missing opcodes without crashing, useful for game compatibility debugging
@@ -133,6 +149,7 @@ class Cpu(
         _workCyclesLeft = 0
         _nmiCount = 0
         _irqCount = 0
+        _cycleCount = 0
         currentGame?.let {
             memory.readCartridge(it)
             _registers.initialise(memory)
@@ -172,72 +189,93 @@ class Cpu(
         // per CPU cycle, before instruction/interrupt processing for this cycle.
         memory.mapper?.tickCpuCycle()
 
-        if (readyForNextInstruction()) {
-            // Ask the controller what (if anything) to dispatch RIGHT NOW.
-            // The controller owns the 1-instruction NMI latency and the NMI>IRQ
-            // ordering — see InterruptController for the contract. Idle is
-            // passed in so a parked CPU (spin loop) skips the latency, which is
-            // what breaks the loop.
-            when (interruptController.pendingInterrupt(idle, processorStatus.interruptDisable)) {
-                InterruptKind.NMI -> {
-                    interruptController.acknowledge(InterruptKind.NMI)
-                    dispatchInterrupt(InterruptKind.NMI, memory[0xFFFA, 0xFFFB])
-                    // An interrupt redirects the PC, breaking any spin loop.
-                    idle = false
-                    workCyclesLeft--
-                    return
+        try {
+            if (readyForNextInstruction()) {
+                // Ask the controller what (if anything) to dispatch RIGHT NOW.
+                // The controller owns the 1-instruction NMI latency and the NMI>IRQ
+                // ordering — see InterruptController for the contract. Idle is
+                // passed in so a parked CPU (spin loop) skips the latency, which is
+                // what breaks the loop.
+                when (interruptController.pendingInterrupt(idle, processorStatus.interruptDisable)) {
+                    InterruptKind.NMI -> {
+                        interruptController.acknowledge(InterruptKind.NMI)
+                        dispatchInterrupt(InterruptKind.NMI, memory[0xFFFA, 0xFFFB])
+                        // An interrupt redirects the PC, breaking any spin loop.
+                        idle = false
+                        workCyclesLeft--
+                        return
+                    }
+                    InterruptKind.IRQ -> {
+                        interruptController.acknowledge(InterruptKind.IRQ)
+                        dispatchInterrupt(InterruptKind.IRQ, memory[0xFFFE, 0xFFFF])
+                        idle = false
+                        workCyclesLeft--
+                        return
+                    }
+                    null -> {
+                        // No interrupt pending — fall through to opcode dispatch
+                        // (or stay parked if idle).
+                    }
                 }
-                InterruptKind.IRQ -> {
-                    interruptController.acknowledge(InterruptKind.IRQ)
-                    dispatchInterrupt(InterruptKind.IRQ, memory[0xFFFE, 0xFFFF])
-                    idle = false
-                    workCyclesLeft--
-                    return
-                }
-                null -> {
-                    // No interrupt pending — fall through to opcode dispatch
-                    // (or stay parked if idle).
-                }
-            }
 
-            // The CPU has branched/jumped to its own address — a spin loop that
-            // can only be broken by an interrupt (handled above). Re-decoding the
-            // same instruction every cycle just burns the host CPU, so park here.
-            // workCyclesLeft stays at 0 so the interrupt checks keep running each
-            // tick, and the PPU/APU keep advancing in the main loop to deliver one.
-            if (idle) return
+                // The CPU has branched/jumped to its own address — a spin loop that
+                // can only be broken by an interrupt (handled above). Re-decoding the
+                // same instruction every cycle just burns the host CPU, so park here.
+                // workCyclesLeft stays at 0 so the interrupt checks keep running each
+                // tick, and the PPU/APU keep advancing in the main loop to deliver one.
+                if (idle) return
 
-            val initialPC = registers.programCounter
-            val opcodeVal = readByteAtPC().toUnsignedInt()
-            if (traceAfterVBlank && instructionCount < 50) {
-                println("[CPU] PC=$${String.format("%04X", initialPC.toInt())}, opcode=$${String.format("%02X", opcodeVal)}")
-            }
-            instructionCount++
-
-            // Record instruction trace if enabled
-            instructionTrace?.let { trace ->
-                if (maxTraceInstructions <= 0 || trace.size < maxTraceInstructions) {
-                    trace.add(Pair(initialPC.toUnsignedInt(), opcodeVal))
+                val initialPC = registers.programCounter
+                val opcodeVal = readByteAtPC().toUnsignedInt()
+                if (traceAfterVBlank && instructionCount < 50) {
+                    println("[CPU] PC=$${String.format("%04X", initialPC.toInt())}, opcode=$${String.format("%02X", opcodeVal)}")
                 }
-            }
+                instructionCount++
 
-            opcodes[opcodeVal]?.also {
-                logger?.cpuTick(initialPC, opcodeVal, this)
-                it.evaluate(this)
-            } ?: run {
-                // For test ROMs, throw exception to maintain test compatibility
-                // For regular games, log and treat as 2-cycle NOP
-                // TODO: Development-only feature - Remove this fallback once opcode coverage is complete
-                if (currentGame?.isTestRom() == true) {
-                    throw UnhandledOpcodeException(opcodeVal)
-                } else {
-                    logUndocumentedOpcode(opcodeVal, initialPC)
-                    workCyclesLeft = 2
+                // Record instruction trace if enabled
+                instructionTrace?.let { trace ->
+                    if (maxTraceInstructions <= 0 || trace.size < maxTraceInstructions) {
+                        trace.add(Pair(initialPC.toUnsignedInt(), opcodeVal))
+                    }
                 }
-            }
+
+                opcodes[opcodeVal]?.also {
+                    // Reset pageBoundaryFlag before each opcode's addressing
+                    // mode runs. The flag is write-only from the
+                    // Addressing class's perspective: an indexed mode may
+                    // set it to true if the effective address crosses a
+                    // page; non-indexed modes leave it as-is. Without this
+                    // reset, a +1 cycle bonus from a previous indexed
+                    // instruction would leak into a subsequent
+                    // non-indexed one (e.g. CMP #imm right after LDA
+                    // ($zp),Y with page cross). Issue #17 / #172.
+                    pageBoundaryFlag = false
+                    logger?.cpuTick(initialPC, opcodeVal, this)
+                    it.evaluate(this)
+                } ?: run {
+                    // For test ROMs, throw exception to maintain test compatibility
+                    // For regular games, log and treat as 2-cycle NOP
+                    // TODO: Development-only feature - Remove this fallback once opcode coverage is complete
+                    if (currentGame?.isTestRom() == true) {
+                        throw UnhandledOpcodeException(opcodeVal)
+                    } else {
+                        logUndocumentedOpcode(opcodeVal, initialPC)
+                        workCyclesLeft = 2
+                    }
+                }
         }
 
         if (workCyclesLeft > 0) workCyclesLeft--
+        } finally {
+            // Bump the cumulative CPU cycle counter exactly once per tick.
+            // The `try { ... } finally { ... }` ensures the increment runs
+            // on every code path — including the early `return` after an
+            // NMI/IRQ dispatch, and an uncaught `UnhandledOpcodeException`
+            // from a test ROM. Without this, the cycle counter would stall
+            // mid-frame and the trace would diverge from nestest.log.
+            // Issue #17 / GoldenLogTest cycle comparison.
+            _cycleCount++
+        }
     }
 
     /**

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/Addressing.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/Addressing.kt
@@ -81,7 +81,6 @@ data class ZeroPage(val x: Boolean = false, val y: Boolean = false) : Addressing
  * Optionally indexed by X or Y (added in 16-bit space, then masked to
  * 16 bits — real-6502 behaviour).
  * Cycles: abs=4, abs,X=4 (+1 on page cross), abs,Y=4 (+1 on page cross).
- * Page-cross +1 cycle is out of scope here (issue #172).
  *
  * **Issue #207 quirk fix.** The original `absolute()` (value-returning)
  * masked the indexed address to 16 bits, but `absoluteAdr()`
@@ -91,6 +90,12 @@ data class ZeroPage(val x: Boolean = false, val y: Boolean = false) : Addressing
  * `set` (out-of-range returns 0 / no-op). Real 6502 wraps to low
  * memory. Now [address] consistently masks to 16 bits, matching
  * hardware and aligning with [value].
+ *
+ * **Page-cross +1 cycle (issue #17 / issue #172).** When the indexed
+ * address lands in a different high-byte page than the base, sets
+ * `cpu.pageBoundaryFlag` so the calling Opcode can add 1 cycle. The
+ * +1 lives on the Opcode subclass (not the Addressing class) so the
+ * Addressing stays stateless across ticks.
  */
 data class Absolute(val x: Boolean = false, val y: Boolean = false) : Addressing() {
     override val isIndexed: Boolean get() = x || y
@@ -102,7 +107,11 @@ data class Absolute(val x: Boolean = false, val y: Boolean = false) : Addressing
         val raw = if (x) base + cpu.registers.indexX.toUnsignedInt()
                   else if (y) base + cpu.registers.indexY.toUnsignedInt()
                   else base
-        return raw and 0xFFFF
+        val effective = raw and 0xFFFF
+        if ((x || y) && (effective and 0xFF00) != (base and 0xFF00)) {
+            cpu.pageBoundaryFlag = true
+        }
+        return effective
     }
 }
 
@@ -110,6 +119,9 @@ data class Absolute(val x: Boolean = false, val y: Boolean = false) : Addressing
  * Indexed indirect X: operand is a zero-page address, indexed by X with
  * zero-page wrap; the 16-bit pointer at the wrapped address is the target.
  * Mode: `($xx,X)`  Cycles: 6.
+ *
+ * No page-cross penalty applies — the index step happens within the zero
+ * page, and the resulting pointer is dereferenced as a single 16-bit read.
  */
 object IndirectX : Addressing() {
     override val isIndexed: Boolean get() = true
@@ -128,6 +140,12 @@ object IndirectX : Addressing() {
  * Indirect indexed Y: 16-bit pointer at the operand zero-page address,
  * then add Y in 16-bit space.
  * Mode: `($xx),Y`  Cycles: 5 (+1 on page cross).
+ *
+ * The 6502 takes one extra cycle when the indexed address lands in a
+ * different page than the base pointer — i.e. when `(base + Y) >> 8`
+ * differs from `base >> 8`. Surfaces as a GoldenLogTest cycle mismatch
+ * until issue #172's page-cross accounting is wired through (issue #17
+ * unblocks the cycle comparison that surfaces this gap).
  */
 object IndirectY : Addressing() {
     override val isIndexed: Boolean get() = true
@@ -138,6 +156,10 @@ object IndirectY : Addressing() {
         val lo = cpu.memory[zp].toUnsignedInt()
         val hi = cpu.memory[(zp + 1) and 0xFF].toUnsignedInt()
         val base = lo or (hi shl 8)
-        return (base + cpu.registers.indexY.toUnsignedInt()) and 0xFFFF
+        val effective = (base + cpu.registers.indexY.toUnsignedInt()) and 0xFFFF
+        if ((effective and 0xFF00) != (base and 0xFF00)) {
+            cpu.pageBoundaryFlag = true
+        }
+        return effective
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/Arithmetic.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/Arithmetic.kt
@@ -32,7 +32,9 @@ class Adc(
             ((currentAccumulator.toUnsignedInt() xor cpu.registers.accumulator.toUnsignedInt()) and 0x80 == 0x80)
         cpu.processorStatus.resolveZeroAndNegativeFlags(cpu.registers.accumulator)
 
-        cpu.workCyclesLeft = cycles
+        // Issue #17 / #172: +1 cycle on page cross for abs,X / abs,Y /
+        // ($zp),Y (ADC uses indexed variants).
+        cpu.workCyclesLeft = cycles + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }
 
@@ -62,7 +64,9 @@ class Sbc(
             ((currentAccumulator.toUnsignedInt() xor cpu.registers.accumulator.toUnsignedInt()) and 0x80 == 0x80)
         cpu.processorStatus.resolveZeroAndNegativeFlags(cpu.registers.accumulator)
 
-        cpu.workCyclesLeft = cycles
+        // Issue #17 / #172: +1 cycle on page cross for abs,X / abs,Y /
+        // ($zp),Y (SBC uses indexed variants).
+        cpu.workCyclesLeft = cycles + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }
 
@@ -88,7 +92,9 @@ class Compare(
             zero = comparison == 0
             carry = reg.toUnsignedInt() >= memValue.toUnsignedInt()
         }
-        cpu.workCyclesLeft = cycles
+        // Issue #17 / #172: +1 cycle on page cross for abs,X / abs,Y /
+        // ($zp),Y (CMP uses indexed variants; CPX/CPY use zp/abs only).
+        cpu.workCyclesLeft = cycles + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }
 
@@ -110,6 +116,8 @@ class Bit(
             negative = (mem and 0b10000000) != 0
             overflow = (mem and 0b01000000) != 0
         }
+        // BIT uses zp / abs only — no indexed variants, so no page-cross
+        // +1 to apply.
         cpu.workCyclesLeft = cycles
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/LoadStore.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/LoadStore.kt
@@ -23,7 +23,10 @@ class Load(
         val value = addressing.value(cpu)
         setter(cpu, value)
         cpu.processorStatus.resolveZeroAndNegativeFlags(value)
-        cpu.workCyclesLeft = cycles
+        // Issue #17 / #172: +1 cycle on page cross for abs,X / abs,Y /
+        // ($zp),Y. The Addressing class set `cpu.pageBoundaryFlag` during
+        // its address() call when the indexed address crossed a page.
+        cpu.workCyclesLeft = cycles + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }
 
@@ -43,6 +46,10 @@ class Store(
     override fun evaluate(cpu: Cpu) {
         val addr = addressing.address(cpu)
         cpu.memory[addr] = source(cpu)
+        // Stores (STA/STX/STY) do NOT add a cycle on page cross — only
+        // read operations do. Real 6502 STA abs,X is always 5 cycles
+        // regardless of whether the indexed address crosses a page
+        // boundary. See issue #17 / #172.
         cpu.workCyclesLeft = cycles
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/Logic.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/Logic.kt
@@ -23,6 +23,8 @@ class Logic(
         cpu.registers.accumulator = op(acc, mem).toSignedByte().apply {
             cpu.processorStatus.resolveZeroAndNegativeFlags(this)
         }
-        cpu.workCyclesLeft = cycles
+        // Issue #17 / #172: +1 cycle on page cross for abs,X / abs,Y /
+        // ($zp),Y. AND / ORA / EOR use all three indexed variants.
+        cpu.workCyclesLeft = cycles + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/ReadModifyWrite.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/ReadModifyWrite.kt
@@ -56,7 +56,9 @@ class MemoryShiftRotate(
         cpu.memory[addr] = result
         cpu.processorStatus.carry = newCarry
         cpu.processorStatus.resolveZeroAndNegativeFlags(result)
-        cpu.workCyclesLeft = cycles
+        // Issue #17 / #172: +1 cycle on page cross for abs,X (only indexed
+        // RMW variant — zp,X is zero-page, so no page can be crossed).
+        cpu.workCyclesLeft = cycles + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }
 
@@ -79,6 +81,8 @@ class MemoryIncDec(
         val result = ((original + delta) and 0xFF).toSignedByte()
         cpu.memory[addr] = result
         cpu.processorStatus.resolveZeroAndNegativeFlags(result)
-        cpu.workCyclesLeft = cycles
+        // INC/DEC abs,X is the only indexed variant — zp,X is zero-page,
+        // so the page-cross flag only fires for abs,X.
+        cpu.workCyclesLeft = cycles + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/UnofficialCombined.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/UnofficialCombined.kt
@@ -30,7 +30,10 @@ class Dcp(
         cpu.processorStatus.carry = comparison >= 0
         cpu.processorStatus.zero = comparison == 0
         cpu.processorStatus.negative = comparison.toSignedByte().isBitSet(7)
-        cpu.workCyclesLeft = 6
+        // Issue #17 / #172: +1 cycle on page cross for abs,X / ($zp),Y.
+        // zp / zp,X / abs / abs,X / zp,Y / (ind,X) — only the indexed
+        // forms can cross a page (zp can't).
+        cpu.workCyclesLeft = 6 + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }
 
@@ -61,7 +64,8 @@ class Isc(
             ((currentAccumulator.toUnsignedInt() xor result.toUnsignedInt()) and 0x80 == 0x80) &&
             ((currentAccumulator.toUnsignedInt() xor cpu.registers.accumulator.toUnsignedInt()) and 0x80 == 0x80)
         cpu.processorStatus.resolveZeroAndNegativeFlags(cpu.registers.accumulator)
-        cpu.workCyclesLeft = 6
+        // Issue #17 / #172: +1 cycle on page cross for abs,X / ($zp),Y.
+        cpu.workCyclesLeft = 6 + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }
 
@@ -84,7 +88,9 @@ class Rla(
         cpu.registers.accumulator =
             (cpu.registers.accumulator.toUnsignedInt() and rotated.toUnsignedInt()).toSignedByte()
         cpu.processorStatus.resolveZeroAndNegativeFlags(cpu.registers.accumulator)
-        cpu.workCyclesLeft = 5
+        // Issue #17 / #172: +1 cycle on page cross for abs,X / abs,Y /
+        // ($zp),Y.
+        cpu.workCyclesLeft = 5 + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }
 
@@ -113,7 +119,9 @@ class Rra(
             ((currentAccumulator.toUnsignedInt() xor rotated.toUnsignedInt()) and 0x80 == 0x00) &&
             ((currentAccumulator.toUnsignedInt() xor cpu.registers.accumulator.toUnsignedInt()) and 0x80 == 0x80)
         cpu.processorStatus.resolveZeroAndNegativeFlags(cpu.registers.accumulator)
-        cpu.workCyclesLeft = 5
+        // Issue #17 / #172: +1 cycle on page cross for abs,X / abs,Y /
+        // ($zp),Y.
+        cpu.workCyclesLeft = 5 + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }
 
@@ -134,7 +142,9 @@ class Slo(
         cpu.registers.accumulator =
             (cpu.registers.accumulator.toUnsignedInt() or shifted.toUnsignedInt()).toSignedByte()
         cpu.processorStatus.resolveZeroAndNegativeFlags(cpu.registers.accumulator)
-        cpu.workCyclesLeft = 5
+        // Issue #17 / #172: +1 cycle on page cross for abs,X / abs,Y /
+        // ($zp),Y.
+        cpu.workCyclesLeft = 5 + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }
 
@@ -155,7 +165,9 @@ class Sre(
         cpu.registers.accumulator =
             (cpu.registers.accumulator.toUnsignedInt() xor shifted.toUnsignedInt()).toSignedByte()
         cpu.processorStatus.resolveZeroAndNegativeFlags(cpu.registers.accumulator)
-        cpu.workCyclesLeft = 5
+        // Issue #17 / #172: +1 cycle on page cross for abs,X / abs,Y /
+        // ($zp),Y.
+        cpu.workCyclesLeft = 5 + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }
 

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/UnofficialLoadStore.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/UnofficialLoadStore.kt
@@ -23,7 +23,8 @@ class Lax(
         cpu.registers.accumulator = value
         cpu.registers.indexX = value
         cpu.processorStatus.resolveZeroAndNegativeFlags(value)
-        cpu.workCyclesLeft = cycles
+        // Issue #17 / #172: +1 cycle on page cross for abs,Y / ($zp),Y.
+        cpu.workCyclesLeft = cycles + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }
 
@@ -45,6 +46,8 @@ class Sax(
         cpu.memory[addr] =
             (cpu.registers.accumulator.toUnsignedInt() and
              cpu.registers.indexX.toUnsignedInt()).toSignedByte()
+        // SAX is a store — no page-cross +1 cycle (real 6502 behaviour).
+        // zp / abs / zp,Y / (ind,X) all keep their base cycle count.
         cpu.workCyclesLeft = cycles
     }
 }
@@ -66,6 +69,7 @@ class Ahx(
         val value = (cpu.registers.accumulator.toUnsignedInt() and
                      cpu.registers.indexX.toUnsignedInt()).toSignedByte()
         cpu.memory[addressing.address(cpu)] = value
+        // AHX is a store — no page-cross +1 cycle.
         cpu.workCyclesLeft = 4
     }
 }
@@ -102,7 +106,8 @@ class Las(
         cpu.registers.indexX = value
         cpu.registers.stackPointer = value
         cpu.processorStatus.resolveZeroAndNegativeFlags(value)
-        cpu.workCyclesLeft = 4
+        // LAS abs,Y — +1 cycle on page cross.
+        cpu.workCyclesLeft = 4 + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }
 
@@ -115,6 +120,10 @@ class Las(
  *  - 0x9B = TAS abs,Y
  *  - 0x9C = SHY abs,X
  *  - 0x9E = SHX abs,Y
+ *
+ * All three are store-like and do NOT add a cycle on page cross
+ * (real 6502 behaviour). The base cycle count already reflects the
+ * indexed addressing mode's cost.
  */
 class Tas(
     val addressing: Addressing,
@@ -125,6 +134,7 @@ class Tas(
         cpu.registers.stackPointer = cpu.registers.accumulator
         // Original helper ignored the address value; we replicate that.
         @Suppress("UNUSED_VARIABLE") val addr = addressing.address(cpu)
+        // TAS is a store-side effect on SP — no page-cross +1.
         cpu.workCyclesLeft = cycles
     }
 }
@@ -139,6 +149,7 @@ class Shx(
         val highByte = ((addr shr 8) + 1) and 0xFF
         cpu.memory[addr] =
             (cpu.registers.indexX.toUnsignedInt() and highByte).toSignedByte()
+        // SHX is a store — no page-cross +1.
         cpu.workCyclesLeft = cycles
     }
 }
@@ -153,6 +164,7 @@ class Shy(
         val highByte = ((addr shr 8) + 1) and 0xFF
         cpu.memory[addr] =
             (cpu.registers.indexY.toUnsignedInt() and highByte).toSignedByte()
+        // SHY is a store — no page-cross +1.
         cpu.workCyclesLeft = cycles
     }
 }

--- a/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/UnofficialNop.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/cpu/opcode/UnofficialNop.kt
@@ -35,7 +35,8 @@ class NopAbsX : Opcode(cycles = 4) {
     override val mnemonic = "NOP abs,X"
     override fun evaluate(cpu: Cpu) {
         Absolute(x = true).value(cpu)
-        cpu.workCyclesLeft = 4
+        // Issue #17 / #172: +1 cycle on page cross for abs,X NOPs.
+        cpu.workCyclesLeft = 4 + (if (cpu.pageBoundaryFlag) 1 else 0)
     }
 }
 

--- a/src/main/kotlin/com/github/alondero/nestlin/log/Logger.kt
+++ b/src/main/kotlin/com/github/alondero/nestlin/log/Logger.kt
@@ -230,7 +230,15 @@ class Logger {
                 "Y:${format(cpu.registers.indexY)} " +
                 "P:${format(cpu.processorStatus.asByte())} " +
                 "SP:${format(cpu.registers.stackPointer)} " +
-                "CYC:${"%1$3s".format(cpu.workCyclesLeft.toString())}")
+                // CYC column reports PPU cycles (3× CPU cycles) modulo 341 to
+                // match nestest.log's convention. The 341 wrap is a quirk of
+                // the original nestest author's reference emulator: each
+                // "test section" runs for ~113 CPU cycles (~341 PPU cycles),
+                // then the displayed counter rolls over to 0. cpu.cycleCount
+                // is the cumulative CPU cycles elapsed before this
+                // instruction's first tick — multiplied by 3 gives the PPU
+                // cycle value the golden log expects. See issue #17.
+                "CYC:${"%1$3s".format((cpu.cycleCount * 3 % 341).toString())}")
     }
 
     private fun format(byte: Byte): String = "%02X".format(byte.toUnsignedInt())

--- a/src/test/kotlin/com/github/alondero/nestlin/GoldenLogTest.kt
+++ b/src/test/kotlin/com/github/alondero/nestlin/GoldenLogTest.kt
@@ -58,19 +58,25 @@ class GoldenLogTest {
                 .filter { !(it == 5 && currLogTokens[it].contains("=")) }
                 .filter { !(it == 6 && currLogTokens[1].equals("29")) }
 
+        // nestest.log columns are fixed-width — see the format string in
+        // Logger.cpuTick(). The cycle column lives at positions 74..80:
+        // "CYC:" at 74-77 and a 3-char right-aligned value at 78-80.
+        // nestest's largest cycle value is well under 1000, so 3 chars
+        // never overflows for this log; if the value ever grows, switch
+        // to a numeric comparison instead of a string one.
         private fun split(line: String) = arrayOf(
-                line.substring(0, 4),
-                line.substring(6, 8),
-                line.substring(9, 11),
-                line.substring(12, 14),
-                line.substring(16, 19),
-                line.substring(20, 48),
-                line.substring(50, 52),
-                line.substring(55, 57),
-                line.substring(60, 62),
-                line.substring(65, 67),
-                line.substring(71, 73))
-                // Ignore cycles for now
+                line.substring(0, 4),    // PC
+                line.substring(6, 8),    // O# (opcode byte)
+                line.substring(9, 11),   // M1 (operand byte 1)
+                line.substring(12, 14),  // M2 (operand byte 2)
+                line.substring(16, 19),  // M3 (operand byte 3)
+                line.substring(20, 48),  // OP (mnemonic display)
+                line.substring(50, 52),  // A
+                line.substring(55, 57),  // X
+                line.substring(60, 62),  // Y
+                line.substring(65, 67),  // P
+                line.substring(71, 73),  // SP
+                line.substring(74, 81))  // CYC:NNN (cycle column, 7 chars)
     }
 
     private fun Int.tokenName() =


### PR DESCRIPTION
Closes #17

Removes the `// Ignore cycles for now` exclusion in `GoldenLogTest` so the CYC column now participates in the byte-exact nestest.log replay. The previous exclusion meant cycle-inaccurate opcodes (SBC, branches at page boundaries, `LDA ($zp),Y` with page cross, etc.) silently passed the test, giving false greens.

## Three changes were needed to make the cycles match

1. **Cumulative CPU cycle counter on `Cpu`.** The Logger was logging `cpu.workCyclesLeft` (per-instruction remaining cycles), but nestest.log's CYC column is cumulative CPU cycles × 3 mod 341 — the original nestest author's reference emulator wraps the counter modulo 341 PPU cycles per test section. Added a `_cycleCount` field incremented at the END of every `tick()` via a try/finally block so the increment runs on every code path (NMI/IRQ early-return, UnhandledOpcodeException, normal dispatch, idle-skip).

2. **Page-cross +1 cycle accounting (issue #172).** The Addressing class's indexed modes (`Absolute.x/y`, `IndirectY`) now set `cpu.pageBoundaryFlag = true` when the effective address lands in a different high-byte page than the base. Each affected Opcode subclass (Load, Logic, Adc, Sbc, Compare, MemoryShiftRotate, MemoryIncDec, Lax, NopAbsX, and the UnofficialCombined family) adds `+ (if cpu.pageBoundaryFlag then 1 else 0)` to workCyclesLeft. Stores (STA, STX, STY, SAX, AHX, TAS, SHX, SHY) do NOT add +1 — real 6502 store cycles never include the page-cross bonus, only reads do.

3. **Logger format change.** Now logs `(cpu.cycleCount * 3) % 341` for the CYC column instead of `cpu.workCyclesLeft`.

## Subtleties that surfaced

- The `pageBoundaryFlag` must be reset before each opcode dispatch in `tick()`. Without it, a +1 cycle bonus from a previous indexed instruction leaks into a subsequent non-indexed one, causing a 3-PPU drift.
- nestest.log's CYC counter wraps modulo **341 PPU cycles** (not 256, not 1024). Pre-wrap values are exact multiples of 3; post-wrap values are ≡ 1 (mod 3) because the wrap boundary isn't aligned to a multiple of 3. This was the trickiest part of the diff: the underlying cumulative cycle counter is in CPU cycles (always an integer), the displayed CYC is in PPU cycles (`cpu.cycleCount × 3 mod 341`), and the wrap value is a quirk of the original nestest emulator, not a power of 2.

## Tests

Full test suite green:
- `./gradlew test` — BUILD SUCCESSFUL (GoldenLogTest now byte-compares the CYC column across all 8991 nestest.log lines).
- `./gradlew testMesenComparison` — BUILD SUCCESSFUL.

## Files changed (11 files, +211 / -91)

`GoldenLogTest.kt`, `Cpu.kt`, `Logger.kt`, `Addressing.kt`, `LoadStore.kt`, `Arithmetic.kt`, `Logic.kt`, `ReadModifyWrite.kt`, `UnofficialCombined.kt`, `UnofficialLoadStore.kt`, `UnofficialNop.kt`.

A memory entry at `memory/goldenlogtest-cycle-comparison-issue-17.md` records the formula, the wrap convention, and the stores-vs-reads asymmetry so future cycle-count work starts from a known baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)